### PR TITLE
close connection when body finished

### DIFF
--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -56,7 +56,7 @@ static int http_client_parser_on_message_complete(php_http_parser *parser);
 static sw_inline void http_client_swString_append_headers(swString* swStr, char* key, zend_size_t key_len, char* data, zend_size_t data_len)
 {
     swString_append_ptr(swStr, key, key_len);
-    swString_append_ptr(swStr, ZEND_STRL(": "));
+    swString_append_ptr(swStr, ZEND_STRL(":"));
     swString_append_ptr(swStr, data, data_len);
     swString_append_ptr(swStr, ZEND_STRL("\r\n"));
 }
@@ -1160,6 +1160,11 @@ static int http_client_parser_on_message_complete(php_http_parser *parser)
     if (retval != NULL)
     {
         sw_zval_ptr_dtor(&retval);
+    }
+
+    if(http->keep_alive == 0)
+    {
+        http_client_close(zobject, http->cli->socket->fd TSRMLS_CC);
     }
 
     return 0;


### PR DESCRIPTION
header信息里面的key去掉冒号，这个地方是个bug。
如果是短连接，在body部分完成后主动关闭连接，防止调用方没有关闭连接导致的内存泄漏。