### PR TITLE
MySQL8 caching_sha2_password support

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -708,6 +708,8 @@ int swString_write_ptr(swString *str, off_t offset, char *write_str, int length)
 int swString_extend(swString *str, size_t new_size);
 char* swString_alloc(swString *str, size_t __size);
 
+#define SWSTRING_CURRENT_VL(buffer) buffer->str + buffer->offset, buffer->length - buffer->offset
+
 static sw_inline int swString_extend_align(swString *str, size_t _new_size)
 {
     size_t align_size = str->size * 2;

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -27,8 +27,12 @@
 #endif
 
 #ifdef SW_USE_OPENSSL
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_NO_RSA
+#define SW_MYSQL_RSA_SUPPORT
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
+#endif
 #endif
 
 static PHP_METHOD(swoole_mysql, __construct);
@@ -598,7 +602,7 @@ int mysql_handshake(mysql_connector *connector, char *buf, int len)
         {
             int len = MAX(13, request.l_auth_plugin_data - 8);
             memcpy(request.auth_plugin_data + 8, tmp, len);
-#ifdef SW_USE_OPENSSL
+#ifdef SW_MYSQL_RSA_SUPPORT
             memcpy(connector->auth_plugin_data, request.auth_plugin_data, SW_MYSQL_NONCE_LENGTH);
 #endif
             tmp += len;
@@ -785,7 +789,7 @@ int mysql_parse_auth_signature(swString *buffer, mysql_connector *connector)
     return tmp[1];
 }
 
-#ifdef SW_USE_OPENSSL
+#ifdef SW_MYSQL_RSA_SUPPORT
 //  Caching sha2 authentication. Public key request and send encrypted password
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchResponse
 int mysql_parse_rsa(mysql_connector *connector, char *buf, int len)

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -718,12 +718,12 @@ int mysql_handshake(mysql_connector *connector, char *buf, int len)
     return next_state;
 }
 
-uint8_t mysql_parse_auth_signature(char *buf, int len)
+uint8_t mysql_parse_auth_signature(swString *buffer)
 {
-    char *tmp = buf;
+    char *tmp = buffer->str;
     int packet_length = mysql_uint3korr(tmp);
     //continue to wait for data
-    if (len < packet_length + 4)
+    if (buffer->length < packet_length + 4)
     {
         return SW_AGAIN;
     }
@@ -735,6 +735,10 @@ uint8_t mysql_parse_auth_signature(char *buf, int len)
     {
         return SW_MYSQL_AUTH_SIGNATURE_ERROR;
     }
+
+    // remaining length
+    buffer->offset = 4 + packet_length;
+    swTraceLog(SW_TRACE_MYSQL_CLIENT, "before signature remaining=%d", buffer->length - buffer->offset);
 
     // signature value
     return tmp[1];

--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -27,7 +27,6 @@
 #endif
 
 #ifdef SW_USE_OPENSSL
-#include <openssl/opensslconf.h>
 #ifndef OPENSSL_NO_RSA
 #define SW_MYSQL_RSA_SUPPORT
 #include <openssl/rsa.h>
@@ -2823,26 +2822,31 @@ static int swoole_mysql_onHandShake(mysql_client *client TSRMLS_DC)
 
     buffer->length += n;
 
-    int ret;
+    int ret = 0;
+
+    _again:
     swTraceLog(SW_TRACE_MYSQL_CLIENT, "handshake on %d", client->handshake);
-    if (client->handshake == SW_MYSQL_HANDSHAKE_WAIT_REQUEST)
+
+    switch(client->handshake)
+    {
+    case SW_MYSQL_HANDSHAKE_WAIT_REQUEST:
     {
         ret = mysql_handshake(connector, buffer->str, buffer->length);
 
-        _send:
         if (ret < 0)
         {
             goto _error;
         }
         else if (ret > 0)
         {
+            _send:
             if (cli->send(cli, connector->buf, connector->packet_length + 4, 0) < 0)
             {
                 system_call_error: connector->error_code = errno;
                 connector->error_msg = strerror(errno);
                 connector->error_length = strlen(connector->error_msg);
                 swoole_mysql_onConnect(client TSRMLS_CC);
-                return SW_OK; //wait the next package
+                return SW_OK;
             }
             else
             {
@@ -2852,37 +2856,76 @@ static int swoole_mysql_onHandShake(mysql_client *client TSRMLS_DC)
                 client->handshake = ret;
             }
         }
+        break;
     }
-    else if (client->handshake == SW_MYSQL_HANDSHAKE_WAIT_SWITCH)
+    case SW_MYSQL_HANDSHAKE_WAIT_SWITCH:
     {
         // handle auth switch request
-        ret = mysql_auth_switch(connector, buffer->str, buffer->length);
-        goto _send;
+        switch (ret = mysql_auth_switch(connector, buffer->str, buffer->length))
+        {
+        case SW_AGAIN:
+            return SW_OK;
+        default:
+            goto _send;
+        }
     }
-    else if (client->handshake == SW_MYSQL_HANDSHAKE_WAIT_SIGNATURE)
+    case SW_MYSQL_HANDSHAKE_WAIT_SIGNATURE:
     {
-        if (mysql_parse_auth_signature(buffer, connector) == SW_MYSQL_AUTH_SIGNATURE_SUCCESS)
+        switch (mysql_parse_auth_signature(buffer, connector))
+        {
+        case SW_MYSQL_AUTH_SIGNATURE_SUCCESS:
         {
             client->handshake = SW_MYSQL_HANDSHAKE_WAIT_RESULT;
-            if (buffer->offset < buffer->length)
-            {
-                // may be more packages
-                goto _result;
-            }
-            else
-            {
-                swString_clear(buffer);
-            }
+            break;
         }
-        else
+        case SW_MYSQL_AUTH_SIGNATURE_FULL_AUTH_REQUIRED:
+        {
+            // send response and wait RSA public key
+            ret = SW_MYSQL_HANDSHAKE_WAIT_RSA; // handshake = ret
+            goto _send;
+        }
+        default:
         {
             goto _error;
         }
+        }
+
+        // may be more packages
+        if (buffer->offset < buffer->length)
+        {
+            goto _again;
+        }
+        else
+        {
+            swString_clear(buffer);
+        }
+        break;
     }
-    else
+    case SW_MYSQL_HANDSHAKE_WAIT_RSA:
     {
-        _result:
-        ret = mysql_get_result(connector, buffer->str + buffer->offset, buffer->length - buffer->offset);
+        // encode by RSA
+#ifdef SW_MYSQL_RSA_SUPPORT
+        switch (mysql_parse_rsa(connector, SWSTRING_CURRENT_VL(buffer)))
+        {
+        case SW_AGAIN:
+            return SW_OK;
+        case SW_OK:
+            ret = SW_MYSQL_HANDSHAKE_WAIT_RESULT; // handshake = ret
+            goto _send;
+        default:
+            goto _error;
+        }
+#else
+        connector->error_code = -1;
+        connector->error_msg = "MySQL8 RSA-Auth need enable OpenSSL!";
+        connector->error_length = strlen(connector->error_msg);
+        swoole_mysql_onConnect(client TSRMLS_CC);
+        return SW_OK;
+#endif
+    }
+    default:
+    {
+        ret = mysql_get_result(connector, SWSTRING_CURRENT_VL(buffer));
         if (ret < 0)
         {
             _error:
@@ -2895,6 +2938,7 @@ static int swoole_mysql_onHandShake(mysql_client *client TSRMLS_DC)
             swoole_mysql_onConnect(client TSRMLS_CC);
         }
         // else recv again
+    }
     }
 
     return SW_OK;

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -60,8 +60,18 @@ enum mysql_command
 enum mysql_handshake_state
 {
     SW_MYSQL_HANDSHAKE_WAIT_REQUEST,
+    SW_MYSQL_HANDSHAKE_WAIT_SWITCH,
+    SW_MYSQL_HANDSHAKE_WAIT_SIGNATURE,
     SW_MYSQL_HANDSHAKE_WAIT_RESULT,
     SW_MYSQL_HANDSHAKE_COMPLETED,
+};
+
+enum mysql_auth_signature
+{
+    SW_MYSQL_AUTH_SIGNATURE_ERROR = 0x00, // get signature failed
+    SW_MYSQL_AUTH_SIGNATURE = 0x01,
+    SW_MYSQL_AUTH_SIGNATURE_SUCCESS = 0x03,
+    SW_MYSQL_AUTH_SIGNATURE_FULL_AUTH_REQUIRED = 0x04 //use the wrong hash
 };
 
 enum mysql_read_state
@@ -416,6 +426,8 @@ typedef struct _mysql_client
 int mysql_get_result(mysql_connector *connector, char *buf, int len);
 int mysql_get_charset(char *name);
 int mysql_handshake(mysql_connector *connector, char *buf, int len);
+uint8_t mysql_parse_auth_signature(char *buf, int len);
+int mysql_auth_switch(mysql_connector *connector, char *buf, int len);
 int mysql_request(swString *sql, swString *buffer);
 int mysql_prepare(swString *sql, swString *buffer);
 int mysql_response(mysql_client *client);

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -426,7 +426,7 @@ typedef struct _mysql_client
 int mysql_get_result(mysql_connector *connector, char *buf, int len);
 int mysql_get_charset(char *name);
 int mysql_handshake(mysql_connector *connector, char *buf, int len);
-uint8_t mysql_parse_auth_signature(char *buf, int len);
+uint8_t mysql_parse_auth_signature(swString *buffer);
 int mysql_auth_switch(mysql_connector *connector, char *buf, int len);
 int mysql_request(swString *sql, swString *buffer);
 int mysql_prepare(swString *sql, swString *buffer);

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -76,6 +76,10 @@ enum mysql_auth_signature
     SW_MYSQL_AUTH_SIGNATURE_FULL_AUTH_REQUIRED = 0x04, //rsa required
 };
 
+// nonce: a number or bit string used only once, in security engineering
+// other names on doc: challenge/scramble/salt
+#define SW_MYSQL_NONCE_LENGTH 20
+
 enum mysql_read_state
 {
     SW_MYSQL_STATE_QUERY,
@@ -219,7 +223,7 @@ typedef struct
     uint8_t protocol_version;
     char *server_version;
     int connection_id;
-    char auth_plugin_data[21];
+    char auth_plugin_data[SW_MYSQL_NONCE_LENGTH + 1]; // nonce + '\0'
     uint8_t l_auth_plugin_data;
     char filler;
     int capability_flags;
@@ -254,7 +258,7 @@ typedef struct
     int packet_length;
     char buf[512];
 #ifdef SW_USE_OPENSSL
-    char auth_plugin_data[20]; // save challenge data for RSA auth
+    char auth_plugin_data[SW_MYSQL_NONCE_LENGTH]; // save challenge data for RSA auth
 #endif
 
     uint16_t error_code;

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -1755,7 +1755,7 @@ static int swoole_mysql_coro_onHandShake(mysql_client *client TSRMLS_DC)
     case SW_MYSQL_HANDSHAKE_WAIT_RSA:
     {
         // encode by RSA
-#ifdef SW_USE_OPENSSL
+#ifdef SW_MYSQL_RSA_SUPPORT
         switch (mysql_parse_rsa(connector, SWSTRING_CURRENT_VL(buffer)))
         {
         case SW_AGAIN:

--- a/tests/swoole_mysql_coro/procedure_in_fetch.phpt
+++ b/tests/swoole_mysql_coro/procedure_in_fetch.phpt
@@ -55,19 +55,23 @@ SQL;
         //PDO
         !extension_loaded('PDO') && exit;
         $_map = $map;
-        $pdo = new PDO(
-            "mysql:host=" . MYSQL_SERVER_HOST . ";dbname=" . MYSQL_SERVER_DB . ";charset=utf8",
-            MYSQL_SERVER_USER, MYSQL_SERVER_PWD
-        );
-        $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-        $stmt = $pdo->prepare("CALL reply(?)");
-        assert($stmt->execute(['hello mysql!']) === true);
-        do {
-            $res = $stmt->fetchAll();
-            assert(current($res[0]) === array_shift($_map));
-        } while ($ret = $stmt->nextRowset());
-        assert($stmt->rowCount() === 1, 'get the affected rows failed!');
-        assert(empty($_map), 'there are some results lost!');
+        try {
+            $pdo = new PDO(
+                "mysql:host=" . MYSQL_SERVER_HOST . ";dbname=" . MYSQL_SERVER_DB . ";charset=utf8",
+                MYSQL_SERVER_USER, MYSQL_SERVER_PWD
+            );
+            $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+            $stmt = $pdo->prepare("CALL reply(?)");
+            assert($stmt->execute(['hello mysql!']) === true);
+            do {
+                $res = $stmt->fetchAll();
+                assert(current($res[0]) === array_shift($_map));
+            } while ($ret = $stmt->nextRowset());
+            assert($stmt->rowCount() === 1, 'get the affected rows failed!');
+            assert(empty($_map), 'there are some results lost!');
+        } catch (\PDOException $e) {
+            assert($e->getCode() === 2054); // not support auth plugin
+        }
     }
 });
 ?>


### PR DESCRIPTION
1. 支持MySQL的新的默认认证方式(caching_sha2_password)
2. 支持在MySQL重启/用户权限刷新时, 通过RSA安全地向服务器发送密钥认证
3. 客户端拥有处理Auth Switch(服务器请求客户端更换认证方式)的能力

- onHandshake部分流程更加完备了, 具备一次性接收多个响应包和处理各种复杂状态的能力
- 分离了加密流程为mysql_auth_encrypt_dispatch, 利于复用代码
- PDO不支持MySQL8, 在单元测试中catch了相关错误跳过对比测试
