### PR TITLE
ensure C++ is used for link command

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -630,7 +630,7 @@ if test "$PHP_SWOOLE" != "no"; then
          LDFLAGS="$LDFLAGS -lboost_context"
     fi
 
-    PHP_NEW_EXTENSION(swoole, $swoole_source_file, $ext_shared)
+    PHP_NEW_EXTENSION(swoole, $swoole_source_file, $ext_shared,,, cxx)
 
     PHP_ADD_INCLUDE([$ext_srcdir])
     PHP_ADD_INCLUDE([$ext_srcdir/include])


### PR DESCRIPTION
This may raise very strange issue, especially when building on RHEL / CentOS with gcc from devtoolset (g++ command need to be invoked at link time to produce proper binaries)

Without this change, during the make

`libtool: link: cc -shared  -fPIC -DPIC  .libs/swoole.o  ...`

With 

`libtool: link: g++  -fPIC -DPIC -shared -nostdlib /usr/lib/gcc/x86_64-redhat-linux/7/../../../../lib64/crti.o /usr/lib/gcc/x86_64-redhat-linux/7/crtbeginS.o  .libs/swoole.o ...`