### PR TITLE
Fix possible file descriptor leak

### DIFF
--- a/src/core/base.c
+++ b/src/core/base.c
@@ -560,6 +560,7 @@ swString* swoole_file_get_contents(char *filename)
     swString *content = swString_new(filesize);
     if (!content)
     {
+        close(fd);
         return NULL;
     }
 


### PR DESCRIPTION
swoole_file_get_contents may return without closing an open file descriptor.