### PR TITLE
Mysql procedure

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1562,7 +1562,7 @@ int mysql_is_over(mysql_client *client)
         }
 
         n_buf -= temp;
-        if (n_buf <= 0)
+        if (n_buf == 0)
         {
             break;
         }

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1134,7 +1134,6 @@ static sw_inline int mysql_read_params(mysql_client *client)
 
             if (mysql_read_eof(client, t_buffer, n_buf) == 0)
             {
-                buffer->offset += 9;
                 return SW_OK;
             }
             else

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1884,6 +1884,26 @@ static PHP_METHOD(swoole_mysql, connect)
         connector->strict_type = 0;
     }
 
+    if (php_swoole_array_get_value(_ht, "fetch_mode", value))
+    {
+#if PHP_MAJOR_VERSION < 7
+        if(Z_TYPE_P(value) == IS_BOOL && Z_BVAL_P(value) == 1)
+#else
+        if (Z_TYPE_P(value) == IS_TRUE)
+#endif
+        {
+            connector->fetch_mode = 1;
+        }
+        else
+        {
+            connector->fetch_mode = 0;
+        }
+    }
+    else
+    {
+        connector->fetch_mode = 0;
+    }
+
     swClient *cli = emalloc(sizeof(swClient));
     int type = SW_SOCK_TCP;
 

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1481,7 +1481,12 @@ int mysql_is_over(mysql_client *client, off_t *check_offset)
     char *p;
     if (*check_offset < buffer->offset)
     {
-        *check_offset = buffer->offset; // not check the first again.
+        *check_offset = buffer->offset; // not check the first response again.
+    }
+    else if (*check_offset == buffer->length)
+    {
+        // have already check all of the data
+        goto again;
     }
     size_t n_buf = buffer->length - *check_offset; // remaining buffer size
     uint32_t temp;
@@ -1543,6 +1548,7 @@ int mysql_is_over(mysql_client *client, off_t *check_offset)
         }
     }
 
+    again:
     client->response.wait_recv = 2;
     return SW_AGAIN;
 }

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -409,6 +409,8 @@ typedef struct _mysql_client
                 mysql_int4store((T),def_temp); \
                 mysql_int4store((T+4),def_temp2); } while (0)
 
+#define MYSQL_RESPONSE_BUFFER  (client->cmd == SW_MYSQL_COM_STMT_EXECUTE ? client->statement->buffer : client->buffer)
+
 int mysql_get_result(mysql_connector *connector, char *buf, int len);
 int mysql_get_charset(char *name);
 int mysql_handshake(mysql_connector *connector, char *buf, int len);

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -296,6 +296,8 @@ typedef struct
     uint16_t unreaded_param_count;
     struct _mysql_client *client;
     zval *object;
+    swString *buffer; /* save the mysql multi responses data */
+    zval *result; /* save the zval array result */
 } mysql_statement;
 
 typedef struct

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -224,6 +224,7 @@ typedef struct
     char *password;
     char *database;
     zend_bool strict_type;
+    zend_bool fetch_mode;
 
     zend_size_t host_len;
     zend_size_t user_len;

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -19,7 +19,6 @@
 #ifndef SWOOLE_MYSQL_H_
 #define SWOOLE_MYSQL_H_
 
-//#define SW_MYSQL_STRICT_TYPE
 //#define SW_MYSQL_DEBUG
 
 enum mysql_command
@@ -339,7 +338,6 @@ typedef struct _mysql_client
     int fd;
     uint32_t transaction :1;
     uint32_t connected :1;
-    uint32_t strict;
 
     mysql_connector connector;
     mysql_statement *statement;
@@ -353,7 +351,6 @@ typedef struct _mysql_client
 #endif
 
     mysql_response_t response; /* single response */
-    swLinkedList *response_list; /* multi responses (in fetch mode) */
 
 } mysql_client;
 

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -417,6 +417,7 @@ int mysql_handshake(mysql_connector *connector, char *buf, int len);
 int mysql_request(swString *sql, swString *buffer);
 int mysql_prepare(swString *sql, swString *buffer);
 int mysql_response(mysql_client *client);
+int mysql_is_over(mysql_client *client, off_t *check_offset);
 
 #ifdef SW_MYSQL_DEBUG
 void mysql_client_info(mysql_client *client);

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -353,6 +353,7 @@ typedef struct _mysql_client
     zval _onClose;
 #endif
 
+    off_t check_offset;
     mysql_response_t response; /* single response */
 
 } mysql_client;
@@ -417,7 +418,7 @@ int mysql_handshake(mysql_connector *connector, char *buf, int len);
 int mysql_request(swString *sql, swString *buffer);
 int mysql_prepare(swString *sql, swString *buffer);
 int mysql_response(mysql_client *client);
-int mysql_is_over(mysql_client *client, off_t *check_offset);
+int mysql_is_over(mysql_client *client);
 
 #ifdef SW_MYSQL_DEBUG
 void mysql_client_info(mysql_client *client);

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1321,11 +1321,6 @@ static PHP_METHOD(swoole_mysql_coro_statement, nextResult)
     }
 
     mysql_client *client = stmt->client;
-    if (!client->cli)
-    {
-        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed.", client->fd);
-        RETURN_FALSE;
-    }
 
     if (stmt->buffer && stmt->buffer->offset < stmt->buffer->length)
     {

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1103,7 +1103,19 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetchAll)
     {
         RETURN_FALSE;
     }
-    RETURN_ZVAL(stmt->result, 0, 1);
+
+    if (stmt->result)
+    {
+        zval *result;
+        ZVAL_ZVAL(result, stmt->result, 0, 1);
+        efree(stmt->result);
+        stmt->result = NULL;
+		RETURN_ZVAL(result, 0, 1);
+    }
+    else
+    {
+        RETURN_NULL();
+    }
 }
 
 static PHP_METHOD(swoole_mysql_coro_statement, __destruct)

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -450,6 +450,7 @@ static void swoole_mysql_coro_parse_end(mysql_client *client, swString *buffer)
         swString_clear(buffer);
     }
     bzero(&client->response, sizeof(client->response));
+    client->statement = NULL;
 }
 
 static int swoole_mysql_coro_statement_free(mysql_statement *stmt TSRMLS_DC)

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1234,6 +1234,11 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetch)
         RETURN_FALSE;
     }
 
+    if (!stmt->client->connector.fetch_mode)
+    {
+        RETURN_FALSE;
+    }
+
     if (stmt->result)
     {
         zval **args[1];
@@ -1283,6 +1288,11 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetchAll)
         RETURN_FALSE;
     }
 
+    if (!stmt->client->connector.fetch_mode)
+    {
+        RETURN_FALSE;
+    }
+
     if (stmt->result)
     {
         zval _result = *stmt->result;
@@ -1301,6 +1311,11 @@ static PHP_METHOD(swoole_mysql_coro_statement, nextResult)
 {
     mysql_statement *stmt = swoole_get_object(getThis());
     if (!stmt)
+    {
+        RETURN_FALSE;
+    }
+
+    if (!stmt->client->connector.fetch_mode)
     {
         RETURN_FALSE;
     }

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -551,15 +551,39 @@ static PHP_METHOD(swoole_mysql_coro, connect)
 #if PHP_MAJOR_VERSION < 7
         if(Z_TYPE_P(value) == IS_BOOL && Z_BVAL_P(value) == 1)
 #else
-        if(Z_TYPE_P(value) == IS_TRUE)
+        if (Z_TYPE_P(value) == IS_TRUE)
 #endif
         {
             connector->strict_type = 1;
-        }else{
+        }
+        else
+        {
             connector->strict_type = 0;
         }
-    } else{
+    }
+    else
+    {
         connector->strict_type = 0;
+    }
+
+    if (php_swoole_array_get_value(_ht, "fetch_mode", value))
+    {
+#if PHP_MAJOR_VERSION < 7
+        if(Z_TYPE_P(value) == IS_BOOL && Z_BVAL_P(value) == 1)
+#else
+        if (Z_TYPE_P(value) == IS_TRUE)
+#endif
+        {
+            connector->fetch_mode = 1;
+        }
+        else
+        {
+            connector->fetch_mode = 0;
+        }
+    }
+    else
+    {
+        connector->fetch_mode = 0;
     }
 
     swClient *cli = emalloc(sizeof(swClient));

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1602,6 +1602,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
                     object_init_ex(result, swoole_mysql_coro_statement_class_entry_ptr);
                     swoole_set_object(result, client->statement);
                     client->statement->object = sw_zval_dup(result);
+                    client->statement->result = NULL;
                     // if (client->connector.fetch_mode)
                     // {
                         // in fetch mode, statement save the response data itself
@@ -1643,6 +1644,11 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
                 if (client->cmd == SW_MYSQL_COM_STMT_EXECUTE && Z_TYPE_P(result) == IS_ARRAY)
                 {
                     // save result on statement and wait for fetch
+                    if (client->statement->result)
+                    {
+                        // free the last one
+                        sw_zval_free(client->statement->result);
+                    }
                     client->statement->result = result;
                     // return true (success)
                     result = NULL;

--- a/tests/swoole_mysql_coro/fetch.phpt
+++ b/tests/swoole_mysql_coro/fetch.phpt
@@ -1,0 +1,30 @@
+--TEST--
+fetch: use fetch to get data
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/config.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER1,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB1,
+        'fetch_mode' => true
+    ];
+
+    $db->connect($server);
+
+    // now we can make the responses independent
+    $stmt = $db->prepare('SELECT `id` FROM `userinfo` LIMIT 2');
+    assert($stmt->execute() === true);
+    assert(is_array($stmt->fetch()));
+    assert(is_array($stmt->fetch()));
+    assert($stmt->fetch() === null);
+    assert($stmt->fetchAll() === null);
+});
+?>
+--EXPECT--

--- a/tests/swoole_mysql_coro/fetch_mode.phpt
+++ b/tests/swoole_mysql_coro/fetch_mode.phpt
@@ -1,0 +1,29 @@
+--TEST--
+fetch_mode: use fetch to get data
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => '127.0.0.1',
+        'user' => 'root',
+        'password' => 'root',
+        'database' => 'test',
+        'fetch_mode' => true
+    ];
+
+    $db->connect($server);
+
+    // now we can make the responses independent
+    $stmt1 = $db->prepare('SELECT * FROM ckl LIMIT 1');
+    assert($stmt1->execute() === true);
+    $stmt2 = $db->prepare('SELECT * FROM ckl LIMIT 2');
+    assert($stmt2->execute() === true);
+    assert(count($stmt1->fetchAll()) === 1);
+    assert(count($stmt2->fetchAll()) === 2);
+});
+?>
+--EXPECT--

--- a/tests/swoole_mysql_coro/fetch_mode_twice.phpt
+++ b/tests/swoole_mysql_coro/fetch_mode_twice.phpt
@@ -1,5 +1,5 @@
 --TEST--
-fetch_mode: use fetch to get data
+fetch_mode_twice: call fetch twice
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
@@ -18,13 +18,12 @@ go(function () {
 
     $db->connect($server);
 
+    assert($db->query("INSERT INTO ckl (`domain`,`path`,`name`) VALUES ('www.baidu.com', '/search', 'baidu')") === true);
     // now we can make the responses independent
-    $stmt1 = $db->prepare('SELECT * FROM ckl LIMIT 1');
-    assert($stmt1->execute() === true);
-    $stmt2 = $db->prepare('SELECT * FROM ckl LIMIT 2');
-    assert($stmt2->execute() === true);
-    assert(count($stmt1->fetchAll()) === 1);
-    assert(count($stmt2->fetchAll()) === 2);
+    $stmt = $db->prepare('SELECT * FROM ckl LIMIT 1');
+    assert($stmt->execute() === true);
+    assert(($ret = $stmt->fetchAll()) && is_array($ret) && count($ret) === 1);
+    assert($stmt->fetchAll() === null);
 });
 ?>
 --EXPECT--

--- a/tests/swoole_mysql_coro/procedure.phpt
+++ b/tests/swoole_mysql_coro/procedure.phpt
@@ -1,0 +1,54 @@
+--TEST--
+procedure: procedure without fetch mode
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/config.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB
+    ];
+
+    $clear = <<<SQL
+    DROP PROCEDURE IF EXISTS `reply`
+SQL;
+    $map = [
+        'You said: "hello mysql!"',
+        'Hey swoole!',
+        'foo',
+        'bar',
+        'PHP is really the best programming language!'
+    ];
+    $procedure = <<<SQL
+  CREATE DEFINER=`root`@`localhost` PROCEDURE `reply`(content varchar(255))
+  BEGIN
+    SELECT concat('You said: \"', content, '\"');
+    SELECT '$map[1]';
+    SELECT '$map[2]';
+    SELECT '$map[3]';
+    SELECT '$map[4]';
+    INSERT INTO ckl (`domain`,`path`,`name`) VALUES ('www.baidu.com', '/search', 'baidu');
+  END
+SQL;
+
+    $db->connect($server);
+    if ($db->query($clear) && $db->query($procedure)) {
+        //SWOOLE
+        $_map = $map;
+        $stmt = $db->prepare('CALL reply(?)');
+        $res = $stmt->execute(['hello mysql!']);
+        do {
+            assert(current($res[0]) === array_shift($_map));
+        } while ($res = $stmt->nextResult());
+        assert($stmt->affected_rows === 1, 'get the affected rows failed!');
+        assert(empty($_map), 'there are some results lost!');
+    }
+});
+?>
+--EXPECT--

--- a/tests/swoole_mysql_coro/procedure_in_fetch.phpt
+++ b/tests/swoole_mysql_coro/procedure_in_fetch.phpt
@@ -1,0 +1,74 @@
+--TEST--
+procedure: procedure in fetch mode
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/config.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB,
+        'fetch_mode' => true
+    ];
+
+    $clear = <<<SQL
+    DROP PROCEDURE IF EXISTS `reply`
+SQL;
+    $map = [
+        'You said: "hello mysql!"',
+        'Hey swoole!',
+        'foo',
+        'bar',
+        'PHP is really the best programming language!'
+    ];
+    $procedure = <<<SQL
+  CREATE DEFINER=`root`@`localhost` PROCEDURE `reply`(content varchar(255))
+  BEGIN
+    SELECT concat('You said: \"', content, '\"');
+    SELECT '$map[1]';
+    SELECT '$map[2]';
+    SELECT '$map[3]';
+    SELECT '$map[4]';
+    INSERT INTO ckl (`domain`,`path`,`name`) VALUES ('www.baidu.com', '/search', 'baidu');
+  END
+SQL;
+
+    $db->connect($server);
+    if ($db->query($clear) && $db->query($procedure)) {
+
+        //SWOOLE
+        $_map = $map;
+        $stmt = $db->prepare('CALL reply(?)');
+        assert($stmt->execute(['hello mysql!']) === true);
+        do {
+            $res = $stmt->fetchAll();
+            assert(current($res[0]) === array_shift($_map));
+        } while ($stmt->nextResult());
+        assert($stmt->affected_rows === 1, 'get the affected rows failed!');
+        assert(empty($_map), 'there are some results lost!');
+
+        //PDO
+        !extension_loaded('PDO') && exit;
+        $_map = $map;
+        $pdo = new PDO(
+            "mysql:host=" . MYSQL_SERVER_HOST . ";dbname=" . MYSQL_SERVER_DB . ";charset=utf8",
+            MYSQL_SERVER_USER, MYSQL_SERVER_PWD
+        );
+        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+        $stmt = $pdo->prepare("CALL reply(?)");
+        assert($stmt->execute(['hello mysql!']) === true);
+        do {
+            $res = $stmt->fetchAll();
+            assert(current($res[0]) === array_shift($_map));
+        } while ($ret = $stmt->nextRowset());
+        assert($stmt->rowCount() === 1, 'get the affected rows failed!');
+        assert(empty($_map), 'there are some results lost!');
+    }
+});
+?>
+--EXPECT--

--- a/tests/swoole_mysql_coro/without_fetch.phpt
+++ b/tests/swoole_mysql_coro/without_fetch.phpt
@@ -1,0 +1,27 @@
+--TEST--
+without_fetch: just execute (test memory leak)
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/config.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER1,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB1,
+        'fetch_mode' => true
+    ];
+
+    $db->connect($server);
+    $stmt = $db->prepare('SELECT * FROM `userinfo` LIMIT 1');
+    assert($stmt->execute() === true);
+    assert($stmt->execute() === true);
+    assert($stmt->execute() === true);
+    assert(is_array($stmt->fetchAll()));
+});
+?>
+--EXPECT--


### PR DESCRIPTION
完整的MySQL存储过程支持

先贴上来, 还有一点细节问题, 说明我一会儿补

------

做了以下几件事:

## fetch mode

一开始先想着和PDO一样给Swoole做一个fetch模式

```php
['fetch_mode' => true] //连接配置里加入这个
```

```php
$stmt = $db->prepare('SELECT `id` FROM `userinfo` LIMIT 2');
$stmt->execute(); // true = success
$stmt->fetch(); // result-set array 1
$stmt->fetch(); // result-set array 2
```



## 分离client和statement

加了一个 `MYSQL_RESPONSE_BUFFER` 宏, 处理了一些代码分离了client和statement的buffer

并给statement结构上也挂了一个result的zval指针

```C
typedef struct
{
    ...
    swString *buffer; /* save the mysql multi responses data */
    zval *result; /* save the zval array result */
} mysql_statement;
```

这样就可以实现以下代码:

```php
$stmt1 = $db->prepare('SELECT * FROM ckl LIMIT 1');
$stmt1->execute();
$stmt2 = $db->prepare('SELECT * FROM ckl LIMIT 2');
$stmt2->execute();
$stmt1->fetchAll();
$stmt2->fetchAll();
```

因为现在result是挂在statement上的, 和client分离干净, 就不会因为这样的写法产生错误

当然这并没有多大用, **主要还是为了后面处理多响应多结果集**



## 分离mysql_parse_response

这样就就可以在除了`onRead`回调之外的别的地方复用这个方法, 处理多结果集了



## 存储过程

存储过程会返回多个响应, 如果和swoole之前的设计一样, 一次性全返回是不太现实的

PDO和MySQLi的设计都是用一个 next 方法来切换到下一个响应

刚开始是想做一个链表存储多个响应, 很快就发现并不需要

所以首先做了一个 [`mysql_is_over`](https://github.com/twose/swoole-src/blob/13ff4ff8ac2723649f05b69f337f49557cf74546/swoole_mysql.c#L1478)方法

它用来**校验MySQL包的完整性**, 这是swoole以前没有的, 所以在之前的PR后虽然可以使用存储过程, 但是并不能每次都收到完整的响应包, 第一次没收到的包会被丢弃

然后说一下几个注意点

1. MySQL协议决定了并不能倒着检查status flag, 我们必须把每个包的包头都扫描一遍, 通过package length快速扫描到最后一个已接收的包体, 这里只是每次只是检查每个包前几个字节, 消耗不大
2. MySQL其它包体中的 `MYSQL_SERVER_MORE_RESULTS_EXISTS` 的标志位并不准确, 不可采信, 只有`eof`和`ok`包中的是准确的 (这里一定要注意)
3. 在存储过程中执行一个耗时操作的话, recv一次性收不完, 而且会等很久, 这时候需要return等下一次onRead触发(之前的代码里是continue阻塞), 这就不得不在client上加一个check_offset来保存上次完整性校验的位置, 从上个位置开始继续校验后续的MySQL包是否完整, 节省时间
4. 存储过程中遇到错误(error响应)就可以直接终止接收了
5. 在PHP7的zval使用上踩了点坑, 现在理解了, 幸好有鸟哥的文章[zval](https://github.com/laruence/php7-internal/blob/master/zval.md)给我解惑..

**校验包的完整性直到所有数据接收完毕**

(分离了client和statement后, execute获取的数据是被存在`statement->buffer`里而不是`client->buffer`)

**这时候onRead中只会解析第一个响应的结果, 并置到statement对象上, 而剩下的数据仍在buffer中, 并等待nextResult来推动offset解析下一个, 可以说是懒解析了, 有时候会比一次性解析所有响应划算, 而且我们可以清楚的知道每一次nextResult切换前后, 对应的affected_rows和insert_id的值(如果一次性读完, 只能知道最后的)**

最后效果就是以下代码

```php
$stmt = $db->prepare('CALL reply(?)');
$stmt->execute(['hello mysql!']); // true
do {
    $res = $stmt->fetchAll();
    var_dump($res);
} while ($stmt->nextResult());
```

非fetch_mode模式下这么写

```php
$stmt = $db->prepare('CALL reply(?)');
$res = $stmt->execute(['hello mysql!']); // the first result
do {
    var_dump($res);
} while ($res = $stmt->nextResult());
```

比较巧妙的是nextResult推到最后一个response_ok包的时候会返回null, while循环终止, 我们就可以在循环后读取ok包的affected_rows, 如果最后存储过程最后一个语句是insert成功, 这里会显示1

```php
var_dump($stmt->affected_rows); //1
```

25个单元测试都通过了, 但是这个单元测试数量感觉还不够, 后续会补