### PR TITLE
Bugs when MySQL reload

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -1793,7 +1793,8 @@ int mysql_query(zval *zobject, mysql_client *client, swString *sql, zval *callba
         if (swConnection_error(errno) == SW_CLOSE)
         {
             zend_update_property_bool(swoole_mysql_class_entry_ptr, zobject, ZEND_STRL("connected"), 0 TSRMLS_CC);
-            zend_update_property_long(swoole_mysql_class_entry_ptr, zobject, ZEND_STRL("errno"), 2006 TSRMLS_CC);
+            zend_update_property_long(swoole_mysql_class_entry_ptr, zobject, ZEND_STRL("errno"), 2013 TSRMLS_CC);
+            zend_update_property_string(swoole_mysql_class_entry_ptr, zobject, ZEND_STRL("error"), "Lost connection to MySQL server during query" TSRMLS_CC);
         }
         return SW_ERR;
     }

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -23,6 +23,7 @@
 
 enum mysql_command
 {
+    SW_MYSQL_COM_NULL = -1,
     SW_MYSQL_COM_SLEEP = 0,
     SW_MYSQL_COM_QUIT,
     SW_MYSQL_COM_INIT_DB,

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1795,6 +1795,11 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
             zend_update_property_long(swoole_mysql_coro_class_entry_ptr, zobject, ZEND_STRL("connect_errno"), 111 TSRMLS_CC);
             swoole_mysql_coro_close(zobject);
 
+            if (!client->cid)
+            {
+                return SW_OK;
+            }
+
             SW_ALLOC_INIT_ZVAL(result);
             ZVAL_BOOL(result, 0);
             if (client->defer && !client->suspending)
@@ -1804,10 +1809,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
                 return SW_OK;
             }
             client->suspending = 0;
-            if (!client->cid)
-            {
-                return SW_OK;
-            }
+
             php_context *sw_current_context = swoole_get_property(zobject, 0);
             ret = coro_resume(sw_current_context, result, &retval);
             sw_zval_free(result);

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -453,6 +453,7 @@ static void swoole_mysql_coro_parse_end(mysql_client *client, swString *buffer)
     }
     bzero(&client->response, sizeof(client->response));
     client->statement = NULL;
+    client->cmd = SW_MYSQL_COM_NULL;
 }
 
 static int swoole_mysql_coro_statement_free(mysql_statement *stmt TSRMLS_DC)


### PR DESCRIPTION
1. 请求结束后置cmd一个空标志位 不然进入错误逻辑分支会coredump
2. client不属于任何协程时可直接提前返回, 不然创建的zval内存泄漏
3. 完善错误代码等, 在连接被mysql端主动关闭时不再发送关闭请求