### PR TITLE
Fix a redis memory leak and trace core dump.

### DIFF
--- a/swoole_redis_coro.c
+++ b/swoole_redis_coro.c
@@ -1375,7 +1375,7 @@ static PHP_METHOD(swoole_redis_coro, __destruct)
     {
         return;
     }
-    if (redis->state != SWOOLE_REDIS_CORO_STATE_CLOSED)
+    if (redis->state != SWOOLE_REDIS_CORO_STATE_CLOSED && redis->state != SWOOLE_REDIS_CORO_STATE_CONNECT)
     {
         swTraceLog(SW_TRACE_REDIS_CLIENT, "close connection, fd=%d", redis->context->c.fd);
 


### PR DESCRIPTION
Co\Redis 未连接或连接失败没有重连的时候, 不会触发onclose, 内存泄漏, __destruct进入了错误的逻辑分支, tracelog会coredump.