### PR TITLE
Fix segment fault error if passing in variables can't be serialized t…

### DIFF
--- a/swoole_server.c
+++ b/swoole_server.c
@@ -198,6 +198,10 @@ int php_swoole_task_pack(swEventData *task, zval *data TSRMLS_DC)
             task_data_str = serialized_data.c;
             task_data_len = serialized_data.len;
 #else
+            if(!serialized_data.s)
+            {
+                return -1;
+            }
             task_data_str = serialized_data.s->val;
             task_data_len = serialized_data.s->len;
 #endif


### PR DESCRIPTION
Displaying user friendly Error messages and Stack trace if passing the variables can't be serialized to Swoole\Server->task(), for example Object(Swoole\Http\Request).