### PR TITLE
Websocket close implementation not follows the standard.

### DIFF
--- a/src/network/ReactorThread.c
+++ b/src/network/ReactorThread.c
@@ -1236,8 +1236,8 @@ static int swReactorThread_onReceive_websocket(swReactor *reactor, swEvent *even
                             swTrace("close error\n");
                             return SW_ERR;
                         }
-                        tmp_package.str[0] = FRAME_SET_LENGTH(WEBSOCKET_CLOSE_NORMAL, 1);
-                        tmp_package.str[1] = FRAME_SET_LENGTH(WEBSOCKET_CLOSE_NORMAL, 0);
+                        tmp_package.str[0] = 0x88;
+                        tmp_package.str[1] = 0x00;
                         tmp_package.length = 2;
                         swConnection_send(conn, tmp_package.str, 2, 0);
                         swReactorThread_onClose(reactor, event);
@@ -1342,8 +1342,8 @@ static int swReactorThread_onReceive_websocket(swReactor *reactor, swEvent *even
                         swTrace("close error\n");
                         return SW_ERR;
                     }
-                    tmp_package.str[0] = FRAME_SET_LENGTH(WEBSOCKET_CLOSE_NORMAL, 1);
-                    tmp_package.str[1] = FRAME_SET_LENGTH(WEBSOCKET_CLOSE_NORMAL, 0);
+                    tmp_package.str[0] = 0x88;
+                    tmp_package.str[1] = 0x00;
                     tmp_package.length = 2;
                     swConnection_send(conn, tmp_package.str, 2, 0);
                     swReactorThread_onClose(reactor, event);


### PR DESCRIPTION
1. https://tools.ietf.org/html/rfc6455#section-5.1.
A server MUST NOT mask any frames that it sends to the client.

2. According to RFC, when a client tries to close, server should
response 10001000 00000000.

3. Current implementation’s mask place is 1 which causes the response
is masked.