### PR TITLE
support bind port 0 to let os choose avaiable port

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -1201,7 +1201,7 @@ static sw_inline uint64_t swoole_ntoh64(uint64_t net)
 }
 
 int swSocket_create(int type);
-int swSocket_bind(int sock, int type, char *host, int port);
+int swSocket_bind(int sock, int type, char *host, int *port);
 int swSocket_wait(int fd, int timeout_ms, int events);
 int swSocket_wait_multi(int *list_of_fd, int n_fd, int timeout_ms, int events);
 void swSocket_clean(int fd);

--- a/src/network/ReactorProcess.c
+++ b/src/network/ReactorProcess.c
@@ -546,7 +546,7 @@ static int swReactorProcess_reuse_port(swListenPort *ls)
         return SW_ERR;
     }
     //bind address and port
-    if (swSocket_bind(sock, ls->type, ls->host, ls->port) < 0)
+    if (swSocket_bind(sock, ls->type, ls->host, &ls->port) < 0)
     {
         return SW_ERR;
     }

--- a/src/network/Server.c
+++ b/src/network/Server.c
@@ -1090,7 +1090,7 @@ swListenPort* swServer_add_port(swServer *serv, int type, char *host, int port)
         swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_TOO_MANY_LISTEN_PORT, "allows up to %d ports to listen", SW_MAX_LISTEN_PORT);
         return NULL;
     }
-    if (!(type == SW_SOCK_UNIX_DGRAM || type == SW_SOCK_UNIX_STREAM) && (port < 1 || port > 65535))
+    if (!(type == SW_SOCK_UNIX_DGRAM || type == SW_SOCK_UNIX_STREAM) && (port < 0 || port > 65535))
     {
         swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_INVALID_LISTEN_PORT, "invalid port [%d]", port);
         return NULL;
@@ -1135,7 +1135,7 @@ swListenPort* swServer_add_port(swServer *serv, int type, char *host, int port)
         return NULL;
     }
     //bind address and port
-    if (swSocket_bind(sock, ls->type, ls->host, ls->port) < 0)
+    if (swSocket_bind(sock, ls->type, ls->host, &ls->port) < 0)
     {
         return NULL;
     }

--- a/swoole.c
+++ b/swoole.c
@@ -36,7 +36,7 @@ extern sapi_module_struct sapi_module;
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_server__construct, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_server__construct, 0, 0, 1)
     ZEND_ARG_INFO(0, host)
     ZEND_ARG_INFO(0, port)
     ZEND_ARG_INFO(0, mode)

--- a/swoole_client.c
+++ b/swoole_client.c
@@ -543,7 +543,7 @@ void php_swoole_client_check_setting(swClient *cli, zval *zset TSRMLS_DC)
     }
     if (bind_address)
     {
-        swSocket_bind(cli->socket->fd, cli->type, bind_address, bind_port);
+        swSocket_bind(cli->socket->fd, cli->type, bind_address, &bind_port);
     }
     /**
      * TCP_NODELAY

--- a/swoole_server.c
+++ b/swoole_server.c
@@ -1246,7 +1246,7 @@ PHP_METHOD(swoole_server, __construct)
     zend_size_t host_len = 0;
     char *serv_host;
     long sock_type = SW_SOCK_TCP;
-    long serv_port;
+    long serv_port = 0;
     long serv_mode = SW_MODE_PROCESS;
 
     //only cli env
@@ -1271,7 +1271,7 @@ PHP_METHOD(swoole_server, __construct)
     swServer *serv = sw_malloc(sizeof (swServer));
     swServer_init(serv);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|ll", &serv_host, &host_len, &serv_port, &serv_mode, &sock_type) == FAILURE)
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|lll", &serv_host, &host_len, &serv_port, &serv_mode, &sock_type) == FAILURE)
     {
         swoole_php_fatal_error(E_ERROR, "invalid parameters.");
         return;
@@ -1313,7 +1313,7 @@ PHP_METHOD(swoole_server, __construct)
 #endif
 
     zend_update_property_stringl(swoole_server_class_entry_ptr, server_object, ZEND_STRL("host"), serv_host, host_len TSRMLS_CC);
-    zend_update_property_long(swoole_server_class_entry_ptr, server_object, ZEND_STRL("port"), serv_port TSRMLS_CC);
+    zend_update_property_long(swoole_server_class_entry_ptr, server_object, ZEND_STRL("port"), (long) port->port TSRMLS_CC);
     zend_update_property_long(swoole_server_class_entry_ptr, server_object, ZEND_STRL("mode"), serv->factory_mode TSRMLS_CC);
     zend_update_property_long(swoole_server_class_entry_ptr, server_object, ZEND_STRL("type"), sock_type TSRMLS_CC);
     swoole_set_object(server_object, serv);
@@ -1523,7 +1523,7 @@ PHP_METHOD(swoole_server, set)
     if (php_swoole_array_get_value(vht, "cpu_affinity_ignore", v))
     {
         int ignore_num = zend_hash_num_elements(Z_ARRVAL_P(v));
-        if (ignore_num >= SW_CPU_NUM) 
+        if (ignore_num >= SW_CPU_NUM)
         {
             swoole_php_fatal_error(E_ERROR, "cpu_affinity_ignore num must be less than cpu num (%d)", SW_CPU_NUM);
             RETURN_FALSE;
@@ -2308,7 +2308,7 @@ PHP_METHOD(swoole_server, taskwait)
 
     sw_atomic_fetch_add(&SwooleStats->tasking_num, 1);
     if (swProcessPool_dispatch_blocking(&SwooleGS->task_workers, &buf, (int*) &dst_worker_id) >= 0)
-    {      
+    {
         task_notify_pipe->timeout = timeout;
         int ret = task_notify_pipe->read(task_notify_pipe, &notify, sizeof(notify));
         if (ret > 0)


### PR DESCRIPTION
As micro service is becoming more and more popular, service's port and address has been registered into some registery like zookeeper, etcd. There is no strong need to listen on certain port. The more service we have, the more port we should manage.

This PR promotes to enable swoole to choose listen port by OS. What we should do is like this,
```php
<?php
$serv = new Swoole\Http\Server("127.0.0.1"); // port is optional now

$serv->on('Request', function($request, $response) {
    $response->end("<h1>Hello Swoole!</h1>");
});

$serv->on('managerStart', function (Swoole\Server $s) {
    var_dump($s->host);
    var_dump($s->port);
    // send host:port to etcd, zookeeper ...
});

$serv->start();
```