### PR TITLE
For PHP73 changes.

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -21,6 +21,7 @@
 #include "coroutine.h"
 #include "swoole_coroutine.h"
 #include "zend_vm.h"
+#include "zend_closures.h"
 
 /* PHP 7.3 compatibility macro {{{*/
 #ifndef ZEND_CLOSURE_OBJECT

--- a/swoole_serialize.c
+++ b/swoole_serialize.c
@@ -1136,7 +1136,11 @@ static void swoole_serialize_object(seriaString *buffer, zval *obj, size_t start
                 //for the zero malloc
                 zend_array tmp_arr;
                 zend_array *ht = (zend_array *) & tmp_arr;
+#if PHP_VERSION_ID >= 70300
+                _zend_hash_init(ht, zend_hash_num_elements(Z_ARRVAL(retval)), ZVAL_PTR_DTOR, 0);
+#else
                 _zend_hash_init(ht, zend_hash_num_elements(Z_ARRVAL(retval)), ZVAL_PTR_DTOR, 0 ZEND_FILE_LINE_CC);
+#endif
                 ht->nTableMask = -(ht)->nTableSize;
                 ALLOCA_FLAG(use_heap);
                 void *ht_addr = do_alloca(HT_SIZE(ht), use_heap);


### PR DESCRIPTION
https://github.com/php/php-src/commit/44e0b79ac64b344fc1335c126e548f00d8308602
_zend_hash_init改动了, PHP73会编译失败.

---

ZEND_CLOSURE_OBJECT定义在zend_closures.h, 需要引入它