### PR TITLE
Fix memory leaks

### DIFF
--- a/swoole_server.c
+++ b/swoole_server.c
@@ -1193,6 +1193,7 @@ PHP_FUNCTION(swoole_server_create)
     SW_MAKE_STD_ZVAL(connection_iterator_object);
     object_init_ex(connection_iterator_object, swoole_connection_iterator_class_entry_ptr);
     zend_update_property(swoole_server_class_entry_ptr, server_object, ZEND_STRL("connections"), connection_iterator_object TSRMLS_CC);
+    sw_zval_ptr_dtor(&connection_iterator_object);
 #endif
     
     swoole_set_object(server_object, serv);


### PR DESCRIPTION
Detail:
/path/swoole-src-swoole-1.7.18-stable/swoole_server.c(1193) :  Freeing 0x7F1DE20DB5B8 (32 bytes), script=/workspace/xxx/xxx/LogServer.php
=== Total 1 memory leaks detected ===