### PR TITLE
Revert "fix gcc warning"

### DIFF
--- a/swoole_async.c
+++ b/swoole_async.c
@@ -317,7 +317,7 @@ PHP_FUNCTION(swoole_async_read)
     }
     if (offset >= file_stat.st_size)
     {
-        swoole_php_fatal_error(E_WARNING, "offset must be less than file_size[=%lld].", file_stat.st_size);
+        swoole_php_fatal_error(E_WARNING, "offset must be less than file_size[=%ld].", file_stat.st_size);
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
Reverts swoole/swoole-src#315

/home/htf/workspace/swoole/swoole_async.c: In function ‘zif_swoole_async_read’:
/home/htf/workspace/swoole/swoole_async.c:320:9: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 5 has type ‘__off_t’ [-Wformat=]
         swoole_php_fatal_error(E_WARNING, "offset must be less than file_size[=%lld].", file_stat.st_size);
         ^

改成lld 反而有 warning.