### PR TITLE
add the strict_type  param

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -682,13 +682,12 @@ static int mysql_decode_row(mysql_client *client, char *buf, int packet_len)
     ulong_t len;
     char nul;
 
-#ifdef SW_MYSQL_STRICT_TYPE
     mysql_row row;
     char value_buffer[32];
     bzero(&row, sizeof(row));
     char *error;
-    char mem;
-#endif
+    //unused
+    //char mem;
 
     zval *result_array = client->response.result_array;
     zval *row_array = NULL;
@@ -756,61 +755,70 @@ static int mysql_decode_row(mysql_client *client, char *buf, int packet_len)
         case SW_MYSQL_TYPE_SHORT:
         case SW_MYSQL_TYPE_INT24:
         case SW_MYSQL_TYPE_LONG:
-#ifdef SW_MYSQL_STRICT_TYPE
-            memcpy(value_buffer, buf + read_n, len);
-            value_buffer[len] = 0;
-            row.sint = strtol(value_buffer, &error, 10);
-            if (*error != '\0')
+            if(client->connector.strict_type)
             {
-                return -SW_MYSQL_ERR_CONVLONG;
+                memcpy(value_buffer, buf + read_n, len);
+                value_buffer[len] = 0;
+                row.sint = strtol(value_buffer, &error, 10);
+                if (*error != '\0')
+                {
+                    return -SW_MYSQL_ERR_CONVLONG;
+                }
+                add_assoc_long(row_array, client->response.columns[i].name, row.sint);
             }
-            add_assoc_long(row_array, client->response.columns[i].name, row.sint);
-#else
-            sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
-#endif
+            else
+            {
+                sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
+
+            }
             break;
         case SW_MYSQL_TYPE_LONGLONG:
-#ifdef SW_MYSQL_STRICT_TYPE
-            memcpy(value_buffer, buf + read_n, len);
-            value_buffer[len] = 0;
-            row.sbigint = strtoll(value_buffer, &error, 10);
-            if (*error != '\0')
-            {
-                return -SW_MYSQL_ERR_CONVLONG;
+            if(client->connector.strict_type) {
+                memcpy(value_buffer, buf + read_n, len);
+                value_buffer[len] = 0;
+                row.sbigint = strtoll(value_buffer, &error, 10);
+                if (*error != '\0') {
+                    return -SW_MYSQL_ERR_CONVLONG;
+                }
+                add_assoc_long(row_array, client->response.columns[i].name, row.sbigint);
             }
-            add_assoc_long(row_array, client->response.columns[i].name, row.sbigint);
-#else
-            sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
-#endif
+            else
+            {
+                sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
+
+            }
             break;
         case SW_MYSQL_TYPE_FLOAT:
-#ifdef SW_MYSQL_STRICT_TYPE
-            memcpy(value_buffer, buf + read_n, len);
-            value_buffer[len] = 0;
-            row.mfloat = strtof(value_buffer, &error);
-            if (*error != '\0')
-            {
-                return -SW_MYSQL_ERR_CONVFLOAT;
+            if(client->connector.strict_type) {
+                memcpy(value_buffer, buf + read_n, len);
+                value_buffer[len] = 0;
+                row.mfloat = strtof(value_buffer, &error);
+                if (*error != '\0') {
+                    return -SW_MYSQL_ERR_CONVFLOAT;
+                }
+                add_assoc_double(row_array, client->response.columns[i].name, row.mfloat);
             }
-            add_assoc_double(row_array, client->response.columns[i].name, row.mfloat);
-#else
-            sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
-#endif
+            else
+            {
+                sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
+            }
             break;
 
         case SW_MYSQL_TYPE_DOUBLE:
-#ifdef SW_MYSQL_STRICT_TYPE
-            memcpy(value_buffer, buf + read_n, len);
-            value_buffer[len] = 0;
-            row.mdouble = strtod(value_buffer, &error);
-            if (*error != '\0')
-            {
-                return -SW_MYSQL_ERR_CONVDOUBLE;
+            if(client->connector.strict_type) {
+                memcpy(value_buffer, buf + read_n, len);
+                value_buffer[len] = 0;
+                row.mdouble = strtod(value_buffer, &error);
+                if (*error != '\0') {
+                    return -SW_MYSQL_ERR_CONVDOUBLE;
+                }
+                add_assoc_double(row_array, client->response.columns[i].name, row.mdouble);
             }
-            add_assoc_double(row_array, client->response.columns[i].name, row.mdouble);
-#else
-            sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
-#endif
+            else
+            {
+                sw_add_assoc_stringl(row_array, client->response.columns[i].name, buf + read_n, len, 1);
+
+            }
             break;
 
         default:
@@ -1824,6 +1832,22 @@ static PHP_METHOD(swoole_mysql, connect)
     else
     {
         connector->character_set = 0;
+    }
+
+    if (php_swoole_array_get_value(_ht, "strict_type", value))
+    {
+#if PHP_MAJOR_VERSION < 7
+        if(Z_TYPE_P(value) == IS_BOOL && Z_BVAL_P(value) == 1)
+#else
+        if(Z_TYPE_P(value) == IS_TRUE)
+#endif
+        {
+            connector->strict_type = 1;
+        }else{
+            connector->strict_type = 0;
+        }
+    } else{
+        connector->strict_type = 0;
     }
 
     swClient *cli = emalloc(sizeof(swClient));

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -176,6 +176,7 @@ typedef struct
     char *user;
     char *password;
     char *database;
+    zend_bool strict_type;
 
     zend_size_t host_len;
     zend_size_t user_len;

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -488,6 +488,22 @@ static PHP_METHOD(swoole_mysql_coro, connect)
         connector->character_set = SW_MYSQL_DEFAULT_CHARSET;
     }
 
+    if (php_swoole_array_get_value(_ht, "strict_type", value))
+    {
+#if PHP_MAJOR_VERSION < 7
+        if(Z_TYPE_P(value) == IS_BOOL && Z_BVAL_P(value) == 1)
+#else
+        if(Z_TYPE_P(value) == IS_TRUE)
+#endif
+        {
+            connector->strict_type = 1;
+        }else{
+            connector->strict_type = 0;
+        }
+    } else{
+        connector->strict_type = 0;
+    }
+
     swClient *cli = emalloc(sizeof(swClient));
     int type = SW_SOCK_TCP;
 


### PR DESCRIPTION
add the strict_type param

```
$swoole_mysql = new Swoole\Coroutine\MySQL();
$swoole_mysql->connect([
    'host' => '127.0.0.1',
    'port' => 3306,
    'user' => 'user',
    'password' => 'pass',
    'database' => 'test',
    'strict_type' => true
]);
$res = $swoole_mysql->query('select * from product limit 1');
var_dump($res);

```
the var_dump result:

```
array(1) {
  [0]=>
  array(18) {
    ["id"]=>
    int(7080)
    ["name"]=>
    string(10) "8424西瓜"
    ["cid1"]=>
    int(65)
    ["category_id"]=>
    int(66)
    ["weight"]=>
    int(0)
    ["min_price"]=>
    int(300)
    ["avg_price"]=>
    float(39.15)
    ["max_price"]=>
    int(300)
    ["primary_unit"]=>
    int(7)
    ["secondary_unit"]=>
    int(1)
    ["primary_property"]=>
    int(0)
    ["pinyin_s"]=>
    string(6) "8424xg"
    ["pinyin_a"]=>
    string(9) "8424xigua"
    ["is_formal"]=>
    int(1)
    ["status"]=>
    int(1)
    ["upid"]=>
    int(8426)
    ["created_time"]=>
    int(1403853025)
    ["updated_time"]=>
    int(1432876713)
  }
}
```
pass test at the mac 、ubuntu php71、php72  environment  