### PR TITLE
修复参数类型clock_id_t为clockid_t

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -80,7 +80,7 @@ typedef cpuset_t cpu_set_t;
 static double orwl_timebase = 0.0;
 static uint64_t orwl_timestart = 0;
 #ifndef HAVE_CLOCK_GETTIME
-int clock_gettime(clock_id_t which_clock, struct timespec *t);
+int clock_gettime(clockid_t which_clock, struct timespec *t);
 #endif
 #endif
 

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -1023,7 +1023,7 @@ void swoole_print_trace(void)
 
 #ifndef HAVE_CLOCK_GETTIME
 #ifdef __MACH__
-int clock_gettime(clock_id_t which_clock, struct timespec *t)
+int clock_gettime(clockid_t which_clock, struct timespec *t)
 {
     // be more careful in a multithreaded environement
     if (!orwl_timestart)


### PR DESCRIPTION
手册中
int clock_gettime(clockid_t clk_id, struct timespec *tp);

参见 https://linux.die.net/man/3/clock_gettime