### PR TITLE
尝试修复swoole_http_client异步请求的内存泄漏问题

### DIFF
--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1309,6 +1309,7 @@ static int http_client_parser_on_message_complete(php_http_parser *parser)
     else if (http->keep_alive == 0)
     {
         http->cli->close(http->cli);
+        sw_zval_ptr_dtor(&zobject);
     }
     return 0;
 }


### PR DESCRIPTION
在worker进程中起一个定时器，重复地使用swoole_http_client发起异步请求，发现内存泄漏问题，参见#692 。调试发现swoole_http_client的__destruct方法没有被调用，就自己跟踪尝试修复这个问题，不知道修改是否有问题，请不吝赐教。

另外感觉内存泄漏问题并没有完全解决，#692 中的测试用例依然会有小量内存泄漏，运行结果是内存每次还会继续增加16 bytes。