### PR TITLE
Include POSIX style poll.h instead of sys/poll.h

### DIFF
--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -17,7 +17,7 @@
 #include "swoole.h"
 
 #include <sys/stat.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length, double timeout)
 {

--- a/src/reactor/ReactorPoll.c
+++ b/src/reactor/ReactorPoll.c
@@ -15,7 +15,7 @@
 */
 
 #include "swoole.h"
-#include <sys/poll.h>
+#include <poll.h>
 
 static int swReactorPoll_add(swReactor *reactor, int fd, int fdtype);
 static int swReactorPoll_set(swReactor *reactor, int fd, int fdtype);


### PR DESCRIPTION
Hello, this patch fixes the warning when compiling swoole on Alpine Linux and similar systems with musl libc:

```
In file included from /build/main/php7.2-swoole/src/swoole-1.9.15/src/core/socket.c:20:0:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
```

[POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html) has example of `poll.h` and I think it should work ok on most systems these days. Glibc has poll.h also as an option since few years ago.

Thank you for considering merging this or checking it out.