### PR TITLE
优化 http_server cookies 解析逻辑

### DIFF
--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -366,7 +366,7 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
             sw_add_assoc_stringl_ex(array, keybuf, klen, valbuf, vlen, 1);
             j = i + 1;
             state = 0;
-			inparse = 0;
+            inparse = 0;
         }
         else if (isspace(*_c))
         {

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -337,6 +337,9 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
     int klen = 0;
     int vlen = 0;
     int state = 0;
+	
+	//Occur first no space char, set inparse = 1; at the end of each cookie(occur ;), set inparse = 0
+	int inparse = 0;
 
     int i = 0, j = 0;
     while (_c < at + length)
@@ -361,9 +364,22 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
             strncpy(valbuf, (char * ) at + j, SW_HTTP_COOKIE_VALLEN);
             vlen = php_url_decode(valbuf, vlen);
             sw_add_assoc_stringl_ex(array, keybuf, klen, valbuf, vlen, 1);
-            j = i + 2;
+            j = i + 1;
             state = 0;
-        }
+			inparse = 0;
+        } 
+		else if (isspace(*_c)) 
+		{
+			if (!inparse)
+			{
+				//Remove leading spaces from cookie names, Keep spaces in the middle of names or values
+				++j;
+			}
+		}
+		else
+		{
+			inparse = 1;
+		}
         _c++;
         i++;
     }

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -367,19 +367,19 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
             j = i + 1;
             state = 0;
 			inparse = 0;
-        } 
-		else if (isspace(*_c)) 
-		{
-			if (!inparse)
-			{
-				//Remove leading spaces from cookie names, Keep spaces in the middle of names or values
-				++j;
-			}
-		}
-		else
-		{
-			inparse = 1;
-		}
+        }
+        else if (isspace(*_c))
+        {
+            if (!inparse)
+            {
+                //Remove leading spaces from cookie names 
+                ++j;
+            }
+        }
+        else
+        {
+            inparse = 1;
+        }
         _c++;
         i++;
     }

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -336,15 +336,12 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
 
     int klen = 0;
     int vlen = 0;
-    int state = 0;
+    int state = -1;
 	
-    //Occur first no space char, set inparse = 1; at the end of each cookie(occur ;), set inparse = 0
-    int inparse = 0;
-
     int i = 0, j = 0;
     while (_c < at + length)
     {
-        if (state == 0 && *_c == '=')
+        if (state <= 0 && *_c == '=')
         {
             klen = i - j + 1;
             if (klen >= SW_HTTP_COOKIE_KEYLEN)
@@ -365,20 +362,19 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
             vlen = php_url_decode(valbuf, vlen);
             sw_add_assoc_stringl_ex(array, keybuf, klen, valbuf, vlen, 1);
             j = i + 1;
-            state = 0;
-            inparse = 0;
+            state = -1;
         }
-        else if (isspace(*_c))
+        else if (state < 0)
         {
-            if (!inparse)
+            if (isspace(*_c))
             {
                 //Remove leading spaces from cookie names 
                 ++j;
+            } 
+            else
+            {
+                state = 0;
             }
-        }
-        else
-        {
-            inparse = 1;
         }
         _c++;
         i++;

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -338,8 +338,8 @@ static void http_parse_cookie(zval *array, const char *at, size_t length)
     int vlen = 0;
     int state = 0;
 	
-	//Occur first no space char, set inparse = 1; at the end of each cookie(occur ;), set inparse = 0
-	int inparse = 0;
+    //Occur first no space char, set inparse = 1; at the end of each cookie(occur ;), set inparse = 0
+    int inparse = 0;
 
     int i = 0, j = 0;
     while (_c < at + length)


### PR DESCRIPTION
示例代码如下:
```php
<?php
$http = new swoole_http_server("127.0.0.1", 8505);
$http->on('request', function (swoole_http_request $request, swoole_http_response $response) {
    $response->end(json_encode($request->cookie));
});

$http->start();
```

正确解析:

    curl --cookie "user=root; pass=123456" "http://localhost:8505"
    {"user":"root","pass":"123456"}

错误解析:

    curl --cookie "user=root;pass=123456" "http://localhost:8505"
    {"user":"root","ass":"123456"}

区别在于，`;` 和 `pass` 之间没有空格，导致在解析 cookie 时有误。

---

上面的 case，PHP 中输出 $_COOKIES 时，能够正常解析:

```php
<?php
var_dump($_COOKIE);
```
    curl --cookie "user=root; pass=123456" "http://localhost/print_cookie.php"
    array(2) {
      ["user"]=>
      string(4) "root"
      ["pass"]=>
      string(6) "123456"
    }

    curl --cookie "user=root;pass=123456" "http://localhost/print_cookie.php"
    array(2) {
      ["user"]=>
      string(4) "root"
      ["pass"]=>
      string(6) "123456"
    }

---

本次修改内容如下：

- 每个cookie name 前面有空格时，去掉空格（逻辑如下：遇到空格时，判断空格是处理 cookie name 前面，还是处于 name=value 中间。如果处于前面，则跳过空格）
- 每个cookie解析结束时，即_cur 为 `;`时，将 j + 2，调整为 j + 1