### PR TITLE
修复自定义进程获取workerId编号时，均为0问题

### DIFF
--- a/swoole.c
+++ b/swoole.c
@@ -932,7 +932,7 @@ PHP_MINIT_FUNCTION(swoole)
     zend_declare_property_null(swoole_server_class_entry_ptr, ZEND_STRL("ports"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_long(swoole_server_class_entry_ptr, ZEND_STRL("master_pid"), 0, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_long(swoole_server_class_entry_ptr, ZEND_STRL("manager_pid"), 0, ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_long(swoole_server_class_entry_ptr, ZEND_STRL("worker_id"), 0, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_long(swoole_server_class_entry_ptr, ZEND_STRL("worker_id"), -1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_bool(swoole_server_class_entry_ptr, ZEND_STRL("taskworker"), 0, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_long(swoole_server_class_entry_ptr, ZEND_STRL("worker_pid"), 0, ZEND_ACC_PUBLIC TSRMLS_CC);
 


### PR DESCRIPTION
修复自定义进程获取workerId编号时，均为0，而worker的起始id为0，导致用户无法在代码中区分是worker/task进程还是自定义process。该处使用场景如：在框架中封装了async task投递方法，在方法中，为了可以在process中调用异步方法，就需要获取当前进程号判断是否为worker或者task worker ，如果不是则通过sendmessage方法发送给主进程或者是task worker，进而需要判断场景。
测试代码：
$http = new swoole_http_server("127.0.0.1", 9501);
$process = new swoole_process(function ()use($http){
        var_dump('process id is '.$http->worker_id);
});
$http->addProcess($process);
$http->on("workerstart", function ($server,$workerId) {
       var_dump('workerid is'.$workerId);
});
$http->on("request", function ($request, $response) {
        $response->header("Content-Type", "text/plain");
    $response->end("Hello World\n");
});
$http->start();