### PR TITLE
swoole_http_client增加设置headers和post功能，修复fd常量使用错误

### DIFF
--- a/examples/swoole_http_client.php
+++ b/examples/swoole_http_client.php
@@ -1,18 +1,19 @@
 <?php
 ini_set('display_errors',1);
-error_reporting(E_ALL);
+//error_reporting(E_ALL);
+error_reporting(0);
 $http = new swoole_http_server("", 9501, SWOOLE_BASE);
 
 $http->set([
-        'worker_num' => 2,
+        //'worker_num' => 2,
 ]);
-
-$http->on('request', function ($request, swoole_http_response $response) {
+$i = 0;
+$http->on('request', function ($request, swoole_http_response $response)use(&$i) {
 
         $route = $request->server['request_uri'];
         if($route == '/info'){
-        $response->end(111);
-        return;
+                $response->end(json_encode($request));
+                return;
         }
 
         $cli = new swoole_http_client('127.0.0.1', 9501);
@@ -20,22 +21,31 @@ $http->on('request', function ($request, swoole_http_response $response) {
                 'timeout' => 0.3,
                 'keep_alive' => 1,
         ]);
+	//post request
+        $cli->setData(http_build_query(['a'=>123,'b'=>"哈哈"]));
+        $cli->setHeaders(['User-Agent' => "swoole"]);
         $cli->on('close', function($cli)use($response){
                 //      echo "close\n";
                 });
         $cli->on('error', function($cli) use ($response){
-                echo "error\n";
                 $response->end("error");
                 });
-        $cli->execute('/info', function($cli)use( $response){
-                $cli->execute('/info', function($cli)use($response){
-                        $ret = json_encode($cli->headers) . $cli->body;
+        $cli->execute('/info', function($cli)use( $response, &$i){
+        	$cli->setHeaders(['User-Agent' => "swoole"]);
+		//get request
+                $cli->execute('/info', function($cli)use($response, &$i){
+                        $ret = json_encode($cli->headers) . "\nSERVER RESPONSE: ". $cli->body;
                         $response->end($ret);
                         $cli->close();
-                        //echo "----->Mem: ", memory_get_usage(), "b\n";
                         });
                 });
+
+
+        if($i++ == 1000){
+            echo "----->Mem: ", memory_get_usage(), "b\n";
+            $i = 0;
+        }
+
 });
 
 $http->start();
-

--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -643,9 +643,9 @@ static void php_http_client_swoole_check_reactor()
         return;
     }
 
-    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, (SW_FD_USER + 1) | SW_EVENT_READ, http_client_onRead);
-    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, (SW_FD_USER + 1) | SW_EVENT_WRITE, http_client_onWrite);
-    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, (SW_FD_USER + 1) | SW_EVENT_ERROR, http_client_onError);
+    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, PHP_SWOOLE_FD_HTTPCLIENT | SW_EVENT_READ, http_client_onRead);
+    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, PHP_SWOOLE_FD_HTTPCLIENT | SW_EVENT_WRITE, http_client_onWrite);
+    SwooleG.main_reactor->setHandle(SwooleG.main_reactor, PHP_SWOOLE_FD_HTTPCLIENT | SW_EVENT_ERROR, http_client_onError);
 
     php_swoole_event_init();
 


### PR DESCRIPTION
新增 $cli->setData() 方法发送post请求
新增 $cli->setHeaders() 方法设置头信息
 
```php
        $cli = new swoole_http_client('127.0.0.1', 9501);
        $cli->set([
                'timeout' => 0.3,
                'keep_alive' => 1,
        ]);
        //post request
        $cli->setData(http_build_query(['a'=>123,'b'=>"哈哈"]));
        $cli->setHeaders(['User-Agent' => "swoole"]);
        $cli->execute('/info', function($cli){$cli->close();});
```

暂不支持PHP7
