### PR TITLE
避免cli创建后在没有connect的情况下导致的内存泄漏

### DIFF
--- a/swoole_client.c
+++ b/swoole_client.c
@@ -1756,18 +1756,22 @@ static PHP_METHOD(swoole_client, on)
 
     if (strncasecmp("connect", cb_name, cb_name_len) == 0)
     {
+       if(cb->onConnect)sw_zval_ptr_dtor(&cb->onConnect);
         cb->onConnect = zcallback;
     }
     else if (strncasecmp("receive", cb_name, cb_name_len) == 0)
     {
+        if(cb->onReceive)sw_zval_ptr_dtor(&cb->onReceive);
         cb->onReceive = zcallback;
     }
     else if (strncasecmp("close", cb_name, cb_name_len) == 0)
     {
+        if(cb->onClose)sw_zval_ptr_dtor(&cb->onClose);
         cb->onClose = zcallback;
     }
     else if (strncasecmp("error", cb_name, cb_name_len) == 0)
     {
+        if(cb->onError)sw_zval_ptr_dtor(&cb->onError);
         cb->onError = zcallback;
     }
     else


### PR DESCRIPTION
在没有connect的情况下，不会创建cli对象，此时析构方法中的client_free不会调用。再次创建cli时会导致原有callback指针丢失，从而导致内存泄漏。

测试代码：
<?php
function a(){
        $cli = new \swoole_client ( SWOOLE_TCP );
        $cli->on ( "connect", null);
}

$i=0;
while($i++<4){
        for($j=0;$j<10000;$j++)a();
        echo \memory_get_usage(),"\n";
}
