### PR TITLE
Fix fdopen() error handling in multipart_body_on_header_complete()

### DIFF
--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -705,7 +705,7 @@ static int multipart_body_on_header_complete(multipart_parser* p)
     int tmpfile = swoole_tmpfile(file_path);
 
     FILE *fp = fdopen(tmpfile, "wb+");
-    if (fp < 0)
+    if (fp == NULL)
     {
         add_assoc_long(multipart_header, "error", HTTP_UPLOAD_ERR_NO_TMP_DIR);
         swWarn("fopen(%s) failed. Error %s[%d]", file_path, strerror(errno), errno);


### PR DESCRIPTION
Reference: Coverity CID #1397851