### PR TITLE
Fixed several memory leaks

### DIFF
--- a/src/core/Base.c
+++ b/src/core/Base.c
@@ -88,6 +88,13 @@ void swoole_clean(void)
         {
             swTimer_free(&SwooleG.timer);
         }
+        
+        if (SwooleG.main_reactor)
+        {
+        	SwooleG.main_reactor->free(SwooleG.main_reactor);
+        }
+        sw_free(SwooleG.main_reactor);
+        
         bzero(&SwooleG, sizeof(SwooleG));
     }
 }

--- a/src/core/hashmap.c
+++ b/src/core/hashmap.c
@@ -314,6 +314,11 @@ void swHashMap_free(swHashMap* hmap)
 		swHashMap_delete_node(root, find);
 		sw_free(find);
 	}
+	
+	sw_free(hmap->root->hh.tbl->buckets);
+	sw_free(hmap->root->hh.tbl);
+	sw_free(hmap->root);
+	
 	sw_free(hmap);
 }
 

--- a/swoole_client.c
+++ b/swoole_client.c
@@ -637,7 +637,6 @@ static swClient* swoole_client_create_socket(zval *object, char *host, int host_
 			ret = recv(cli->connection.fd, &tmp_buf, sizeof(tmp_buf), MSG_DONTWAIT | MSG_PEEK);
 			if (ret == 0 || (ret < 0 && swConnection_error(errno) == SW_CLOSE))
 			{
-                
 				cli->close(cli);
 				goto create_socket;
 			}
@@ -1504,12 +1503,11 @@ PHP_METHOD(swoole_client, on)
 	{
 		return;
 	}
-	zval_add_ref(&getThis());
+
 	for(i=0; i<PHP_CLIENT_CALLBACK_NUM; i++)
 	{
 		if (strncasecmp(php_sw_callbacks[i] + 2, cb_name, cb_name_len) == 0)
 		{
-			zval_add_ref(&zcallback);
 			zend_update_property(swoole_client_class_entry_ptr, getThis(), php_sw_callbacks[i], strlen(php_sw_callbacks[i]), zcallback TSRMLS_CC);
 			RETURN_TRUE;
 		}


### PR DESCRIPTION
1. Free main_reactor on clean
2. Free hashmap root node
3. Invalid zval_add_ref() usage leads swoole_client leak
