### PR TITLE
Patch mysql execute empty

### DIFF
--- a/examples/coroutine/mysql_execute_empty.php
+++ b/examples/coroutine/mysql_execute_empty.php
@@ -1,0 +1,14 @@
+<?php
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host'     => '127.0.0.1',
+        'user'     => 'root',
+        'password' => 'root',
+        'database' => 'test'
+    ];
+    $db->connect($server);
+    $stmt = $db->prepare('SELECT * FROM `userinfo`');
+    $ret = $stmt->execute();
+    var_dump($ret);
+});


### PR DESCRIPTION
空prepare支持的基础上再支持空参数execute, 模板语句有缓存且只需传递id, 多次使用性能比query更好.