### PR TITLE
HTTP2 do_response时发送WINDOW_UPATE帧

### DIFF
--- a/include/http2.h
+++ b/include/http2.h
@@ -119,6 +119,14 @@ static sw_inline uint32_t swHttp2_get_length(char *buf)
     return (((uint8_t) buf[0]) << 16) + (((uint8_t) buf[1]) << 8) + (uint8_t) buf[2];
 }
 
+static sw_inline uint32_t swHttp2_get_increment_size(char *buf)
+{
+    return (((uint8_t) buf[1 + SW_HTTP2_FRAME_HEADER_SIZE]) << 16)      \
+            + (((uint8_t) buf[2 + SW_HTTP2_FRAME_HEADER_SIZE]) << 8)    \
+            + (uint8_t) buf[3 + SW_HTTP2_FRAME_HEADER_SIZE];
+}
+
+
 int swHttp2_get_frame_length(swProtocol *protocol, swConnection *conn, char *buf, uint32_t length);
 int swHttp2_send_setting_frame(swProtocol *protocol, swConnection *conn);
 int swHttp2_parse_frame(swProtocol *protocol, swConnection *conn, char *data, uint32_t length);

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -259,6 +259,7 @@
 #define SW_HTTP2_MAX_CONCURRENT_STREAMS  128
 #define SW_HTTP2_MAX_FRAME_SIZE          ((1u << 24) - 1)
 #define SW_HTTP2_MAX_WINDOW              ((1u << 31) - 1)
+#define SW_HTTP2_DEFAULT_WINDOW          65535
 
 #define SW_HTTP_CLIENT_USERAGENT         "swoole-http-client"
 #define SW_HTTP_CLIENT_BOUNDARY_PREKEY   "----SwooleBoundary"

--- a/swoole_http.h
+++ b/swoole_http.h
@@ -134,10 +134,12 @@ typedef struct _swoole_http_client
     uint32_t http2 :1;
 
 #ifdef SW_USE_HTTP2
+    uint32_t init :1;
     swHashMap *streams;
     nghttp2_hd_inflater *deflater;
     nghttp2_hd_inflater *inflater;
     uint32_t window_size;
+    uint32_t remote_window_size;
 #endif
 
 } swoole_http_client;

--- a/swoole_http_v2_server.c
+++ b/swoole_http_v2_server.c
@@ -344,7 +344,6 @@ int swoole_http2_do_response(http_context *ctx, swString *body)
     if (body->length > 0)
     {
         client->window_size -= body->length;    // TODO:flow control?
-        swTrace("-----------client->window_size=%u---------", client->window_size);
     }
     if (client->streams)
     {
@@ -520,8 +519,8 @@ int swoole_http2_onFrame(swoole_http_client *client, swEventData *req)
     if (!client->init)
     {
         client->window_size = SW_HTTP2_DEFAULT_WINDOW;
-    	client->remote_window_size = SW_HTTP2_DEFAULT_WINDOW;
-    	client->init = 1;
+        client->remote_window_size = SW_HTTP2_DEFAULT_WINDOW;
+        client->init = 1;
     }
 
     int fd = req->info.fd;
@@ -653,8 +652,7 @@ int swoole_http2_onFrame(swoole_http_client *client, swEventData *req)
     }
     else if (type == SW_HTTP2_TYPE_WINDOW_UPDATE)
     {
-        uint32_t increment_size = swHttp2_get_increment_size(buf);
-        client->window_size += increment_size;
+        client->window_size += swHttp2_get_increment_size(buf);
     }
     sw_zval_ptr_dtor(&zdata);
     return SW_OK;


### PR DESCRIPTION
HTTP2 do_response时发送WINDOW_UPATE帧，避免客户端因为remote_window太小而无法发送新的DATA帧