### PR TITLE
Fixed opcode in callback OnMessage

### DIFF
--- a/swoole_websocket_server.c
+++ b/swoole_websocket_server.c
@@ -225,7 +225,7 @@ int swoole_websocket_onMessage(swEventData *req)
 
     char *buf = Z_STRVAL_P(zdata);
     long finish = buf[0] ? 1 : 0;
-    long opcode = buf[1] ? 1 : 0;
+    long opcode = buf[1];
 
     zval *zframe;
     SW_MAKE_STD_ZVAL(zframe);


### PR DESCRIPTION
按照官网的说明，回调中opcode的取值可以是Ox1或者Ox2
http://wiki.swoole.com/wiki/page/413.html
•WEBSOCKET_OPCODE_TEXT = 0x1，UTF-8 text
•WEBSOCKET_OPCODE_BINARY = 0x2，Binary

按WebSocket的协议，Opcode应该是buf[1]位置的取值，而取值范围可以是Ox0 ~ OxF，其中有数据意义的还是Ox1和Ox2，但原来的写法中不能正确的返回Ox2的情况，无论客户端发的binary还是string，回调都是Ox1，修改后，如果客户端发送的是Ox2，也能正确回调Ox2了。