### PR TITLE
Fix shmat() error handling in swShareMemory_sysv_create()

### DIFF
--- a/src/memory/ShareMemory.c
+++ b/src/memory/ShareMemory.c
@@ -157,7 +157,7 @@ void *swShareMemory_sysv_create(swShareMemory *object, int size, int key)
         swWarn("shmget() failed. Error: %s[%d]", strerror(errno), errno);
         return NULL;
     }
-    if ((mem = shmat(shmid, NULL, 0)) < 0)
+    if ((mem = shmat(shmid, NULL, 0)) == (void *) -1)
     {
         swWarn("shmat() failed. Error: %s[%d]", strerror(errno), errno);
         return NULL;


### PR DESCRIPTION
"on error, (void *) -1 is returned" -- man 2 shmat

Reference: Coverity CID #1397852