### PR TITLE
修复php7下swoole_mysql的callback没有被调用和swoole_mysql->close方法出现异常的问题

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -58,7 +58,7 @@ void swoole_mysql_init(int module_number TSRMLS_DC)
     swoole_mysql_class_entry_ptr = zend_register_internal_class(&swoole_mysql_ce TSRMLS_CC);
 
     SWOOLE_INIT_CLASS_ENTRY(swoole_mysql_exception_ce, "swoole_mysql_exception", "Swoole\\MySQL\Exception", NULL);
-    swoole_mysql_exception_class_entry = zend_register_internal_class_ex(&swoole_mysql_exception_ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
+    swoole_mysql_exception_class_entry = zend_register_internal_class_ex(&swoole_mysql_exception_ce, zend_exception_get_default(TSRMLS_C));
 }
 
 static PHP_METHOD(swoole_mysql, __construct)

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -297,7 +297,8 @@ static sw_inline void mysql_get_socket(zval *mysql_link, zval *return_value, int
     php_stream *stream;
     *sock = -1;
 
-    if (Z_TYPE_P(mysql_link) != IS_OBJECT || strcasecmp(Z_OBJCE_P(mysql_link)->name, "mysqli") != 0)
+    const char* mysql_link_name = ZSTR_VAL(Z_OBJCE_P(mysql_link)->name);
+    if (Z_TYPE_P(mysql_link) != IS_OBJECT || strcasecmp(mysql_link_name, "mysqli") != 0)
     {
         return;
     }

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -184,6 +184,7 @@ typedef struct
     int fd;
 
 #if PHP_MAJOR_VERSION >= 7
+    zval _object;
     zval _callback;
     zval _mysqli;
 #endif


### PR DESCRIPTION
#694 
修复php7下swoole_mysql的callback没有被调用和swoole_mysql->close方法出现异常的问题。