### PR TITLE
Reset start status after server shutdown

### DIFF
--- a/src/network/Server.c
+++ b/src/network/Server.c
@@ -1145,6 +1145,8 @@ static void swServer_signal_hanlder(int sig)
         {
             SwooleG.running = 0;
         }
+        // Reset start status
+        SwooleGS->start = 0;
         swNotice("Server is shutdown now.");
         break;
     case SIGALRM:


### PR DESCRIPTION
The start status which is set in `swServer_start()`:
```c
568    SwooleGS->start = 1;
```
Should be reset after shoutdown