### PR TITLE
Some patches

### DIFF
--- a/examples/coroutine/form-data.php
+++ b/examples/coroutine/form-data.php
@@ -1,0 +1,12 @@
+<?php
+go(function () {
+    $cli = new Swoole\Coroutine\Http\Client('eu.httpbin.org', 80);
+    $cli->setHeaders([
+        'Host' => "eu.httpbin.org",
+        'Content-Type' => 'multipart/form-data' // Swoole will add random boundary automatically
+    ]);
+    $cli->set(['timeout' => -1]);
+    $cli->post('/post', ['foo' => 'bar']);
+    var_dump(json_decode($cli->body, true));
+    $cli->close();
+});

--- a/examples/coroutine/http_download.php
+++ b/examples/coroutine/http_download.php
@@ -1,0 +1,13 @@
+<?php
+go(function () {
+    $host = 'www.swoole.com';
+    $cli = new \Swoole\Coroutine\Http\Client($host, 443, true);
+    $cli->set(['timeout' => -1]);
+    $cli->setHeaders([
+        'Host' => $host,
+        "User-Agent" => 'Chrome/49.0.2587.3',
+        'Accept' => '*',
+        'Accept-Encoding' => 'gzip'
+    ]);
+    $cli->download('/static/files/swoole-logo.svg', __DIR__ . '/logo.svg');
+});

--- a/examples/coroutine/mysql_execute_empty.php
+++ b/examples/coroutine/mysql_execute_empty.php
@@ -1,0 +1,14 @@
+<?php
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host'     => '127.0.0.1',
+        'user'     => 'root',
+        'password' => 'root',
+        'database' => 'test'
+    ];
+    $db->connect($server);
+    $stmt = $db->prepare('SELECT * FROM `userinfo`');
+    $ret = $stmt->execute();
+    var_dump($ret);
+});

--- a/examples/coroutine/mysql_statement_destruct.php
+++ b/examples/coroutine/mysql_statement_destruct.php
@@ -1,0 +1,20 @@
+<?php
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => '127.0.0.1',
+        'user' => 'root',
+        'password' => 'root',
+        'database' => 'test'
+    ];
+    $db->connect($server);
+    $stmt1 = $db->prepare('SELECT * FROM `userinfo`');
+    $stmt2 = $db->prepare('SELECT * FROM `userinfo` WHERE id=?');
+    $stmt3 = $db->prepare('SELECT `id` FROM `userinfo`');
+    $prepared_num = ($db->query('show status like \'Prepared_stmt_count\''))[0]['Value'];
+    echo "prepared_num: $prepared_num\n"; // 3
+    $stmt1 = null;
+    unset($stmt2);
+    $prepared_num = ($db->query('show status like \'Prepared_stmt_count\''))[0]['Value'];
+    echo "prepared_num: $prepared_num\n"; // 1
+});

--- a/src/protocol/MimeTypes.c
+++ b/src/protocol/MimeTypes.c
@@ -44,7 +44,7 @@ char* swoole_get_mimetype(char *file)
     }
     else if (strcasecmp(dot, ".jpeg") == 0 || strcasecmp(dot, ".jpg") == 0)
     {
-        return "image/jpeg ";
+        return "image/jpeg";
     }
     else if (strcasecmp(dot, ".png") == 0)
     {

--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1089,6 +1089,10 @@ static int http_client_send_http_request(zval *zobject TSRMLS_DC)
                 {
                     continue;
                 }
+                if (sw_zend_hash_find(Z_ARRVAL_P(value), ZEND_STRS("size"), (void **) &zsize) == FAILURE)
+                {
+                    continue;
+                }
                 if (sw_zend_hash_find(Z_ARRVAL_P(value), ZEND_STRS("type"), (void **) &ztype) == FAILURE)
                 {
                     continue;
@@ -1124,10 +1128,6 @@ static int http_client_send_http_request(zval *zobject TSRMLS_DC)
         if ((ret = http->cli->send(http->cli, header_buf, n, 0)) < 0)
         {
             goto send_fail;
-        }
-        else
-        {
-            return SW_OK;
         }
     }
     //x-www-form-urlencoded or raw

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -108,17 +108,23 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_get, 0, 0, 1)
     ZEND_ARG_INFO(0, path)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_post, 0, 0, 2)
+    ZEND_ARG_INFO(0, path)
+    ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_download, 0, 0, 2)
+    ZEND_ARG_INFO(0, path)
+    ZEND_ARG_INFO(0, file)
+    ZEND_ARG_INFO(0, offset)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_recv, 0, 0, 0)
     ZEND_ARG_INFO(0, timeout)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_upgrade, 0, 0, 1)
     ZEND_ARG_INFO(0, path)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_post, 0, 0, 2)
-    ZEND_ARG_INFO(0, path)
-    ZEND_ARG_INFO(0, data)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_client_coro_push, 0, 0, 1)
@@ -142,8 +148,9 @@ static PHP_METHOD(swoole_http_client_coro, execute);
 static PHP_METHOD(swoole_http_client_coro, isConnected);
 static PHP_METHOD(swoole_http_client_coro, close);
 static PHP_METHOD(swoole_http_client_coro, get);
-static PHP_METHOD(swoole_http_client_coro, upgrade);
 static PHP_METHOD(swoole_http_client_coro, post);
+static PHP_METHOD(swoole_http_client_coro, download);
+static PHP_METHOD(swoole_http_client_coro, upgrade);
 static PHP_METHOD(swoole_http_client_coro, push);
 static PHP_METHOD(swoole_http_client_coro, setDefer);
 static PHP_METHOD(swoole_http_client_coro, getDefer);
@@ -161,6 +168,7 @@ static const zend_function_entry swoole_http_client_coro_methods[] =
     PHP_ME(swoole_http_client_coro, execute, arginfo_swoole_http_client_coro_execute, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_client_coro, get, arginfo_swoole_http_client_coro_get, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_client_coro, post, arginfo_swoole_http_client_coro_post, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_http_client_coro, download, arginfo_swoole_http_client_coro_download, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_client_coro, upgrade, arginfo_swoole_http_client_coro_upgrade, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_client_coro, addFile, arginfo_swoole_http_client_coro_addFile, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_http_client_coro, isConnected, arginfo_swoole_void, ZEND_ACC_PUBLIC)
@@ -233,6 +241,42 @@ static int http_client_coro_execute(zval *zobject, char *uri, zend_size_t uri_le
 
     http->uri = estrdup(uri);
     http->uri_len = uri_len;
+
+    http_client_property *hcc = swoole_get_property(zobject, http_client_coro_property_request);
+
+    /**
+     * download response body
+     */
+    if (hcc->download_file)
+    {
+        int fd = open(Z_STRVAL_P(hcc->download_file), O_CREAT | O_WRONLY, 0664);
+        if (fd < 0)
+        {
+            swSysError("open(%s, O_CREAT | O_WRONLY) failed.", Z_STRVAL_P(hcc->download_file));
+            return SW_ERR;
+        }
+        if (hcc->download_offset == 0)
+        {
+            if (ftruncate(fd, 0) < 0)
+            {
+                swSysError("ftruncate(%s) failed.", Z_STRVAL_P(hcc->download_file));
+                close(fd);
+                return SW_ERR;
+            }
+        }
+        else
+        {
+            if (lseek(fd, hcc->download_offset, SEEK_SET) < 0)
+            {
+                swSysError("fseek(%s, %ld) failed.", Z_STRVAL_P(hcc->download_file), hcc->download_offset);
+                close(fd);
+                return SW_ERR;
+            }
+        }
+        http->download = 1;
+        http->file_fd = fd;
+    }
+
     //if connection exists
     if (http->cli)
     {
@@ -296,11 +340,7 @@ static int http_client_coro_execute(zval *zobject, char *uri, zend_size_t uri_le
     }
 
     cli->object = zobject;
-	
-#if PHP_MAJOR_VERSION >= 7
-    http_client_property *hcc = swoole_get_property(zobject, http_client_coro_property_request);
     sw_copy_to_stack(cli->object, hcc->_object);
-#endif
 
     cli->open_eof_check = 0;
     cli->open_length_check = 0;
@@ -857,7 +897,7 @@ static int http_client_coro_send_http_request(zval *zobject TSRMLS_DC)
     http_client *http = swoole_get_object(zobject);
     if (!http->cli || !http->cli->socket )
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_http_client.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_http_client_coro.");
         return SW_ERR;
     }
 
@@ -1599,8 +1639,6 @@ static PHP_METHOD(swoole_http_client_coro, addFile)
     RETURN_TRUE;
 }
 
-
-
 static PHP_METHOD(swoole_http_client_coro, setMethod)
 {
     zval *method;
@@ -1640,7 +1678,7 @@ static PHP_METHOD(swoole_http_client_coro, close)
     swClient *cli = http->cli;
     if (!cli)
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_http_client.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_http_client_coro.");
         RETURN_FALSE;
     }
     if (!cli->socket)
@@ -1757,6 +1795,54 @@ static PHP_METHOD(swoole_http_client_coro, post)
     zend_update_property(swoole_http_client_coro_class_entry_ptr, getThis(), ZEND_STRL("requestBody"), post_data TSRMLS_CC);
     hcc->request_body = sw_zend_read_property(swoole_http_client_coro_class_entry_ptr, getThis(), ZEND_STRL("requestBody"), 1 TSRMLS_CC);
     sw_copy_to_stack(hcc->request_body, hcc->_request_body);
+    if (hcc->cid != 0 && hcc->cid != COROG.current_coro->cid)
+    {
+        swoole_php_fatal_error(E_WARNING, "client has been bound to another coro");
+    }
+
+    if (hcc->defer)
+    {
+        if (hcc->defer_status != HTTP_CLIENT_STATE_DEFER_INIT)
+        {
+            RETURN_FALSE;
+        }
+        hcc->defer_status = HTTP_CLIENT_STATE_DEFER_SEND;
+    }
+    ret = http_client_coro_execute(getThis(), uri, uri_len TSRMLS_CC);
+    if (ret == SW_ERR)
+    {
+        SW_CHECK_RETURN(ret);
+    }
+
+    php_context *context = swoole_get_property(getThis(), 1);
+    if (hcc->defer)
+    {
+        RETURN_TRUE;
+    }
+    hcc->cid = COROG.current_coro->cid;
+    coro_save(context);
+    coro_yield();
+}
+
+static PHP_METHOD(swoole_http_client_coro, download)
+{
+    int ret;
+    char *uri = NULL;
+    zend_size_t uri_len = 0;
+    zval *download_file;
+    off_t offset = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|l", &uri, &uri_len, &download_file, &offset) == FAILURE)
+    {
+        return;
+    }
+
+    http_client_property *hcc = swoole_get_property(getThis(), 0);
+    zend_update_property(swoole_http_client_coro_class_entry_ptr, getThis(), ZEND_STRL("downloadFile"), download_file TSRMLS_CC);
+    hcc->download_file = sw_zend_read_property(swoole_http_client_coro_class_entry_ptr, getThis(), ZEND_STRL("downloadFile"), 1 TSRMLS_CC);
+    hcc->download_offset = offset;
+    sw_copy_to_stack(hcc->download_file, hcc->_download_file);
+
     if (hcc->cid != 0 && hcc->cid != COROG.current_coro->cid)
     {
         swoole_php_fatal_error(E_WARNING, "client has been bound to another coro");

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -189,6 +189,15 @@ static int swoole_mysql_coro_close(zval *this)
         return FAILURE;
     }
 
+    //send quit command
+    swString_clear(mysql_request_buffer);
+    client->cmd = SW_MYSQL_COM_QUIT;
+    bzero(mysql_request_buffer->str, 5);
+    mysql_request_buffer->str[4] = SW_MYSQL_COM_QUIT;//command
+    mysql_request_buffer->length = 5;
+    mysql_pack_length(mysql_request_buffer->length - 4, mysql_request_buffer->str);
+    SwooleG.main_reactor->write(SwooleG.main_reactor, client->fd, mysql_request_buffer->str, mysql_request_buffer->length);
+
     zend_update_property_bool(swoole_mysql_coro_class_entry_ptr, this, ZEND_STRL("connected"), 0 TSRMLS_CC);
     SwooleG.main_reactor->del(SwooleG.main_reactor, client->fd);
 
@@ -210,6 +219,8 @@ static int swoole_mysql_coro_close(zval *this)
             mysql_statement *stmt = node->data;
             if (stmt->object)
             {
+                // after connection closed, mysql stmt cache closed too
+                // so we needn't send stmt close command here like pdo.
                 swoole_set_object(stmt->object, NULL);
                 efree(stmt->object);
             }
@@ -373,6 +384,36 @@ static int swoole_mysql_coro_execute(zval *zobject, mysql_client *client, zval *
     {
         client->state = SW_MYSQL_STATE_READ_START;
         return SW_OK;
+    }
+
+    return SW_OK;
+}
+
+static int swoole_mysql_coro_statement_close(mysql_statement *stmt TSRMLS_DC)
+{
+    // call mysql-server to destruct this statement
+    swString_clear(mysql_request_buffer);
+    stmt->client->cmd = SW_MYSQL_COM_STMT_CLOSE;
+    bzero(mysql_request_buffer->str, 5);
+    //command
+    mysql_request_buffer->str[4] = SW_MYSQL_COM_STMT_CLOSE;
+    mysql_request_buffer->length = 5;
+    char *p = mysql_request_buffer->str;
+    p += 5;
+
+    // stmt.id
+    mysql_int4store(p, stmt->id);
+    p += 4;
+    mysql_request_buffer->length += 4;
+    //length
+    mysql_pack_length(mysql_request_buffer->length - 4, mysql_request_buffer->str);
+    //send data, mysql-server would not reply
+    SwooleG.main_reactor->write(SwooleG.main_reactor, stmt->client->fd, mysql_request_buffer->str, mysql_request_buffer->length);
+
+    if (stmt->object)
+    {
+        swoole_set_object(stmt->object, NULL);
+        efree(stmt->object);
     }
 
     return SW_OK;
@@ -1027,8 +1068,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, __destruct)
     {
         return;
     }
-    efree(stmt->object);
-    stmt->object = NULL;
+    swoole_mysql_coro_statement_close(stmt TSRMLS_CC);
     swLinkedList_remove(stmt->client->statement_list, stmt);
     efree(stmt);
 }

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -49,7 +49,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, execute);
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_connect, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_connect, 0, 0, 1)
     ZEND_ARG_ARRAY_INFO(0, server_config, 0)
 ZEND_END_ARG_INFO()
 
@@ -67,7 +67,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_rollback, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_prepare, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_prepare, 0, 0, 1)
     ZEND_ARG_INFO(0, query)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
1. 修正一些参数个数声明错误
2. 在支持空参数prepare的基础上再支持execute空参数, 而不必每次传入一个空数组
3. 在content-type为multipart/form-data的时自动打包数组数据, 满足非文件上传时使用form-data需求
4. **修正文件body打包时遗失的size参数, 否则多文件上传时会使用最后一个文件的size导致报错**
5. **修正进入文件上传逻辑中过早返回, timeout被跳过而失效的问题**
6. **修正post参数是空数组时httpbuild失败而报错的问题**
7. 删除mime多余字符
8. **MySQL-Statement对象销毁时向mysql服务器发出close命令释放模板语句缓存, 否则在长连接时无用的缓存语句数量会持续上涨**
9. **MySQL-Client关闭时向mysql服务器发出quit命令, 否则MySQL端Aborted_clients数量会持续上涨, 不利于在问题发生时进行分析**
10. **增加协程http文件下载方法, 已测试本地大文件没有问题.**

如有不妥之处请指正...学习中...