### PR TITLE
setDefer has 0 required args

### DIFF
--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -87,7 +87,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_setData, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_setDefer, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_setDefer, 0, 0, 0)
     ZEND_ARG_INFO(0, defer)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
According to [document](https://wiki.swoole.com/wiki/page/607.html) and [implement](https://github.com/swoole/swoole-src/blob/0be121ed76617f891e2710b82d30d3a3d5d8611e/swoole_http_client_coro.c#L1374-L1377), 

`Swoole\Coroutine\Http\Client::setDefer` has 0 required arguments.