### PR TITLE
fix class registration

### DIFF
--- a/swoole_http.c
+++ b/swoole_http.c
@@ -382,7 +382,7 @@ void swoole_http_init(int module_number TSRMLS_DC)
     INIT_CLASS_ENTRY(swoole_http_response_ce, "swoole_http_response", swoole_http_response_methods);
     swoole_http_response_class_entry_ptr = zend_register_internal_class(&swoole_http_response_ce TSRMLS_CC);
 
-    INIT_CLASS_ENTRY(swoole_http_response_ce, "swoole_http_request", NULL);
+    INIT_CLASS_ENTRY(swoole_http_request_ce, "swoole_http_request", NULL);
     swoole_http_request_class_entry_ptr = zend_register_internal_class(&swoole_http_request_ce TSRMLS_CC);
 }
 


### PR DESCRIPTION
Noticed using reflection

```
$ php --re swoole | grep Class
- Classes [9] {
Class [ <internal:swoole> class swoole_server ] {
Class [ <internal:swoole> class swoole_lock ] {
Class [ <internal:swoole> class swoole_process ] {
Class [ <internal:swoole> class swoole_buffer ] {
Class [ <internal:swoole> class swoole_client ] {
Class [ <internal:swoole> <iterateable> class swoole_table implements Iterator, Traversable, Countable ] {
Class [ <internal:swoole> class swoole_http_server extends swoole_server ] {
Class [ <internal:swoole> class swoole_http_response ] {
Class [ <internal:swoole> class (null) ] {
```

=> last one have no name, so is very probably unusable
