### PR TITLE
Disallow swoole_server->finish be called in onPipeMessage callback.

### DIFF
--- a/src/network/ReactorThread.c
+++ b/src/network/ReactorThread.c
@@ -194,7 +194,6 @@ static int swReactorThread_onPackage(swReactor *reactor, swEvent *event)
 
         task.target_worker_id = -1;
         uint32_t header_size = sizeof(pkt);
-		task.data.info.fd = task.data.info.fd & 0x7FFFFFF; //make sure fd is positive.
 
         //dgram header
         memcpy(task.data.data, &pkt, sizeof(pkt));

--- a/src/network/ReactorThread.c
+++ b/src/network/ReactorThread.c
@@ -194,6 +194,7 @@ static int swReactorThread_onPackage(swReactor *reactor, swEvent *event)
 
         task.target_worker_id = -1;
         uint32_t header_size = sizeof(pkt);
+		task.data.info.fd = task.data.info.fd & 0x7FFFFFF; //make sure fd is positive.
 
         //dgram header
         memcpy(task.data.data, &pkt, sizeof(pkt));

--- a/src/network/TaskWorker.c
+++ b/src/network/TaskWorker.c
@@ -152,6 +152,11 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags)
         swWarn("cannot use task/finish, because no set serv->task_worker_num.");
         return SW_ERR;
     }
+	if (current_task->info.type == SW_EVENT_PIPE_MESSAGE)
+	{
+		swWarn("task/finish is not supported in onPipeMessage callback.");
+		return SW_ERR;
+	}
 
     uint16_t source_worker_id = current_task->info.from_id;
     swWorker *worker = swServer_get_worker(serv, source_worker_id);


### PR DESCRIPTION
If swoole_server->finish is called in onPipeMessage callback, and the source process is a task worker, segfault may occurred.
see issue #1198