### PR TITLE
Add request_time_float

### DIFF
--- a/php7_wrapper.h
+++ b/php7_wrapper.h
@@ -154,12 +154,16 @@ static sw_inline int sw_add_assoc_stringl_ex(zval *arg, const char *key, size_t 
     return add_assoc_stringl_ex(arg, key, key_len - 1, str, length);
 }
 
-#define sw_add_assoc_double_ex(arg, key, key_len, d)     add_assoc_double_ex(arg, key, key_len - 1, d)
 #define sw_add_next_index_stringl(arr, str, len, dup)    add_next_index_stringl(arr, str, len)
 
 static sw_inline int sw_add_assoc_long_ex(zval *arg, const char *key, size_t key_len, long value)
 {
     return add_assoc_long_ex(arg, key, key_len - 1, value);
+}
+
+static sw_inline int sw_add_assoc_double_ex(zval *arg, const char *key, size_t key_len, double value)
+{
+    return add_assoc_double_ex(arg, key, key_len - 1, value);
 }
 
 #define SW_Z_ARRVAL_P(z)                          Z_ARRVAL_P(z)->ht

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -1114,6 +1114,10 @@ static int http_onReceive(swServer *serv, swEventData *req)
         sw_add_assoc_stringl(zserver, "path_info", ctx->request.path, ctx->request.path_len, 1);
         sw_add_assoc_long_ex(zserver, ZEND_STRS("request_time"), SwooleGS->now);
 
+        // Add REQUEST_TIME_FLOAT
+        double now_float = swoole_microtime();
+        sw_add_assoc_double_ex(zserver, ZEND_STRS("request_time_float"), now_float);
+
         swConnection *conn = swWorker_get_connection(SwooleG.serv, fd);
         if (!conn)
         {

--- a/swoole_http_v2_server.c
+++ b/swoole_http_v2_server.c
@@ -499,6 +499,11 @@ int swoole_http2_onFrame(swoole_http_client *client, swEventData *req)
 
         zval *zserver = ctx->request.zserver;
         sw_add_assoc_long_ex(zserver, ZEND_STRS("request_time"), SwooleGS->now);
+
+        // Add REQUEST_TIME_FLOAT
+        double now_float = swoole_microtime();
+        sw_add_assoc_double_ex(zserver, ZEND_STRS("request_time_float"), now_float);
+
         add_assoc_long(zserver, "server_port", swConnection_get_port(&SwooleG.serv->connection_list[conn->from_fd]));
         add_assoc_long(zserver, "remote_port", swConnection_get_port(conn));
         sw_add_assoc_string(zserver, "remote_addr", swConnection_get_ip(conn), 1);


### PR DESCRIPTION
PHP5.4在$_SERVER中新增了REQUEST_TIME_FLOAT字段，浮点型的请求时间。
参考`sw_add_assoc_long_ex`的方式，修复了PHP7下CI构建不通过的问题。
这个可以用来计算脚本运行时间等，个人比较倾向有这个小功能，希望合并此PR。