### PR TITLE
重构websocket

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -179,8 +179,8 @@ if test "$PHP_SWOOLE" != "no"; then
         swoole_buffer.c \
         swoole_table.c \
         swoole_http.c \
-        swoole_websocket.c\
-	src/core/base.c \
+        swoole_websocket.c \
+        src/core/base.c \
         src/core/log.c \
         src/core/hashmap.c \
         src/core/RingQueue.c \

--- a/config.m4
+++ b/config.m4
@@ -179,8 +179,8 @@ if test "$PHP_SWOOLE" != "no"; then
         swoole_buffer.c \
         swoole_table.c \
         swoole_http.c \
-	swoole_websocket.c \
-        src/core/base.c \
+        swoole_websocket.c\
+	src/core/base.c \
         src/core/log.c \
         src/core/hashmap.c \
         src/core/RingQueue.c \

--- a/config.m4
+++ b/config.m4
@@ -179,6 +179,7 @@ if test "$PHP_SWOOLE" != "no"; then
         swoole_buffer.c \
         swoole_table.c \
         swoole_http.c \
+	swoole_websocket.c \
         src/core/base.c \
         src/core/log.c \
         src/core/hashmap.c \

--- a/examples/server/websocket_server.php
+++ b/examples/server/websocket_server.php
@@ -17,9 +17,9 @@ $ser-> on( 'message', function( $ser, $fd, $data, $opcode, $fin)
 	$ser -> push( $fd, "this is server", WEBSOCKET_OPCODE_TEXT, 1 );
 });
 
-$ser-> on( 'close', function()
+$ser-> on( 'close', function( $ser, $fd)
 {
-	echo "client closed\r\n";
+	echo "client {$fd} closed\r\n";
 });
 
 $ser-> start();

--- a/examples/server/websocket_server.php
+++ b/examples/server/websocket_server.php
@@ -1,78 +1,27 @@
-<?php
-$http = new swoole_http_server("0.0.0.0", 9501);
-$http->set(['worker_num' => 4, 'user'=>'www', 'group'=>'www', 'daemonize'=>0]);
+<?
 
-$http->on('open', function($response) {  //handshake成功之后回调, 和js的onopen对应
-    echo "handshake success\n";
-    var_dump($response);
+$ser= new swoole_websocket_server("0.0.0.0", 9501);
+
+$ser-> set(array( 
+	"work_num" => 1
+));
+
+$ser-> on( 'open', function($ser, $fd)
+{
+	echo "server:shakehand success with fd{$fd}\r\n";
 });
 
-$http->on('message', function(swoole_websocket_frame $frame) use ($http) {
-    //var_dump($frame);
-    echo "fd:".$frame->fd . ", fin:".$frame->fin . ", opcode:".$frame->opcode."\n";
-    $frame->message("server send:".$frame->data);
-    //$http->push($frame->fd, "hello, i am swoole http server.");
+$ser-> on( 'message', function( $ser, $fd, $data, $opcode, $fin)
+{
+	echo "receive from {$fd}:{$data},opcode:{$opcode},fin:{$fin}\r\n";
+	$ser -> push( $fd, "this is server", WEBSOCKET_OPCODE_TEXT, 1 );
 });
 
-$http->on('request', function ($request, swoole_http_response $response) {
-    $response->header('Content-Type', 'text/html; charset=utf-8');
-	$response->end(<<<HTML
-<!doctype html>
-<html>
-	<head>
-	    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-		<title>swoole websocket demo ...</title>
-	</head>
-	<body>
-		<script type="text/javascript">
-			var ws  = new WebSocket("ws://127.0.0.1:9501");
-			ws.onopen = function(){
-                console.log("连接服务器成功");
-                ws.send("i client");
-            };
-			ws.onmessage = function(e) {
-                console.log("From Server: "+e.data);
-            };
-			ws.onclose = function(){
-                console.log("服务器已关闭");
-            };
-		</script>
-
-	</body>
-</html>
-HTML
-);
+$ser-> on( 'close', function()
+{
+	echo "client closed\r\n";
 });
 
-$http->on('close', function(){
-    echo "on close\n";
-});
+$ser-> start();
 
-/*
-$http->on('handshake', function($request, $response) {  //自定定握手规则，没有设置则用系统内置的（只支持version:13的）
-            if (!isset($request->header['sec-websocket-key'])) {
-                    //'Bad protocol implementation: it is not RFC6455.'
-                    $response->end();
-                    return false;
-    }
-    if (0 === preg_match('#^[+/0-9A-Za-z]{21}[AQgw]==$#', $request->header['sec-websocket-key']) || 16 !== strlen(base64_decode($request->header['sec-websocket-key']))) {
-                    //Header Sec-WebSocket-Key is illegal;
-                    $response->end();
-                    return false;
-    }
-    $headers =  array(
-            'Upgrade' => 'websocket',
-            'Connection' => 'Upgrade',
-            'Sec-WebSocket-Accept' => ''. base64_encode(sha1($request->header['sec-websocket-key'] . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', true)),
-            'Sec-WebSocket-Version' => '13',
-            'KeepAlive' => 'off',
-        );
-    foreach($headers as $key => $val) {
-                    $response->header($key, $val);
-                }
-    $response->status(101);
-    $response->end();
-});
-*/
-
-$http->start();
+?>

--- a/package.xml
+++ b/package.xml
@@ -164,6 +164,7 @@
 			<file role="src" name="swoole_table.c" />
 			<file role="src" name="swoole_buffer.c" />
 			<file role="src" name="swoole_http.c" />
+			<file role="src" name="swoole_websocket.c" />
 			<dir name="thirdparty">
 				<file role="src" name="php_http_parser.c" />
 				<file role="src" name="php_http_parser.h" />

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -374,7 +374,6 @@ PHP_METHOD(swoole_table, unlock);
 PHP_METHOD(swoole_http_server, on);
 PHP_METHOD(swoole_http_server, start);
 PHP_METHOD(swoole_http_server, setGlobal);
-PHP_METHOD(swoole_http_server, push);
 
 PHP_METHOD(swoole_http_request, rawcontent);
 
@@ -384,7 +383,8 @@ PHP_METHOD(swoole_http_response, rawcookie);
 PHP_METHOD(swoole_http_response, header);
 PHP_METHOD(swoole_http_response, status);
 
-PHP_METHOD(swoole_websocket_frame, message);
+PHP_METHOD(swoole_websocket_server, on);
+PHP_METHOD(swoole_websocket_server, push);
 
 void swoole_destory_lock(zend_resource *rsrc TSRMLS_DC);
 void swoole_destory_process(zend_resource *rsrc TSRMLS_DC);

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -395,6 +395,7 @@ void swoole_async_init(int module_number TSRMLS_DC);
 void swoole_table_init(int module_number TSRMLS_DC);
 void swoole_client_init(int module_number TSRMLS_DC);
 void swoole_http_init(int module_number TSRMLS_DC);
+void swoole_websocket_init(int module_number TSRMLS_DC);
 void swoole_event_init(void);
 
 int php_swoole_process_start(swWorker *process, zval *object TSRMLS_DC);

--- a/swoole.c
+++ b/swoole.c
@@ -586,6 +586,7 @@ PHP_MINIT_FUNCTION(swoole)
 	swoole_async_init(module_number TSRMLS_CC);
 	swoole_table_init(module_number TSRMLS_CC);
 	swoole_http_init(module_number TSRMLS_CC);
+	swoole_websocket_init(module_number TSRMLS_CC);
 
     if (SWOOLE_G(socket_buffer_size) > 0)
     {

--- a/swoole_websocket.c
+++ b/swoole_websocket.c
@@ -1,0 +1,259 @@
+/*
+  +----------------------------------------------------------------------+
+  | Swoole                                                               |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 2.0 of the Apache license,    |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
+  | to obtain it through the world-wide-web, please send a note to       |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Tianfeng Han  <mikan.tenny@gmail.com>                        |
+  +----------------------------------------------------------------------+
+*/
+
+#include "php_swoole.h"
+
+#include <ext/standard/url.h>
+#include <ext/standard/sha1.h>
+#include <ext/standard/php_var.h>
+#include <ext/standard/php_string.h>
+#include <ext/date/php_date.h>
+#include <main/php_variables.h>
+
+#include "websocket.h"
+#include "Connection.h"
+#include "base64.h"
+#include "thirdparty/php_http_parser.h"
+
+
+zend_class_entry swoole_websocket_server_ce;
+zend_class_entry *swoole_websocket_server_class_entry_ptr;
+
+static zval* php_sw_websocket_server_callbacks[2];
+
+int isset_websocket_onMessage();
+int websocket_onMessage(swEventData *req TSRMLS_DC);
+void websocket_onOpen(int fd);
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_websocket_server_on, 0, 0, 2)
+    ZEND_ARG_INFO(0, ha_name)
+    ZEND_ARG_INFO(0, cb)
+ZEND_END_ARG_INFO()
+
+const zend_function_entry swoole_websocket_server_methods[] =
+{
+    PHP_ME(swoole_websocket_server, on,         arginfo_swoole_websocket_server_on, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_websocket_server, push,       NULL, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+
+int isset_websocket_onMessage()
+{
+	int ret = 0;
+	if (php_sw_websocket_server_callbacks[1] != NULL)
+		ret = 1;
+	return ret;
+}
+
+void websocket_onOpen(int fd)
+{
+    TSRMLS_FETCH_FROM_CTX(sw_thread_ctx ? sw_thread_ctx : NULL);
+
+    swConnection *conn = swWorker_get_connection(SwooleG.serv, fd);
+    if (!conn)
+    {
+        swWarn("connection[%d] is closed.", fd);
+        return;
+    }
+    if (conn->websocket_status == WEBSOCKET_STATUS_CONNECTION)
+    {
+        conn->websocket_status = WEBSOCKET_STATUS_HANDSHAKE;
+    }
+
+    swTrace("\n\n\n\nconn ws status:%d, fd=%d\n\n\n", conn->websocket_status, fd);
+
+    if (php_sw_websocket_server_callbacks[0] != NULL)
+    {
+        swTrace("\n\n\n\nhandshake success\n\n\n");
+
+	zval **args[2];
+	swServer *serv = SwooleG.serv;
+	zval *zserv = (zval *)serv->ptr2;
+	zval *zfd;
+	MAKE_STD_ZVAL(zfd);
+	ZVAL_LONG(zfd, fd);		
+	args[0] = &zserv;
+	args[1] = &zfd;
+	zval *retval;
+
+	if (call_user_function_ex(EG(function_table), NULL, php_sw_websocket_server_callbacks[0], &retval, 2, args, 0, NULL TSRMLS_CC) == FAILURE)
+	{
+            php_error_docref(NULL TSRMLS_CC, E_WARNING, "onMessage handler error");
+        }
+        swTrace("===== message callback end======");
+        if (EG(exception))
+        {
+            zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);
+        }
+        if (retval)
+        {
+            zval_ptr_dtor(&retval);
+        }
+    }
+}
+
+int websocket_onMessage(swEventData *req TSRMLS_DC)
+{
+	int fd = req->info.fd;
+	zval *zdata = php_swoole_get_data(req TSRMLS_CC);
+
+	char *buf = Z_STRVAL_P(zdata);
+	long fin = buf[0] ? 1 : 0;
+	long opcode = buf[1] ? 1 : 0;
+
+	buf += 2;
+
+	swServer *serv = SwooleG.serv;
+	zval *zserv = (zval *)serv->ptr2;
+	zval *zd, *zfd, *zopcode, *zfin;
+	MAKE_STD_ZVAL(zd);
+	MAKE_STD_ZVAL(zfd);
+	MAKE_STD_ZVAL(zopcode);
+	MAKE_STD_ZVAL(zfin);
+	SW_ZVAL_STRINGL(zd, buf, Z_STRLEN_P(zdata) - 2, 1);
+	ZVAL_LONG(zfd, fd);
+	ZVAL_LONG(zopcode, opcode);
+	ZVAL_LONG(zfin, fin);
+	zval **args[5];
+	args[0] = &zserv;
+	args[1] = &zfd;
+	args[2] = &zd;
+	args[3] = &zopcode;
+	args[4] = &zfin;
+	zval *retval;
+	if (call_user_function_ex(EG(function_table), NULL, php_sw_websocket_server_callbacks[1], &retval, 5, args, 0,  NULL TSRMLS_CC) == FAILURE)
+	{
+        	zval_ptr_dtor(&zdata);
+	        php_error_docref(NULL TSRMLS_CC, E_WARNING, "onMessage handler error");
+	}
+
+    //swTrace("===== message callback end======");
+
+    if (EG(exception))
+    {
+        zval_ptr_dtor(&zdata);
+        zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);
+    }
+
+    if (retval)
+    {
+        zval_ptr_dtor(&retval);
+    }
+    zval_ptr_dtor(&zdata);
+    zval_ptr_dtor(&zfd);
+    zval_ptr_dtor(&zd);
+    zval_ptr_dtor(&zopcode);
+    zval_ptr_dtor(&zfin);
+    zval_ptr_dtor(&zserv);
+
+    return SW_OK;
+}
+
+void swoole_websocket_init(int module_number TSRMLS_DC)
+{
+    INIT_CLASS_ENTRY(swoole_websocket_server_ce, "swoole_websocket_server", swoole_websocket_server_methods);
+    swoole_websocket_server_class_entry_ptr = zend_register_internal_class_ex(&swoole_websocket_server_ce, swoole_http_server_class_entry_ptr, "swoole_http_server" TSRMLS_CC);
+
+    REGISTER_LONG_CONSTANT("WEBSOCKET_OPCODE_TEXT", WEBSOCKET_OPCODE_TEXT_FRAME, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("WEBSOCKET_OPCODE_BINARY", WEBSOCKET_OPCODE_BINARY_FRAME, CONST_CS | CONST_PERSISTENT);
+}
+
+PHP_METHOD( swoole_websocket_server, on)
+{
+    zval *callback;
+    zval *event_name;
+    swServer *serv;
+
+    if (SwooleGS->start > 0)
+    {
+        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Server is running. Unable to set event callback now.");
+        RETURN_FALSE;
+    }
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz", &event_name, &callback) == FAILURE)
+    {
+        return;
+    }
+
+    SWOOLE_GET_SERVER(getThis(), serv);
+
+    char *func_name = NULL;
+    if (!zend_is_callable(callback, 0, &func_name TSRMLS_CC))
+    {
+        php_error_docref(NULL TSRMLS_CC, E_ERROR, "Function '%s' is not callable", func_name);
+        efree(func_name);
+        RETURN_FALSE;
+    }
+    efree(func_name);
+
+    if (strncasecmp("open", Z_STRVAL_P(event_name), Z_STRLEN_P(event_name)) == 0)
+    {
+        zval_add_ref(&callback);
+        php_sw_websocket_server_callbacks[0] = callback;
+    }
+    else if (strncasecmp("message", Z_STRVAL_P(event_name), Z_STRLEN_P(event_name)) == 0)
+    {
+        zval_add_ref(&callback);
+        php_sw_websocket_server_callbacks[1] = callback;
+    }
+    else
+    {
+        zend_call_method_with_2_params(&getThis(), swoole_http_server_class_entry_ptr, NULL, "on", &return_value, event_name, callback);
+    }
+}
+
+
+PHP_METHOD(swoole_websocket_server, push)
+{
+    swString data;
+    data.length = 0;
+    long fd = 0;
+    long opcode = WEBSOCKET_OPCODE_TEXT_FRAME;
+    zend_bool fin = 1;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ls|lb", &fd, &data.str, &data.length, &opcode, &fin) == FAILURE)
+    {
+        return;
+    }
+
+    if (fd <= 0)
+    {
+        swoole_php_fatal_error(E_WARNING, "fd[%d] is invalid.", (int )fd);
+        RETURN_FALSE;
+    }
+
+    if (opcode > WEBSOCKET_OPCODE_PONG)
+    {
+        swoole_php_fatal_error(E_WARNING, "opcode max 10");
+        RETURN_FALSE;
+    }
+
+    swConnection *conn = swWorker_get_connection(SwooleG.serv, fd);
+    if (!conn || conn->websocket_status < WEBSOCKET_STATUS_HANDSHAKE)
+    {
+        swoole_php_fatal_error(E_WARNING, "connection[%d] is not a websocket client.", (int ) fd);
+        RETURN_FALSE;
+    }
+
+    swTrace("need send:%s len:%zd\n", data.str, data.length);
+    swString *response = swWebSocket_encode(&data, opcode, (int) fin);
+    int ret = swServer_tcp_send(SwooleG.serv, fd, response->str, response->length);
+    swTrace("need send:%s len:%zd\n", response->str, response->length);
+    swString_free(response);
+    SW_CHECK_RETURN(ret);
+}
+


### PR DESCRIPTION
1.封装了4个接口，例子在example/server/websocket_server.php中：
onopen($server, $fd）//shakehand成功后调用
onclose($server, $fd）//客户端关闭连接时调用
onmessage( $server, $fd, $data, $opcode, $fin)//接收到客户端数据包时调用
push( $fd, $data, $opcode, $fin)//向客户端发送数据

2.websocket握手交给http server，从http server剥离webosocket的业务逻辑