### PR TITLE
fix swoole_sync_dns_lookup error

### DIFF
--- a/src/os/base.c
+++ b/src/os/base.c
@@ -268,7 +268,7 @@ static int swAioBase_thread_onTask(swThreadPool *pool, void *task, int task_len)
         }
         else
         {
-            if (inet_ntop(event->flags, event->flags == AF_INET6 ? (void *) &addr_v6 : (void *) &addr_v4, event->buf,
+            if (inet_ntop(event->flags == AF_INET6 ? AF_INET6 : AF_INET, event->flags == AF_INET6 ? (void *) &addr_v6 : (void *) &addr_v4, event->buf,
                     event->nbytes) == NULL)
             {
                 ret = -1;


### PR DESCRIPTION
 the error information:
```
PHP Warning:  swoole_event_wait(): Aio Error: Unknown error: 705[705] in Unknown on line 0

Warning: swoole_event_wait(): Aio Error: Unknown error: 705[705] in Unknown on line 0
```

reason:

The first param of this function is   AF_INET (2) or AF_INET6 (30), but the event->flags == 0 , so the  error happend.