### PR TITLE
php core in swoole_timer_tick base php7

### DIFF
--- a/swoole_timer.c
+++ b/swoole_timer.c
@@ -72,6 +72,10 @@ static long php_swoole_add_timer(int ms, zval *callback, zval *param, int is_tic
     {
         memcpy(cb->data, param, sizeof(zval));
     }
+    else
+    {
+        cb->data = NULL;
+    }
 #else
     cb->data = param;
     cb->callback = callback;


### PR DESCRIPTION
I use swoole base php7, find a core ,bt is here:

```c
(gdb) bt
#0  zval_addref_p (pz=0x7f50b4e55608, pz=0x7f50b4e55608) at /xxxx/php-src-php-7.0.0RC5/include/php/Zend/zend_types.h:822
#1  php_swoole_add_timer (ms=500, callback=0x7f50b4e136d0, param=0x0, is_tick=is_tick@entry=1) at /xxxx/swoole/swoole-src-swoole-1.7.20-stable/swoole_timer.c:95
#2  0x00007f50b1d785ae in zif_swoole_timer_tick (execute_data=<optimized out>, return_value=0x7f50b4e13640) at /xxxx/swoole/swoole-src-swoole-1.7.20-stable/swoole_timer.c:352
```

In php code,I use swoole_add_timer(xx,xx), let param = NULL

```c
static long php_swoole_add_timer(int ms, zval *callback, zval *param, int is_tick TSRMLS_DC) 
{
//....................
#if PHP_MAJOR_VERSION >= 7
    cb->data = &cb->_data; //here,  cb->data != NULL forever
    cb->callback = &cb->_callback;
    memcpy(cb->callback, callback, sizeof(zval));
    if (param)
    {
        memcpy(cb->data, param, sizeof(zval));
    }
#else
    cb->data = param;
    cb->callback = callback;
#endif

   //.....................
    if (cb->data)
    {
        sw_zval_add_ref(&cb->data);     //come to here any conditions. if param is NULL, will lead a core
    }
}
```

