### PR TITLE
Coro clear

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -386,9 +386,9 @@ int sw_coro_save(zval *return_value, php_context *sw_current_context)
 
 int sw_coro_resume(php_context *sw_current_context, zval *retval, zval *coro_retval)
 {
-    swTraceLog(SW_TRACE_COROUTINE,"sw_coro_resume coro id %d", COROG.current_coro->cid);
     coro_task *task = SWCC(current_task);
     COROG.current_coro = task;
+    swTraceLog(SW_TRACE_COROUTINE,"sw_coro_resume coro id %d", COROG.current_coro->cid);
     task->state = SW_CORO_RUNNING;
     EG(current_execute_data) = SWCC(current_execute_data);
     EG(vm_stack) = SWCC(current_vm_stack);

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -444,6 +444,8 @@ void sw_coro_close()
     free_cidmap(task->cid);
     efree(task->stack);
     --COROG.coro_num;
+    COROG.current_coro = NULL;
+    COROG.require = 0;
     swTraceLog(SW_TRACE_COROUTINE, "close coro and %d remained. usage size: %zu. malloc size: %zu", COROG.coro_num, zend_memory_usage(0), zend_memory_usage(1));
 }
 

--- a/tests/swoole_coroutine/coro_current.phpt
+++ b/tests/swoole_coroutine/coro_current.phpt
@@ -1,0 +1,19 @@
+--TEST--
+swoole_coroutine: current cid
+--SKIPIF--
+<?php require  __DIR__ . "/../include/skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../include/swoole.inc";
+assert(Co::getuid() === -1);
+go(function () {
+    assert(Co::getuid() === 1);
+    Co::sleep(1);
+    assert(Co::getuid() === 1);
+});
+go(function () {
+    assert(Co::getuid() === 2);
+});
+assert(Co::getuid() === -1);
+?>
+--EXPECT--


### PR DESCRIPTION
在协程退出时进行清理, 否则会出现以下状况
```php
go(function(){});
echo Co::getuid(); // 1
```
然后coro_check失效, 莫名其妙就coredump了
resume的时候会恢复这几个量