### PR TITLE
Run swServer_free(serv) before SwooleGS->start = 0

### DIFF
--- a/src/network/Server.c
+++ b/src/network/Server.c
@@ -660,8 +660,8 @@ int swServer_start(swServer *serv)
     {
         ret = swServer_start_proxy(serv);
     }
-    SwooleGS->start = 0;
     swServer_free(serv);
+    SwooleGS->start = 0;
     return SW_OK;
 }
 


### PR DESCRIPTION
There is a condition on line 800:

```c
    if (SwooleGS->start > 0 && serv->onShutdown != NULL)
    {
        serv->onShutdown(serv);
    }
```

onShutdow will never be invoked