### PR TITLE
fix  compile warning under the mac and php72

### DIFF
--- a/swoole_atomic.c
+++ b/swoole_atomic.c
@@ -156,7 +156,7 @@ void swoole_atomic_init(int module_number TSRMLS_DC)
 
 PHP_METHOD(swoole_atomic, __construct)
 {
-    long value = 0;
+    zend_long value = 0;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -184,7 +184,7 @@ PHP_METHOD(swoole_atomic, __construct)
 
 PHP_METHOD(swoole_atomic, add)
 {
-    long add_value = 1;
+    zend_long add_value = 1;
     sw_atomic_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -203,7 +203,7 @@ PHP_METHOD(swoole_atomic, add)
 
 PHP_METHOD(swoole_atomic, sub)
 {
-    long sub_value = 1;
+    zend_long sub_value = 1;
     sw_atomic_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -229,7 +229,7 @@ PHP_METHOD(swoole_atomic, get)
 PHP_METHOD(swoole_atomic, set)
 {
     sw_atomic_t *atomic = swoole_get_object(getThis());
-    long set_value;
+    zend_long set_value;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -246,7 +246,7 @@ PHP_METHOD(swoole_atomic, set)
 
 PHP_METHOD(swoole_atomic, cmpset)
 {
-    long cmp_value, set_value;
+    zend_long cmp_value, set_value;
     sw_atomic_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -302,7 +302,7 @@ PHP_METHOD(swoole_atomic, wait)
 
 PHP_METHOD(swoole_atomic, wakeup)
 {
-    long n = 1;
+    zend_long n = 1;
     sw_atomic_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -326,7 +326,7 @@ PHP_METHOD(swoole_atomic, wakeup)
 
 PHP_METHOD(swoole_atomic_long, __construct)
 {
-    long value = 0;
+    zend_long value = 0;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -354,7 +354,7 @@ PHP_METHOD(swoole_atomic_long, __construct)
 
 PHP_METHOD(swoole_atomic_long, add)
 {
-    long add_value = 1;
+    zend_long add_value = 1;
     sw_atomic_long_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -374,7 +374,7 @@ PHP_METHOD(swoole_atomic_long, add)
 
 PHP_METHOD(swoole_atomic_long, sub)
 {
-    long sub_value = 1;
+    zend_long sub_value = 1;
     sw_atomic_long_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP
@@ -401,7 +401,7 @@ PHP_METHOD(swoole_atomic_long, get)
 PHP_METHOD(swoole_atomic_long, set)
 {
     sw_atomic_long_t *atomic = swoole_get_object(getThis());
-    long set_value;
+    zend_long set_value;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -418,7 +418,7 @@ PHP_METHOD(swoole_atomic_long, set)
 
 PHP_METHOD(swoole_atomic_long, cmpset)
 {
-    long cmp_value, set_value;
+    zend_long cmp_value, set_value;
     sw_atomic_long_t *atomic = swoole_get_object(getThis());
 
 #ifdef FAST_ZPP

--- a/swoole_client.c
+++ b/swoole_client.c
@@ -1201,7 +1201,7 @@ static PHP_METHOD(swoole_client, set)
 
 static PHP_METHOD(swoole_client, connect)
 {
-    long port = 0, sock_flag = 0;
+    zend_long port = 0, sock_flag = 0;
     char *host = NULL;
     zend_size_t host_len;
     double timeout = SW_CLIENT_DEFAULT_TIMEOUT;
@@ -1353,7 +1353,7 @@ static PHP_METHOD(swoole_client, send)
 {
     char *data;
     zend_size_t data_len;
-    long flags = 0;
+    zend_long flags = 0;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -1489,8 +1489,8 @@ static PHP_METHOD(swoole_client, sendfile)
 
 static PHP_METHOD(swoole_client, recv)
 {
-    long buf_len = SW_PHP_CLIENT_BUFFER_SIZE;
-    long flags = 0;
+    zend_long buf_len = SW_PHP_CLIENT_BUFFER_SIZE;
+    zend_long flags = 0;
     int ret;
     char *buf = NULL;
 

--- a/swoole_coroutine_util.c
+++ b/swoole_coroutine_util.c
@@ -750,7 +750,7 @@ static void aio_onWriteCompleted(swAio_event *event)
 static PHP_METHOD(swoole_coroutine_util, fread)
 {
     zval *handle;
-    long length = 0;
+    zend_long length = 0;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(1, 2)
@@ -827,7 +827,7 @@ static PHP_METHOD(swoole_coroutine_util, fwrite)
     zval *handle;
     char *str;
     zend_size_t l_str;
-    long length = 0;
+    zend_long length = 0;
 
 #ifdef FAST_ZPP
     ZEND_PARSE_PARAMETERS_START(2, 3)

--- a/swoole_server.c
+++ b/swoole_server.c
@@ -2453,7 +2453,7 @@ PHP_METHOD(swoole_server, send)
 
     zval *zfd;
     zval *zdata;
-    long server_socket = -1;
+    zend_long server_socket = -1;
 
     if (SwooleGS->start == 0)
     {
@@ -2560,8 +2560,8 @@ PHP_METHOD(swoole_server, sendto)
     char *data;
     zend_size_t len, ip_len;
 
-    long port;
-    long server_socket = -1;
+    zend_long port;
+    zend_long server_socket = -1;
     zend_bool ipv6 = 0;
 
     if (SwooleGS->start == 0)
@@ -2661,7 +2661,7 @@ PHP_METHOD(swoole_server, close)
 {
     zval *zobject = getThis();
     zend_bool reset = SW_FALSE;
-    long fd;
+    zend_long fd;
 
     if (SwooleGS->start == 0)
     {
@@ -3239,7 +3239,7 @@ PHP_METHOD(swoole_server, task)
     zval *data;
     zval *callback = NULL;
 
-    long dst_worker_id = -1;
+    zend_long dst_worker_id = -1;
 
     if (SwooleGS->start == 0)
     {
@@ -3462,7 +3462,7 @@ PHP_METHOD(swoole_server, connection_info)
 
     swServer *serv = swoole_get_object(zobject);
 
-    long fd = 0;
+    zend_long fd = 0;
     zend_bool ipv6_udp = 0;
 
     //ipv6 udp
@@ -3709,7 +3709,7 @@ PHP_METHOD(swoole_server, exist)
 {
     zval *zobject = getThis();
 
-    long fd;
+    zend_long fd;
 
     if (SwooleGS->start == 0)
     {


### PR DESCRIPTION
the warning like this:

```
/data/swoole-src/swoole_server.c:3722:9: warning: incompatible pointer types passing 'long *' to parameter of type 'zend_long *' (aka 'long long *') [-Wincompatible-pointer-types]
        Z_PARAM_LONG(fd)
        ^~~~~~~~~~~~~~~~
/usr/local/Cellar/php72/7.2.0_11/include/php/Zend/zend_API.h:943:2: note: expanded from macro 'Z_PARAM_LONG'
        Z_PARAM_LONG_EX(dest, _dummy, 0, 0)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/php72/7.2.0_11/include/php/Zend/zend_API.h:940:2: note: expanded from macro 'Z_PARAM_LONG_EX'
        Z_PARAM_LONG_EX2(dest, is_null, check_null, separate, separate)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/php72/7.2.0_11/include/php/Zend/zend_API.h:933:45: note: expanded from macro 'Z_PARAM_LONG_EX2'
                if (UNEXPECTED(!zend_parse_arg_long(_arg, &dest, &is_null, check_null, 0))) { \
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/php72/7.2.0_11/include/php/Zend/zend_portability.h:312:52: note: expanded from macro 'UNEXPECTED'
# define UNEXPECTED(condition) __builtin_expect(!!(condition), 0)
                                                   ^~~~~~~~~
/usr/local/Cellar/php72/7.2.0_11/include/php/Zend/zend_API.h:1141:73: note: passing argument to parameter 'dest' here
static zend_always_inline int zend_parse_arg_long(zval *arg, zend_long *dest, zend_bool *is_null, int check_null, int cap) 
```