### PR TITLE
Fixed possible segfault in swoole_table

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -530,6 +530,45 @@ typedef struct _swMemoryPool
 	void (*destroy)(struct _swMemoryPool *pool);
 } swMemoryPool;
 
+
+typedef struct _swFixedPool_slice
+{
+    uint8_t lock;
+    struct _swFixedPool_slice *next;
+    struct _swFixedPool_slice *pre;
+    char data[0];
+
+} swFixedPool_slice;
+
+typedef struct _swFixedPool
+{
+    void *memory;
+    size_t size;
+
+    swFixedPool_slice *head;
+    swFixedPool_slice *tail;
+
+    /**
+     * total memory size
+     */
+    uint32_t slice_num;
+
+    /**
+     * memory usage
+     */
+    uint32_t slice_use;
+
+    /**
+     * Fixed slice size, not include the memory used by swFixedPool_slice
+     */
+    uint32_t slice_size;
+
+    /**
+     * use shared memory
+     */
+    uint8_t shared;
+
+} swFixedPool;
 /**
  * FixedPool, random alloc/free fixed size memory
  */


### PR DESCRIPTION
The `memory_size` in `swTable_create` should be:

``` c
size_t memory_size = (row_num * row_memory_size) + (table->size * sizeof(swTableRow *))  + sizeof(swMemoryPool) + sizeof(swFixedPool) + ((row_num - table->size) * sizeof(swFixedPool_slice));
```

otherwise, `swFixedPool_init()` may override not allocated memory and cause segfault.
