### PR TITLE
修复swoole_buffer中的Bugs并增加新的特性

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -601,6 +601,8 @@ void swString_print(swString *str);
 void swString_free(swString *str);
 int swString_append(swString *str, swString *append_str);
 int swString_append_ptr(swString *str, char *append_str, int length);
+int swString_write(swString *str, off_t offset, swString *write_str);
+int swString_write_ptr(swString *str, off_t offset, char *write_str, int length);
 int swString_extend(swString *str, size_t new_size);
 char* swString_alloc(swString *str, size_t __size);
 

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -127,6 +127,48 @@ int swString_append_ptr(swString *str, char *append_str, int length)
     return SW_OK;
 }
 
+int swString_write(swString *str, off_t offset, swString *write_str)
+{
+    int new_length = offset + write_str->length;
+    if (new_length > str->size)
+    {
+        if (swString_extend(str, swoole_size_align(new_length * 2, sysconf(_SC_PAGESIZE))) < 0)
+        {
+            return SW_ERR;
+        }
+    }
+
+    memcpy(str->str + offset, write_str->str, write_str->length);
+
+    if (new_length > str->length)
+    {
+        str->length = new_length;
+    }
+
+    return SW_OK;
+}
+
+int swString_write_ptr(swString *str, off_t offset, char *write_str, int length)
+{
+    int new_length = offset + length;
+    if (new_length > str->size)
+    {
+        if (swString_extend(str, swoole_size_align(new_length * 2, sysconf(_SC_PAGESIZE))) < 0)
+        {
+            return SW_ERR;
+        }
+    }
+
+    memcpy(str->str + offset, write_str, length);
+
+    if (new_length > str->length)
+    {
+        str->length = new_length;
+    }
+
+    return SW_OK;
+}
+
 int swString_extend(swString *str, size_t new_size)
 {
     assert(new_size > str->size);

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -151,8 +151,9 @@ static PHP_METHOD(swoole_buffer, append)
         {
             zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("capacity"), buffer->size TSRMLS_CC);
         }
-        zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"), buffer->length TSRMLS_CC);
-        RETURN_LONG(buffer->length);
+        zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),
+                buffer->length - buffer->offset TSRMLS_CC);
+        RETURN_LONG(buffer->length - buffer->offset);
     }
     else
     {

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -138,7 +138,7 @@ static PHP_METHOD(swoole_buffer, append)
     }
     swString *buffer = swoole_get_object(getThis());
 
-    if ((str.length + buffer->length) > SW_STRING_BUFFER_MAXLEN)
+    if ((str.length + buffer->length) > buffer->size && (str.length + buffer->length) > SW_STRING_BUFFER_MAXLEN)
     {
         php_error_docref(NULL TSRMLS_CC, E_WARNING, "buffer size must not exceed %d", SW_STRING_BUFFER_MAXLEN);
         RETURN_FALSE;

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -110,6 +110,7 @@ static PHP_METHOD(swoole_buffer, __construct)
 
     swoole_set_object(getThis(), buffer);
     zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("capacity"), size TSRMLS_CC);
+    zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"), 0 TSRMLS_CC);
 }
 
 static PHP_METHOD(swoole_buffer, __destruct)

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -238,6 +238,12 @@ static PHP_METHOD(swoole_buffer, write)
 
     offset += buffer->offset;
 
+    if ((str.length + offset) > SW_STRING_BUFFER_MAXLEN)
+    {
+        php_error_docref(NULL TSRMLS_CC, E_WARNING, "buffer size must not exceed %d", SW_STRING_BUFFER_MAXLEN);
+        RETURN_FALSE;
+    }
+
     size_t size_old = buffer->size;
     if (swString_write(buffer, offset, &str) == SW_OK)
     {

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -163,17 +163,17 @@ static PHP_METHOD(swoole_buffer, substr)
 {
     long offset;
     long length = -1;
-    zend_bool seek = 0;
+    zend_bool remove = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|lb", &offset, &length, &seek) == FAILURE)
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|lb", &offset, &length, &remove) == FAILURE)
     {
         RETURN_FALSE;
     }
     swString *buffer = swoole_get_object(getThis());
 
-    if (seek && !(offset == 0 && length < buffer->length))
+    if (remove && !(offset == 0 && length < buffer->length))
     {
-        seek = 0;
+        remove = 0;
     }
     if (offset < 0)
     {
@@ -189,7 +189,7 @@ static PHP_METHOD(swoole_buffer, substr)
         php_error_docref(NULL TSRMLS_CC, E_WARNING, "offset(%ld,%ld) out of bounds.", offset, length);
         RETURN_FALSE;
     }
-    if (seek)
+    if (remove)
     {
         buffer->offset += length;
         zend_update_property_long(swoole_buffer_class_entry_ptr, getThis(), ZEND_STRL("length"),

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -214,6 +214,8 @@
 
 #define SW_STRING_BUFFER_MAXLEN          (1024*1024*128)
 #define SW_STRING_BUFFER_DEFAULT         128
+#define SW_STRING_BUFFER_GARBAGE_MIN     (1024*64)
+#define SW_STRING_BUFFER_GARBAGE_RATIO   4
 
 #define SW_SIGNO_MAX                     128
 


### PR DESCRIPTION
1. 修复swoole_buffer中多个关于缓冲长度计算的问题。
2. 让swoole_buffer::write()能够自动扩容。
3. 在某些情况下，swoole_buffer的自动扩容能够申请超过SW_STRING_BUFFER_MAXLEN，也就是128M的内存，现在这些内存也能用于缓冲数据了。
4. 增加swoole_buffer::recycle()方法，可以释放被swoole_buffer::substr()定义为截断的垃圾数据，使得使用者能够在缓冲区内有数据的情况下进行无用内容的清理，让swoole_buffer更容易长期处理数据缓冲。
5. swoole_buffer::substr()在一定条件下能够自动触发回收机制。