### PR TITLE
add "-std=gnu89" to CFLAGS when using clang compiler

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -166,6 +166,20 @@ AC_DEFUN([AC_SWOOLE_EVENTFD],
 	])
 ])
 
+AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([], [[
+        #ifndef __clang__
+            not clang
+        #endif
+    ]])],
+    [CLANG=yes], [CLANG=no]
+)
+AC_MSG_RESULT([$CLANG])
+
+if test "$CLANG" = "yes"; then
+    CFLAGS="$CFLAGS -std=gnu89"
+fi
+
 if test "$PHP_SWOOLE" != "no"; then
     PHP_ADD_INCLUDE($SWOOLE_DIR/include)
     PHP_ADD_LIBRARY(pthread)


### PR DESCRIPTION
By default, Clang builds C code according to the C99 standard, which provides different semantics for the inline keyword than GCC's default behavior. see the [clang manual](%28http://clang.llvm.org/compatibility.html#inline%29) for more info.
the SW_INLINE macro need to be compile with the gnu89 standard.
