### PR TITLE
Update swoole_buffer.c

### DIFF
--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -139,7 +139,7 @@ static PHP_METHOD(swoole_buffer, substr)
     }
     swString *buffer = swoole_get_object(getThis());
 
-    if (seek && !(offset == 0 && length < buffer->length))
+    if (seek && !(offset == 0 && length <= buffer->length))
     {
         seek = 0;
     }

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -133,7 +133,7 @@ static PHP_METHOD(swoole_buffer, substr)
     long length = -1;
     long seek = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|lb", &offset, &length, &seek) == FAILURE)
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|ll", &offset, &length, &seek) == FAILURE)
     {
         RETURN_FALSE;
     }

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -164,9 +164,12 @@ static PHP_METHOD(swoole_buffer, substr)
 			zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
 					buffer->length - buffer->offset TSRMLS_CC);
     	} else {
+    		SW_RETVAL_STRINGL(buffer->str + offset, length, 1);
+    		buffer->length -= length;
     		zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
-    							buffer->length - length TSRMLS_CC);
-    		memcpy(buffer->str, buffer->str + length, buffer->length - length);
+    							buffer->length TSRMLS_CC);
+    		memcpy(buffer->str, buffer->str + length, buffer->length);
+    		return;
     	}
     }
     SW_RETURN_STRINGL(buffer->str + offset, length, 1);

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -131,7 +131,7 @@ static PHP_METHOD(swoole_buffer, substr)
 {
     long offset;
     long length = -1;
-    zend_bool seek = 0;
+    long seek = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|lb", &offset, &length, &seek) == FAILURE)
     {
@@ -159,9 +159,15 @@ static PHP_METHOD(swoole_buffer, substr)
     }
     if (seek)
     {
-        buffer->offset += length;
-        zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
-                buffer->length - buffer->offset TSRMLS_CC);
+        if (1 == seek) {
+			buffer->offset += length;
+			zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
+					buffer->length - buffer->offset TSRMLS_CC);
+    	} else {
+    		zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
+    							buffer->length - length TSRMLS_CC);
+    		memcpy(buffer->str, buffer->str + length, buffer->length - length);
+    	}
     }
     SW_RETURN_STRINGL(buffer->str + offset, length, 1);
 }


### PR DESCRIPTION
额外选项控制是否数据可以前移，如果不前移使用swoole_buffer后续追加可能触发再次分配内存，之前被移除的空位置没有利用