### PR TITLE
Fix warning.

### DIFF
--- a/src/network/Connection.c
+++ b/src/network/Connection.c
@@ -68,7 +68,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_trunk *chunk)
         ret = swoole_sendfile(conn->fd, task->fd, &task->offset, sendn);
     }
 
-    swTrace("ret=%d|task->offset=%ld|sendn=%d|filesize=%ld", ret, task->offset, sendn, task->length);
+    swTrace("ret=%d|task->offset=%ld|sendn=%d|filesize=%ld", ret, (long)task->offset, sendn, task->length);
 
     if (ret <= 0)
     {

--- a/src/os/base.c
+++ b/src/os/base.c
@@ -262,7 +262,7 @@ static void swAio_handler_stream_get_line(swAio_event *event)
     {
         avail = writepos - readpos;
 
-        swTraceLog(SW_TRACE_AIO, "readpos=%ld, writepos=%ld", readpos, writepos);
+        swTraceLog(SW_TRACE_AIO, "readpos=%ld, writepos=%ld", (long)readpos, (long)writepos);
 
         if (avail > 0)
         {

--- a/src/os/sendfile.c
+++ b/src/os/sendfile.c
@@ -34,7 +34,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
 #endif
 
     //sent_bytes = (off_t)size;
-    swTrace("send file, out_fd:%d, in_fd:%d, offset:%d, size:%ld", out_fd, in_fd, *offset, (long)size);
+    swTrace("send file, out_fd:%d, in_fd:%d, offset:%ld, size:%ld", out_fd, in_fd, (long)*offset, (long)size);
 
     do_sendfile:
 #ifdef __MACH__

--- a/src/protocol/Base.c
+++ b/src/protocol/Base.c
@@ -62,7 +62,7 @@ static sw_inline int swProtocol_split_package_by_eof(swProtocol *protocol, swCon
         eof_pos = swoole_strnpos(buffer->str + buffer->offset, buffer->length - buffer->offset, protocol->package_eof, protocol->package_eof_len);
     }
 
-    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[0] count=%d, length=%ld, size=%ld, offset=%ld.", count, buffer->length, buffer->size, buffer->offset);
+    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[0] count=%d, length=%ld, size=%ld, offset=%ld.", count, buffer->length, buffer->size, (long)buffer->offset);
 
     //waiting for more data
     if (eof_pos < 0)
@@ -122,7 +122,7 @@ static sw_inline int swProtocol_split_package_by_eof(swProtocol *protocol, swCon
             }
         }
     }
-    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[3] length=%ld, size=%ld, offset=%ld", buffer->length, buffer->size, buffer->offset);
+    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[3] length=%ld, size=%ld, offset=%ld", buffer->length, buffer->size, (long)buffer->offset);
     swString_clear(buffer);
     return SW_OK;
 }


### PR DESCRIPTION
看了下C89并不支持size_t(%zu)和off_t(%jd)的占位符...只能转为long了, 调试日志的warning比较碍眼, 不过问题不大.