### PR TITLE
Fix building with libressl.

### DIFF
--- a/src/protocol/SSL.c
+++ b/src/protocol/SSL.c
@@ -98,7 +98,7 @@ static const SSL_METHOD *swSSL_get_method(int method)
 
 void swSSL_init(void)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
 #else
     OPENSSL_config(NULL);


### PR DESCRIPTION
I try to build swoole-1.9.21 on FreeBSD with libressl, but could not find some constants.

here is the patch for libressl, please help to check, thanks.