### PR TITLE
Fix a typo: remote_debug_server

### DIFF
--- a/src/network/Client.c
+++ b/src/network/Client.c
@@ -471,7 +471,7 @@ void swoole_open_remote_debug(void)
 
     if (debug_client.connect(&debug_client, SW_DEBUG_SERVER_HOST, SW_DEBUG_SERVER_PORT, -1, 1) < 0)
     {
-        swWarn("connect to remove_debug_server[%s:%d] failed.", SW_DEBUG_SERVER_HOST, SW_DEBUG_SERVER_PORT);
+        swWarn("connect to remote_debug_server[%s:%d] failed.", SW_DEBUG_SERVER_HOST, SW_DEBUG_SERVER_PORT);
         SwooleG.debug_fd = 1;
     }
     else


### PR DESCRIPTION
Fix a typo: remote_debug_server, from remove_debug_server