### PR TITLE
FIX: swPort_onRead_check_eof coredump

### DIFF
--- a/src/network/Port.c
+++ b/src/network/Port.c
@@ -561,7 +561,7 @@ static int swPort_onRead_check_eof(swReactor *reactor, swListenPort *port, swEve
         return SW_ERR;
     }
 
-    if (swProtocol_recv_check_eof(protocol, conn, conn->object) < 0)
+    if (swProtocol_recv_check_eof(protocol, conn, buffer) < 0)
     {
         swReactorThread_onClose(reactor, event);
     }


### PR DESCRIPTION
设置为固定结尾的包解析时，建立连接然后直接断开，会诱发coredump。