### PR TITLE
Implement RFC-1011

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -66,9 +66,6 @@ PHP_ARG_WITH(jemalloc_dir, for jemalloc support,
 PHP_ARG_ENABLE(mysqlnd, enable mysqlnd support,
 [  --enable-mysqlnd       Do you have mysqlnd?], no, no)
 
-PHP_ARG_ENABLE(coroutine, whether to enable coroutine,
-[  --enable-coroutine      Enable coroutine (requires PHP >= 5.5)], yes, no)
-
 PHP_ARG_ENABLE(asan, whether to enable asan,
 [  --enable-asan      Enable asan], no, no)
 
@@ -280,10 +277,6 @@ if test "$PHP_SWOOLE" != "no"; then
     if test "$PHP_ASAN" != "no"; then
         PHP_DEBUG=1
         CFLAGS="$CFLAGS -fsanitize=address -fno-omit-frame-pointer"
-    fi
-
-    if test "$PHP_COROUTINE" != "no"; then
-        AC_DEFINE(SW_COROUTINE, 1, [enable ability of coroutine])
     fi
 
     if test "$PHP_TRACE_LOG" != "no"; then

--- a/examples/coroutine/enable_coroutine.php
+++ b/examples/coroutine/enable_coroutine.php
@@ -1,0 +1,27 @@
+<?php
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+$http = new swoole_http_server('127.0.0.1', 9501);
+
+$http->set([
+    'enable_coroutine' => false, // close build-in coroutine
+]);
+
+$http->on('workerStart', function () {
+    echo "Coroutine is " . (Co::getuid() > 0 ? 'enable' : 'disable');
+});
+
+$http->on("request", function (Request $request, Response $response) {
+    $response->header("Content-Type", "text/plain");
+    if ($request->server['request_uri'] == '/co') {
+        go(function () use ($response) {
+            $response->end("Hello Coroutine #" . Co::getuid());
+        });
+    } else {
+        $response->end("Hello Swoole #" . Co::getuid());
+    }
+});
+
+$http->start();

--- a/examples/coroutine/enable_coroutine.php
+++ b/examples/coroutine/enable_coroutine.php
@@ -10,7 +10,7 @@ $http->set([
 ]);
 
 $http->on('workerStart', function () {
-    echo "Coroutine is " . (Co::getuid() > 0 ? 'enable' : 'disable');
+    echo "Coroutine is " . (Co::getuid() > 0 ? 'enable' : 'disable')."\n";
 });
 
 $http->on("request", function (Request $request, Response $response) {

--- a/examples/timer/enable_coroutine.php
+++ b/examples/timer/enable_coroutine.php
@@ -1,0 +1,9 @@
+<?php
+swoole_async_set([
+    'enable_coroutine' => false
+]);
+swoole_timer_tick(1000, function () {
+    $uid = Co::getuid();
+    assert($uid === -1);
+    echo "#{$uid}\n";
+});

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -2087,6 +2087,7 @@ typedef struct
     swTimer timer;
 
     uint8_t running :1;
+    uint8_t enable_coroutine :1;
     uint8_t use_timerfd :1;
     uint8_t use_signalfd :1;
     uint8_t enable_signalfd :1;

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -42,6 +42,7 @@ void swoole_init(void)
     bzero(sw_error, SW_ERROR_MSG_SIZE);
 
     SwooleG.running = 1;
+    SwooleG.enable_coroutine = 1;
     sw_errno = 0;
 
     SwooleG.log_fd = STDOUT_FILENO;

--- a/swoole_async.c
+++ b/swoole_async.c
@@ -876,7 +876,7 @@ PHP_FUNCTION(swoole_async_set)
 {
     if (SwooleG.main_reactor != NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "eventLoop has already been created. unable to create swoole_server.");
+        swoole_php_fatal_error(E_ERROR, "eventLoop has already been created. unable to change settings.");
         RETURN_FALSE;
     }
 
@@ -945,6 +945,11 @@ PHP_FUNCTION(swoole_async_set)
     {
         convert_to_boolean(v);
         SwooleG.use_async_resolver = Z_BVAL_P(v);
+    }
+    if (php_swoole_array_get_value(vht, "enable_coroutine", v))
+    {
+        convert_to_boolean(v);
+        SwooleG.enable_coroutine = Z_BVAL_P(v);
     }
 #if defined(HAVE_REUSEPORT) && defined(HAVE_EPOLL)
     //reuse port

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -23,6 +23,8 @@
 #endif
 #endif
 
+#define SW_COROUTINE               1
+
 #define SW_MAX_FDTYPE              32   //32 kinds of event
 #define SW_MAX_HOOK_TYPE           32
 #define SW_ERROR_MSG_SIZE          512

--- a/swoole_http_server.c
+++ b/swoole_http_server.c
@@ -1125,11 +1125,6 @@ static int http_onReceive(swServer *serv, swEventData *req)
     else
     {
         zval *retval = NULL;
-#ifndef SW_COROUTINE
-        zval **args[2];
-#else
-        zval *args[2];
-#endif
 
         zval *zrequest_object = ctx->request.zobject;
         zval *zresponse_object = ctx->response.zobject;
@@ -1183,14 +1178,6 @@ static int http_onReceive(swServer *serv, swEventData *req)
             goto free_object;
         }
 
-#ifndef SW_COROUTINE
-        args[0] = &zrequest_object;
-        args[1] = &zresponse_object;
-#else
-        args[0] = zrequest_object;
-        args[1] = zresponse_object;
-#endif
-
         int callback_type = 0;
         if (conn->websocket_status == WEBSOCKET_STATUS_CONNECTION)
         {
@@ -1210,31 +1197,39 @@ static int http_onReceive(swServer *serv, swEventData *req)
             }
         }
 
-#ifndef SW_COROUTINE
-        zcallback = php_swoole_server_get_callback(serv, req->info.from_fd, callback_type);
-#ifdef PHP_SWOOLE_ENABLE_FASTCALL
-        zend_fcall_info_cache *fci_cache = php_swoole_server_get_cache(serv, req->info.from_fd, callback_type);
-        if (sw_call_user_function_fast(zcallback, fci_cache, &retval, 2, args TSRMLS_CC) == FAILURE)
-#else
-        if (sw_call_user_function_ex(EG(function_table), NULL, zcallback, &retval, 2, args, 0, NULL TSRMLS_CC) == FAILURE)
-#endif
+        if (SwooleG.enable_coroutine)
         {
-            swoole_php_error(E_WARNING, "onRequest handler error");
-        }
-#else
-        zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, req->info.from_fd, callback_type);
-        int ret = coro_create(cache, args, 2, &retval, NULL, NULL);
-        if (ret < 0)
-        {
-            sw_zval_ptr_dtor(&zrequest_object);
-            sw_zval_ptr_dtor(&zresponse_object);
-            if (ret == CORO_LIMIT)
+            zval *args[2];
+            args[0] = zrequest_object;
+            args[1] = zresponse_object;
+
+            zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, req->info.from_fd, callback_type);
+            int ret = coro_create(cache, args, 2, &retval, NULL, NULL);
+            if (ret < 0)
             {
-                serv->factory.end(&SwooleG.serv->factory, fd);
+                sw_zval_ptr_dtor(&zrequest_object);
+                sw_zval_ptr_dtor(&zresponse_object);
+                if (ret == CORO_LIMIT)
+                {
+                    serv->factory.end(&SwooleG.serv->factory, fd);
+                }
+                return SW_OK;
             }
-            return SW_OK;
         }
-#endif
+        else
+        {
+            zval **args[2];
+            args[0] = &zrequest_object;
+            args[1] = &zresponse_object;
+
+            zcallback = php_swoole_server_get_callback(serv, req->info.from_fd, callback_type);
+            zend_fcall_info_cache *fci_cache = php_swoole_server_get_cache(serv, req->info.from_fd, callback_type);
+            if (sw_call_user_function_fast(zcallback, fci_cache, &retval, 2, args TSRMLS_CC) == FAILURE)
+            {
+                swoole_php_error(E_WARNING, "onRequest handler error");
+            }
+        }
+
         if (EG(exception))
         {
             zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);
@@ -1256,6 +1251,7 @@ static int http_onReceive(swServer *serv, swEventData *req)
             sw_zval_ptr_dtor(&retval);
         }
     }
+
     return SW_OK;
 }
 

--- a/swoole_redis_server.c
+++ b/swoole_redis_server.c
@@ -196,43 +196,47 @@ static int redis_onReceive(swServer *serv, swEventData *req)
     SW_MAKE_STD_ZVAL(zfd);
     ZVAL_LONG(zfd, fd);
 
-#ifndef SW_COROUTINE
-    zval **args[2];
-    zval *zcallback = sw_zend_read_property(swoole_redis_server_class_entry_ptr, zobject, _command, _command_len, 1 TSRMLS_CC);
-    if (!zcallback || ZVAL_IS_NULL(zcallback))
+    if (SwooleG.enable_coroutine)
     {
-        length = snprintf(err_msg, sizeof(err_msg), "-ERR unknown command '%*s'\r\n", command_len, command);
-        swServer_tcp_send(serv, fd, err_msg, length);
-        return SW_OK;
-    }
-    args[0] = &zfd;
-    args[1] = &zparams;
+        zval *index = sw_zend_read_property(swoole_redis_server_class_entry_ptr, zobject, _command, _command_len, 1 TSRMLS_CC);
+        if (!index || ZVAL_IS_NULL(index))
+        {
+            length = snprintf(err_msg, sizeof(err_msg), "-ERR unknown command '%*s'\r\n", command_len, command);
+            swServer_tcp_send(serv, fd, err_msg, length);
+            return SW_OK;
+        }
+        zval *args[2];
+        args[0] = zfd;
+        args[1] = zparams;
 
-    if (sw_call_user_function_ex(EG(function_table), NULL, zcallback, &retval, 2, args, 0, NULL TSRMLS_CC) == FAILURE)
-    {
-        swoole_php_error(E_WARNING, "command handler error.");
+        zend_fcall_info_cache *cache = func_cache_array.array[Z_LVAL_P(index)];
+        if (coro_create(cache, args, 2, &retval, NULL, NULL) < 0)
+        {
+            sw_zval_ptr_dtor(&zfd);
+            sw_zval_ptr_dtor(&zdata);
+            sw_zval_ptr_dtor(&zparams);
+            return SW_OK;
+        }
     }
-#else
-    zval *index = sw_zend_read_property(swoole_redis_server_class_entry_ptr, zobject, _command, _command_len, 1 TSRMLS_CC);
-    if (!index || ZVAL_IS_NULL(index))
+    else
     {
-        length = snprintf(err_msg, sizeof(err_msg), "-ERR unknown command '%*s'\r\n", command_len, command);
-        swServer_tcp_send(serv, fd, err_msg, length);
-        return SW_OK;
-    }
-    zval *args[2];
-    args[0] = zfd;
-    args[1] = zparams;
+        zval **args[2];
+        zval *zcallback = sw_zend_read_property(swoole_redis_server_class_entry_ptr, zobject, _command, _command_len, 1 TSRMLS_CC);
+        if (!zcallback || ZVAL_IS_NULL(zcallback))
+        {
+            length = snprintf(err_msg, sizeof(err_msg), "-ERR unknown command '%*s'\r\n", command_len, command);
+            swServer_tcp_send(serv, fd, err_msg, length);
+            return SW_OK;
+        }
+        args[0] = &zfd;
+        args[1] = &zparams;
 
-    zend_fcall_info_cache *cache = func_cache_array.array[Z_LVAL_P(index)];
-    if (coro_create(cache, args, 2, &retval, NULL, NULL) < 0)
-    {
-        sw_zval_ptr_dtor(&zfd);
-        sw_zval_ptr_dtor(&zdata);
-        sw_zval_ptr_dtor(&zparams);
-        return SW_OK;
+        if (sw_call_user_function_ex(EG(function_table), NULL, zcallback, &retval, 2, args, 0, NULL TSRMLS_CC) == FAILURE)
+        {
+            swoole_php_error(E_WARNING, "command handler error.");
+        }
     }
-#endif
+
     if (EG(exception))
     {
         zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);

--- a/swoole_server.c
+++ b/swoole_server.c
@@ -1619,17 +1619,11 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
     zval *zserv = (zval *) serv->ptr2;
     zval *zfd;
     zval *zfrom_id;
-#ifdef SW_COROUTINE
-    zval *args[3];
-#else
-    zval **args[3];
-#endif
     zval *retval = NULL;
 
     SWOOLE_GET_TSRMLS;
 
-#ifdef SW_COROUTINE
-    if (serv->send_yield)
+    if (SwooleG.enable_coroutine && serv->send_yield)
     {
         swLinkedList *coros_list = swHashMap_find_int(send_coroutine_map, info->fd);
         if (coros_list)
@@ -1652,7 +1646,6 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
             }
         }
     }
-#endif
 
     SW_MAKE_STD_ZVAL(zfd);
     ZVAL_LONG(zfd, info->fd);
@@ -1660,42 +1653,46 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
     SW_MAKE_STD_ZVAL(zfrom_id);
     ZVAL_LONG(zfrom_id, info->from_id);
 
-#ifndef SW_COROUTINE
-    args[0] = &zserv;
-    args[1] = &zfd;
-    args[2] = &zfrom_id;
-#else
-    args[0] = zserv;
-    args[1] = zfd;
-    args[2] = zfrom_id;
-#endif
+    if (SwooleG.enable_coroutine)
+    {
+        zval *args[3];
+        args[0] = zserv;
+        args[1] = zfd;
+        args[2] = zfrom_id;
 
-#ifndef SW_COROUTINE
-    zval *callback = php_swoole_server_get_callback(serv, info->from_fd, SW_SERVER_CB_onClose);
-    if (callback == NULL || ZVAL_IS_NULL(callback))
-    {
-        return;
+        zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, info->from_fd, SW_SERVER_CB_onClose);
+        if (cache == NULL)
+        {
+            return;
+        }
+
+        int ret = coro_create(cache, args, 3, &retval, NULL, NULL);
+        sw_zval_ptr_dtor(&zfd);
+        sw_zval_ptr_dtor(&zfrom_id);
+
+        if (ret < 0)
+        {
+            return;
+        }
     }
-    if (sw_call_user_function_ex(EG(function_table), NULL, callback, &retval, 3, args, 0, NULL TSRMLS_CC) == FAILURE)
+    else
     {
-        swoole_php_error(E_WARNING, "onClose handler error.");
-    }
-#else
-    zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, info->from_fd, SW_SERVER_CB_onClose);
-    if (cache == NULL)
-    {
-        return;
+        zval **args[3];
+        args[0] = &zserv;
+        args[1] = &zfd;
+        args[2] = &zfrom_id;
+
+        zval *callback = php_swoole_server_get_callback(serv, info->from_fd, SW_SERVER_CB_onClose);
+        if (callback == NULL || ZVAL_IS_NULL(callback))
+        {
+            return;
+        }
+        if (sw_call_user_function_ex(EG(function_table), NULL, callback, &retval, 3, args, 0, NULL TSRMLS_CC) == FAILURE)
+        {
+            swoole_php_error(E_WARNING, "onClose handler error.");
+        }
     }
 
-    int ret = coro_create(cache, args, 3, &retval, NULL, NULL);
-    sw_zval_ptr_dtor(&zfd);
-    sw_zval_ptr_dtor(&zfrom_id);
-
-    if (ret < 0)
-    {
-        return;
-    }
-#endif
     if (EG(exception))
     {
         zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);

--- a/swoole_server.c
+++ b/swoole_server.c
@@ -2169,6 +2169,11 @@ PHP_METHOD(swoole_server, set)
         serv->max_wait_time = (uint32_t) Z_LVAL_P(v);
     }
 #ifdef SW_COROUTINE
+    if (php_swoole_array_get_value(vht, "enable_coroutine", v))
+    {
+        convert_to_double(v);
+        SwooleG.enable_coroutine = Z_DVAL_P(v);
+    }
     if (php_swoole_array_get_value(vht, "max_coro_num", v) || php_swoole_array_get_value(vht, "max_coroutine", v))
     {
         convert_to_long(v);

--- a/swoole_server.c
+++ b/swoole_server.c
@@ -1290,7 +1290,6 @@ static void php_swoole_onShutdown(swServer *serv)
     SwooleG.lock.unlock(&SwooleG.lock);
 }
 
-#ifdef SW_COROUTINE
 static void php_swoole_onWorkerStart_coroutine(zval *zserv, zval *zworker_id)
 {
     zval *retval = NULL;
@@ -1319,7 +1318,6 @@ static void php_swoole_onWorkerStart_coroutine(zval *zserv, zval *zworker_id)
         sw_zval_ptr_dtor(&retval);
     }
 }
-#endif
 
 static void php_swoole_onWorkerStart_callback(zval *zserv, zval *zworker_id)
 {
@@ -1391,13 +1389,12 @@ static void php_swoole_onWorkerStart(swServer *serv, int worker_id)
     {
         return;
     }
-#ifdef SW_COROUTINE
-    if (worker_id < serv->worker_num)
+
+    if (SwooleG.enable_coroutine && worker_id < serv->worker_num)
     {
         php_swoole_onWorkerStart_coroutine(zserv, zworker_id);
     }
     else
-#endif
     {
         php_swoole_onWorkerStart_callback(zserv, zworker_id);
     }

--- a/swoole_timer.c
+++ b/swoole_timer.c
@@ -71,7 +71,6 @@ void php_swoole_clear_all_timer()
     }
 }
 
-#ifdef SW_COROUTINE
 int php_swoole_add_timer_coro(int ms, int cli_fd, long *timeout_id, void* param, swLinkedList_node **node TSRMLS_DC) //void *
 {
     if (SwooleG.serv && swIsMaster())
@@ -177,7 +176,6 @@ int php_swoole_del_timer_coro(swTimer_node *tnode TSRMLS_DC)
     efree(scc);
     return SW_OK;
 }
-#endif
 
 long php_swoole_add_timer(int ms, zval *callback, zval *param, int persistent TSRMLS_DC)
 {
@@ -193,15 +191,11 @@ long php_swoole_add_timer(int ms, zval *callback, zval *param, int persistent TS
     }
 
     char *func_name = NULL;
-#ifndef SW_COROUTINE
-    if (!sw_zend_is_callable(callback, 0, &func_name TSRMLS_CC))
-    {
-#else
+
     zend_fcall_info_cache *func_cache = emalloc(sizeof(zend_fcall_info_cache));
     if (!sw_zend_is_callable_ex(callback, NULL, 0, &func_name, NULL, func_cache, NULL TSRMLS_CC))
     {
         efree(func_cache);
-#endif
         efree(func_name);
         swoole_php_fatal_error(E_ERROR, "Function '%s' is not callable", func_name);
         return SW_ERR;
@@ -216,7 +210,6 @@ long php_swoole_add_timer(int ms, zval *callback, zval *param, int persistent TS
     php_swoole_check_timer(ms);
     swTimer_callback *cb = emalloc(sizeof(swTimer_callback));
 
-#if PHP_MAJOR_VERSION >= 7
     cb->data = &cb->_data;
     cb->callback = &cb->_callback;
     memcpy(cb->callback, callback, sizeof(zval));
@@ -228,14 +221,16 @@ long php_swoole_add_timer(int ms, zval *callback, zval *param, int persistent TS
     {
         cb->data = NULL;
     }
-#else
-    cb->data = param;
-    cb->callback = callback;
-#endif
 
-#ifdef SW_COROUTINE
-    cb->func_cache = func_cache;
-#endif
+
+    if (SwooleG.enable_coroutine)
+    {
+        cb->func_cache = func_cache;
+    }
+    else
+    {
+        efree(func_cache);
+    }
 
     swTimerCallback timer_func;
     if (persistent)
@@ -283,24 +278,17 @@ static int php_swoole_del_timer(swTimer_node *tnode TSRMLS_DC)
     {
         sw_zval_ptr_dtor(&cb->data);
     }
-#ifdef SW_COROUTINE
-    if (cb->func_cache)
+    if (SwooleG.enable_coroutine && cb->func_cache)
     {
         efree(cb->func_cache);
     }
-#endif
     efree(cb);
     return SW_OK;
 }
 
 void php_swoole_onTimeout(swTimer *timer, swTimer_node *tnode)
 {
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH_FROM_CTX(sw_thread_ctx ? sw_thread_ctx : NULL);
-#endif
-
-#ifdef SW_COROUTINE
-    if (tnode->type == SW_TIMER_TYPE_CORO)
+    if (tnode->type == SW_TIMER_TYPE_CORO) // coroutine timeout
     {
         swTimer_coro_callback *scc = tnode->data;
         // del the reactor handle
@@ -314,45 +302,55 @@ void php_swoole_onTimeout(swTimer *timer, swTimer_node *tnode)
 
         php_swoole_del_timer_coro(tnode TSRMLS_CC);
     }
-    else
-#endif
+    else // swoole_timer
     {
         swTimer_callback *cb = tnode->data;
         zval *retval = NULL;
-#ifndef SW_COROUTINE
-        zval **args[2];
-#else
-        zval *args[2];
-#endif
-        int argc;
 
-        if (NULL == cb->data)
+        if (SwooleG.enable_coroutine)
         {
-            argc = 0;
-            args[0] = NULL;
+            zval *args[2];
+            int argc;
+
+            if (NULL == cb->data)
+            {
+                argc = 0;
+                args[0] = NULL;
+            }
+            else
+            {
+                argc = 1;
+                args[0] = cb->data;
+            }
+            int ret = coro_create(cb->func_cache, args, argc, &retval, NULL, NULL);
+            if (CORO_LIMIT == ret)
+            {
+                swoole_php_fatal_error(E_WARNING, "swoole_timer: coroutine limit");
+                return;
+            }
         }
         else
         {
-            argc = 1;
-#ifndef SW_COROUTINE
-            args[0] = &cb->data;
-        }
+            zval **args[2];
+            int argc;
 
-        if (sw_call_user_function_ex(EG(function_table), NULL, cb->callback, &retval, argc, args, 0, NULL TSRMLS_CC) == FAILURE)
-        {
-            swoole_php_fatal_error(E_WARNING, "swoole_timer: onTimeout handler error");
-            return;
+            if (NULL == cb->data)
+            {
+                argc = 0;
+                args[0] = NULL;
+            }
+            else
+            {
+                argc = 1;
+                args[0] = &cb->data;
+            }
+
+            if (sw_call_user_function_ex(EG(function_table), NULL, cb->callback, &retval, argc, args, 0, NULL TSRMLS_CC) == FAILURE)
+            {
+                swoole_php_fatal_error(E_WARNING, "swoole_timer: onTimeout handler error");
+                return;
+            }
         }
-#else
-            args[0] = cb->data;
-        }
-        int ret = coro_create(cb->func_cache, args, argc, &retval, NULL, NULL);
-        if (CORO_LIMIT == ret)
-        {
-            swoole_php_fatal_error(E_WARNING, "swoole_timer: coroutine limit");
-            return;
-        }
-#endif
 
         if (EG(exception))
         {
@@ -368,16 +366,7 @@ void php_swoole_onTimeout(swTimer *timer, swTimer_node *tnode)
 
 void php_swoole_onInterval(swTimer *timer, swTimer_node *tnode)
 {
-#if PHP_MAJOR_VERSION < 7
-    TSRMLS_FETCH_FROM_CTX(sw_thread_ctx ? sw_thread_ctx : NULL);
-#endif
-
     zval *retval = NULL;
-#ifndef SW_COROUTINE
-    zval **args[2];
-#else
-    zval *args[2];
-#endif
     int argc = 1;
 
     zval *ztimer_id;
@@ -387,32 +376,41 @@ void php_swoole_onInterval(swTimer *timer, swTimer_node *tnode)
     SW_MAKE_STD_ZVAL(ztimer_id);
     ZVAL_LONG(ztimer_id, tnode->id);
 
-    if (cb->data)
+    if (SwooleG.enable_coroutine)
     {
-        argc = 2;
-        sw_zval_add_ref(&cb->data);
-#ifndef SW_COROUTINE
-        args[1] = &cb->data;
-    }
-    args[0] = &ztimer_id;
+        zval *args[2];
+        if (cb->data)
+        {
+            argc = 2;
+            sw_zval_add_ref(&cb->data);
+            args[1] = cb->data;
+        }
+        args[0] = ztimer_id;
 
-    if (sw_call_user_function_ex(EG(function_table), NULL, cb->callback, &retval, argc, args, 0, NULL TSRMLS_CC) == FAILURE)
+        int ret = coro_create(cb->func_cache, args, argc, &retval, NULL, NULL);
+        if (CORO_LIMIT == ret)
+        {
+            swoole_php_fatal_error(E_WARNING, "swoole_timer: coroutine limit");
+            return;
+        }
+    }
+    else
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_timer: onTimerCallback handler error");
-        return;
-    }
-#else
-        args[1] = cb->data;
-    }
-    args[0] = ztimer_id;
+        zval **args[2];
+        if (cb->data)
+        {
+            argc = 2;
+            sw_zval_add_ref(&cb->data);
+            args[1] = &cb->data;
+        }
+        args[0] = &ztimer_id;
 
-    int ret = coro_create(cb->func_cache, args, argc, &retval, NULL, NULL);
-    if (CORO_LIMIT == ret)
-    {
-        swoole_php_fatal_error(E_WARNING, "swoole_timer: coroutine limit");
-        return;
+        if (sw_call_user_function_ex(EG(function_table), NULL, cb->callback, &retval, argc, args, 0, NULL TSRMLS_CC) == FAILURE)
+        {
+            swoole_php_fatal_error(E_WARNING, "swoole_timer: onTimerCallback handler error");
+            return;
+        }
     }
-#endif
 
     if (EG(exception))
     {

--- a/swoole_websocket_server.c
+++ b/swoole_websocket_server.c
@@ -259,37 +259,39 @@ int swoole_websocket_onMessage(swEventData *req)
 
     swServer *serv = SwooleG.serv;
     zval *zserv = (zval *) serv->ptr2;
-
-#ifndef SW_COROUTINE
-    zval **args[2];
-    args[0] = &zserv;
-    args[1] = &zframe;
-#else
-    zval *args[2];
-    args[0] = zserv;
-    args[1] = zframe;
-#endif
-
     zval *retval = NULL;
 
-#ifndef SW_COROUTINE
-    zend_fcall_info_cache *fci_cache = php_swoole_server_get_cache(serv, req->info.from_fd, SW_SERVER_CB_onMessage);
-    zval *zcallback = php_swoole_server_get_callback(SwooleG.serv, req->info.from_fd, SW_SERVER_CB_onMessage);
-    if (sw_call_user_function_fast(zcallback, fci_cache, &retval, 2, args TSRMLS_CC) == FAILURE)
+    if (SwooleG.enable_coroutine)
     {
-        swoole_php_error(E_WARNING, "onMessage handler error");
+        zval *args[2];
+        args[0] = zserv;
+        args[1] = zframe;
+
+        zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, req->info.from_fd, SW_SERVER_CB_onMessage);
+        int ret = coro_create(cache, args, 2, &retval, NULL, NULL);
+        if (ret == CORO_LIMIT)
+        {
+            sw_zval_ptr_dtor(&zdata);
+            sw_zval_ptr_dtor(&zframe);
+            SwooleG.serv->factory.end(&SwooleG.serv->factory, fd);
+            return SW_OK;
+        }
     }
-#else
-    zend_fcall_info_cache *cache = php_swoole_server_get_cache(serv, req->info.from_fd, SW_SERVER_CB_onMessage);
-    int ret = coro_create(cache, args, 2, &retval, NULL, NULL);
-    if (ret == CORO_LIMIT)
+    else
     {
-        sw_zval_ptr_dtor(&zdata);
-        sw_zval_ptr_dtor(&zframe);
-        SwooleG.serv->factory.end(&SwooleG.serv->factory, fd);
-        return SW_OK;
+        zval **args[2];
+        args[0] = &zserv;
+        args[1] = &zframe;
+
+        zend_fcall_info_cache *fci_cache = php_swoole_server_get_cache(serv, req->info.from_fd, SW_SERVER_CB_onMessage);
+        zval *zcallback = php_swoole_server_get_callback(SwooleG.serv, req->info.from_fd, SW_SERVER_CB_onMessage);
+
+        if (sw_call_user_function_fast(zcallback, fci_cache, &retval, 2, args TSRMLS_CC) == FAILURE)
+        {
+            swoole_php_error(E_WARNING, "onMessage handler error");
+        }
     }
-#endif
+
     if (EG(exception))
     {
         zend_exception_error(EG(exception), E_ERROR TSRMLS_CC);

--- a/tests/swoole_http_server/enable_coroutine.phpt
+++ b/tests/swoole_http_server/enable_coroutine.phpt
@@ -1,0 +1,44 @@
+--TEST--
+enable_coroutine: enable_coroutine setting in server
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/lib/curl.php';
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+$pm = new ProcessManager;
+$pm->parentFunc = function ($pid) {
+    echo curlGet('http://127.0.0.1:9501/') . "\n";
+    echo curlGet('http://127.0.0.1:9501/co') . "\n";
+    echo curlGet('http://127.0.0.1:9501/co') . "\n";
+    echo curlGet('http://127.0.0.1:9501/co') . "\n";
+    swoole_process::kill($pid);
+};
+$pm->childFunc = function () use ($pm) {
+    $http = new swoole_http_server('127.0.0.1', 9501);
+    $http->set([
+        'enable_coroutine' => false, // close build-in coroutine
+        'log_level' => -1
+    ]);
+    $http->on("request", function (Request $request, Response $response) {
+        $response->header("Content-Type", "text/plain");
+        if ($request->server['request_uri'] == '/co') {
+            go(function () use ($response) {
+                $response->end(Co::getuid());
+            });
+        } else {
+            $response->end(Co::getuid());
+        }
+    });
+    $http->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+-1
+1
+2
+3

--- a/tests/swoole_timer/enable_coroutine.phpt
+++ b/tests/swoole_timer/enable_coroutine.phpt
@@ -1,0 +1,17 @@
+--TEST--
+enable_coroutine: enable_coroutine setting
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+swoole_async_set([
+    'enable_coroutine' => false
+]);
+swoole_timer_after(1, function () {
+    $uid = Co::getuid();
+    echo "#{$uid}\n";
+});
+?>
+--EXPECT--
+#-1


### PR DESCRIPTION
RFC1011: https://github.com/swoole/rfc-chinese/issues/24
### 改动
- 去除--enable_coroutine编译参数, SW_COROUTINE默认开启
- 在server->set和swoole_async_set增加enable_coroutine选项
- 增加两个使用例子
- 增加两个单元测试

> enable_coroutine 选项相当于在回调中关闭以前版本的SW_COROUTINE宏开关, 关闭时在回调事件中不再创建协程，但是保留用户创建协程的能力。
---

### enable_coroutine影响范围
所有原有自动创建协程的回调, 包括
- onWorkerStart
- onConnect
- onOpen
- onReceive
- redis_onReceive
- onHandShake
- onPacket
- onRequest
- onMessage
- onPipeMessage
- onClose
- tick/after 定时器