### PR TITLE
Patch redis auth

### DIFF
--- a/examples/coroutine/redis/auth.php
+++ b/examples/coroutine/redis/auth.php
@@ -1,0 +1,8 @@
+<?php
+go(function () {
+    $redis = new Swoole\Coroutine\Redis;
+    $redis->connect('127.0.0.1', 6379);
+    $redis->auth('root');
+    $redis->set('key', 'swoole redis work');
+    var_dump($redis->get('key'));
+});

--- a/swoole_redis_coro.c
+++ b/swoole_redis_coro.c
@@ -1375,7 +1375,7 @@ static PHP_METHOD(swoole_redis_coro, __destruct)
     {
         return;
     }
-    if (redis->state != SWOOLE_REDIS_CORO_STATE_CLOSED)
+    if (redis->state != SWOOLE_REDIS_CORO_STATE_CLOSED && redis->state != SWOOLE_REDIS_CORO_STATE_CONNECT)
     {
         swTraceLog(SW_TRACE_REDIS_CLIENT, "close connection, fd=%d", redis->context->c.fd);
 

--- a/swoole_redis_coro.c
+++ b/swoole_redis_coro.c
@@ -3958,6 +3958,11 @@ static void swoole_redis_coro_parse_result(swRedisClient *redis, zval* return_va
 
     case REDIS_REPLY_ERROR:
         ZVAL_FALSE(return_value);
+        if (redis->context->err == 0)
+        {
+            redis->context->err = -1;
+            redis->context->errstr = reply->str;
+        }
         zend_update_property_long(swoole_redis_coro_class_entry_ptr, redis->object, ZEND_STRL("errCode"), redis->context->err TSRMLS_CC);
         zend_update_property_string(swoole_redis_coro_class_entry_ptr, redis->object, ZEND_STRL("errMsg"), redis->context->errstr TSRMLS_CC);
         break;


### PR DESCRIPTION
#1655 
看了一圈, 应该是hiredis的问题
在响应的首个符号是'-'的时候会进入ERROR分支, 但是在NOAUTH情况下并没有给err和errstr赋值
搜了一圈发现没有相关的问题, 看来这个应该在客户端实现