### PR TITLE
add dispatch_mode = 6, fixed #766

### DIFF
--- a/include/Server.h
+++ b/include/Server.h
@@ -727,6 +727,18 @@ static sw_inline uint32_t swServer_worker_schedule(swServer *serv, uint32_t sche
             target_worker_id = schedule_key % serv->worker_num;
         }
     }
+    else if (serv->dispatch_mode == SW_DISPATCH_CONNSIDMOD)
+    {
+        swConnection *conn = swServer_connection_get(serv, schedule_key);
+        if (conn == NULL)
+        {
+            target_worker_id = schedule_key % serv->worker_num;
+        }
+        else
+        {
+            target_worker_id = conn->session_id % serv->worker_num;
+        }
+    }
     //Preemptive distribution
     else
     {

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -253,6 +253,7 @@ enum swFactory_dispatch_mode
     SW_DISPATCH_QUEUE = 3,
     SW_DISPATCH_IPMOD = 4,
     SW_DISPATCH_UIDMOD = 5,
+    SW_DISPATCH_CONNSIDMOD = 6,
 };
 
 enum swWorker_status


### PR DESCRIPTION
增加一个用连接的session_id取模平均分配worker的模式，可以解决少量客户端下频繁短连接请求导致 worker 分配不均衡的问题，见 #766 