### PR TITLE
perfect mysql_decode_row_prepare function，now  it decode null value right.

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -921,6 +921,13 @@ static int mysql_decode_row_prepare(mysql_client *client, char *buf, int packet_
 
     for (i = 0; i < client->response.num_column; i++)
     {
+        /* to check Null-Bitmap @see https://dev.mysql.com/doc/internals/en/null-bitmap.html */
+        if( ( (buf - null_count + 1)[((i+2)/8)] & (0x01 << ((i+2)%8)) ) != 0 ){
+            swTraceLog(SW_TRACE_MYSQL_CLIENT, "value: %s is null ,flag2", client->response.columns[i].name);
+            add_assoc_null(row_array, client->response.columns[i].name);
+            continue;
+        }
+
         int type = client->response.columns[i].type;
         swTraceLog(SW_TRACE_MYSQL_CLIENT, "value: name=%s, type=%d", client->response.columns[i].name, type);
         switch (type)


### PR DESCRIPTION
The binary protocol sends NULL values as bits inside a bitmap instead of a full byte (such as MYSQL_TYPE_NULL or byte of length is 251),
when we use COM_STMT_EXECUTE command.

@see https://dev.mysql.com/doc/internals/en/binary-protocol-value.html
@see  https://dev.mysql.com/doc/internals/en/null-bitmap.html