### PR TITLE
Fix coro nest

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -444,8 +444,6 @@ void sw_coro_close()
     free_cidmap(task->cid);
     efree(task->stack);
     --COROG.coro_num;
-    COROG.current_coro = NULL;
-    COROG.require = 0;
     swTraceLog(SW_TRACE_COROUTINE, "close coro and %d remained. usage size: %zu. malloc size: %zu", COROG.coro_num, zend_memory_usage(0), zend_memory_usage(1));
 }
 

--- a/swoole_coroutine_util.c
+++ b/swoole_coroutine_util.c
@@ -294,10 +294,8 @@ PHP_FUNCTION(swoole_coroutine_create)
     callback = sw_zval_dup(callback);
     sw_zval_add_ref(&callback);
 
-    int parent_cid;
-    parent_cid = get_current_cid();
-    coro_task *parent_coro;
-    if (parent_cid > 0)
+    coro_task *parent_coro = NULL;
+    if (likely(COROG.current_coro != NULL))
     {
         parent_coro = COROG.current_coro;
     }
@@ -318,7 +316,7 @@ PHP_FUNCTION(swoole_coroutine_create)
         sw_zval_ptr_dtor(&retval);
     }
 
-    if (parent_cid > 0)
+    if (likely(parent_coro != NULL))
     {
         COROG.current_coro = parent_coro;
         parent_coro = NULL;

--- a/swoole_coroutine_util.c
+++ b/swoole_coroutine_util.c
@@ -294,6 +294,14 @@ PHP_FUNCTION(swoole_coroutine_create)
     callback = sw_zval_dup(callback);
     sw_zval_add_ref(&callback);
 
+    int parent_cid;
+    parent_cid = get_current_cid();
+    coro_task *parent_coro;
+    if (parent_cid > 0)
+    {
+        parent_coro = COROG.current_coro;
+    }
+
     zval *retval = NULL;
     zval *args[1];
     php_context *ctx = emalloc(sizeof(php_context));
@@ -309,6 +317,19 @@ PHP_FUNCTION(swoole_coroutine_create)
     {
         sw_zval_ptr_dtor(&retval);
     }
+
+    if (parent_cid > 0)
+    {
+        COROG.current_coro = parent_coro;
+        parent_coro = NULL;
+        COROG.require = 1;
+    }
+    else
+    {
+        COROG.current_coro = NULL;
+        COROG.require = 0;
+    }
+
     RETURN_TRUE;
 }
 

--- a/tests/swoole_coroutine/coro_nested_strict.phpt
+++ b/tests/swoole_coroutine/coro_nested_strict.phpt
@@ -1,0 +1,33 @@
+--TEST--
+swoole_coroutine: coro nested strict
+--SKIPIF--
+<?php require  __DIR__ . "/../include/skipif.inc"; ?>
+--FILE--
+<?php
+assert(Co::getuid() === -1);
+go(function () {
+    assert(Co::getuid() === 1);
+    Co::sleep(0.01);
+    assert(Co::getuid() === 1);
+});
+assert(Co::getuid() === -1);
+go(function () {
+    assert(Co::getuid() === 2);
+    go(function () {
+        assert(Co::getuid() === 3);
+        go(function () {
+            assert(Co::getuid() === 4);
+            go(function () {
+                assert(Co::getuid() === 5);
+                Co::sleep(0.01);
+                assert(Co::getuid() === 5);
+            });
+            assert(Co::getuid() === 4);
+        });
+        assert(Co::getuid() === 3);
+    });
+    assert(Co::getuid() === 2);
+});
+assert(Co::getuid() === -1);
+?>
+--EXPECT--


### PR DESCRIPTION
之前的修复并不正确, 在嵌套协程和协程睡眠挂起的情景下产生了错误
可能是由于新的协程内核改动, 创建的自定义协程立即返回后COROG并没有恢复到父协程
导致一系列依赖于getuid来实现context管理的框架发生错误
可能不是最优解, 但我只能想到这个方法来解决问题, 因为目前只有自定义协程才会产生有嵌套操作