### PR TITLE
CodeAi fixes: 1 Null Deref, 2 Dead Code, 2 Uninitialized Variable

### DIFF
--- a/src/network/DNS.c
+++ b/src/network/DNS.c
@@ -132,7 +132,7 @@ static int swDNSResolver_onReceive(swReactor *reactor, swEvent *event)
     RR_FLAGS *rrflags = NULL;
 
     char packet[SW_CLIENT_BUFFER_SIZE];
-    uchar rdata[10][254];
+    uchar rdata[10][254] = {0};
     uint32_t type[10];
 
     char *temp;

--- a/src/network/ProcessPool.c
+++ b/src/network/ProcessPool.c
@@ -489,6 +489,7 @@ int swProcessPool_wait(swProcessPool *pool)
     int reload_worker_i = 0;
     int ret;
     int status;
+    status = 0;
 
     swWorker *reload_workers;
     reload_workers = sw_calloc(pool->worker_num, sizeof(swWorker));

--- a/src/network/Worker.c
+++ b/src/network/Worker.c
@@ -311,7 +311,7 @@ int swWorker_onTask(swFactory *factory, swEventData *task)
             worker->request_count++;
             sw_atomic_fetch_add(&SwooleStats->request_count, 1);
         }
-        if (task->info.type == SW_EVENT_PACKAGE_END)
+        if (package && (task->info.type == SW_EVENT_PACKAGE_END))
         {
             package->length = 0;
         }

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1443,7 +1443,6 @@ static int mysql_read_columns(mysql_client *client)
     }
 
     buffer += 9;
-    n_buf -= 9;
 
     if (client->cmd != SW_MYSQL_COM_STMT_PREPARE)
     {

--- a/thirdparty/php_http_parser.c
+++ b/thirdparty/php_http_parser.c
@@ -1028,7 +1028,6 @@ size_t php_http_parser_execute (php_http_parser *parser,
         if (ch == LF) {
           /* they might be just sending \n instead of \r\n so this would be
            * the second \n to denote the end of headers*/
-          state = s_headers_almost_done;
           goto headers_almost_done;
         }
 


### PR DESCRIPTION
CodeAI (www.mycode.ai) found 40 defects and fixed 37 in Swoole.  It wants to merge commits fixing 5 of these issues- 1 Null Pointer Dereference, 2 Dead Code, and 2 Unitialized Variables.  A screenshot of the results as well as the Dockerfile used to build and run your project in CodeAI can be found here- https://drive.google.com/drive/folders/1tZCN_B50eXP70DDUKwB44yLpq8QL-1KS?usp=sharing.