### PR TITLE
Output controller in coroutine

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -203,16 +203,23 @@ int sw_coro_create(zend_fcall_info_cache *fci_cache, zval **argv, int argc, zval
     COROG.error = 0;
     COROG.coro_num++;
 
-    // clear output control global
-    while (OG(active))
+    zend_output_globals *coro_output_globals_ptr = NULL;
+    if (OG(active)) // save the current OG
     {
-        if (php_output_end() == FAILURE)
-        {
-            break;
-        }
+        coro_output_globals_ptr = (zend_output_globals *) emalloc(sizeof(zend_output_globals));
+        memcpy(coro_output_globals_ptr, &output_globals, sizeof(zend_output_globals));
+        php_output_activate();
     }
 
-    return coroutine_create(sw_coro_func, (void*) &php_args);
+    int ret = coroutine_create(sw_coro_func, (void*) &php_args);
+
+    if (coro_output_globals_ptr) // resume the parent OG
+    {
+        memcpy(&output_globals, coro_output_globals_ptr, sizeof(zend_output_globals));
+        efree(coro_output_globals_ptr);
+    }
+
+    return ret;
 }
 
 void sw_coro_save(zval *return_value, php_context *sw_current_context)

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -244,7 +244,7 @@ void sw_coro_save(zval *return_value, php_context *sw_current_context)
         zend_output_globals *coro_output_globals_ptr = (zend_output_globals *) emalloc(sizeof(zend_output_globals));
         memcpy(coro_output_globals_ptr, SWOG, sizeof(zend_output_globals));
         SWCC(current_coro_output_ptr) = coro_output_globals_ptr;
-        bzero(SWOG, sizeof(zend_output_globals));
+        php_output_activate(); // reset output
     }
     else
     {

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -203,21 +203,25 @@ int sw_coro_create(zend_fcall_info_cache *fci_cache, zval **argv, int argc, zval
     COROG.error = 0;
     COROG.coro_num++;
 
+    /**===================Before Coroutine======================**/
     zend_output_globals *coro_output_globals_ptr = NULL;
     if (OG(active)) // save the current OG
     {
         coro_output_globals_ptr = (zend_output_globals *) emalloc(sizeof(zend_output_globals));
         memcpy(coro_output_globals_ptr, &output_globals, sizeof(zend_output_globals));
-        php_output_activate();
+        php_output_activate(); // new output
     }
+    /**=========================================================**/
 
     int ret = coroutine_create(sw_coro_func, (void*) &php_args);
 
+    /**===================After Coroutine=======================**/
     if (coro_output_globals_ptr) // resume the parent OG
     {
         memcpy(&output_globals, coro_output_globals_ptr, sizeof(zend_output_globals));
         efree(coro_output_globals_ptr);
     }
+    /**========================================================**/
 
     return ret;
 }

--- a/swoole_coroutine.h
+++ b/swoole_coroutine.h
@@ -68,6 +68,7 @@ typedef struct _php_context
     coro_task *current_task;
     zend_vm_stack current_vm_stack;
     php_context_state state;
+    zend_output_globals *current_coro_output_ptr;
 } php_context;
 
 typedef struct _coro_global

--- a/tests/swoole_coroutine/output/in_nested_co.phpt
+++ b/tests/swoole_coroutine/output/in_nested_co.phpt
@@ -1,0 +1,25 @@
+--TEST--
+ob_nest: use ob_* in nest co
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../../include/bootstrap.php';
+go(function () {
+    ob_start();
+    echo "2\n"; // [#1] yield
+    go(function () {
+        echo "1\n"; // [#2] output: 1
+        co::sleep(0.001); // yield
+        // [#4] resume
+        ob_start(); // to buffer
+        echo "4\n";
+    }); // [#5] destroyed and output: 4
+    echo "3\n";
+}); // [#3] destroyed and output: 2 3
+?>
+--EXPECT--
+1
+2
+3
+4

--- a/tests/swoole_coroutine/output/output_control.phpt
+++ b/tests/swoole_coroutine/output/output_control.phpt
@@ -1,10 +1,10 @@
 --TEST--
 output_control: ob_* in coroutine
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
 --FILE--
 <?php
-require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../../include/bootstrap.php';
 // #co1
 go(function () {
     ob_start();

--- a/tests/swoole_coroutine/output_control.phpt
+++ b/tests/swoole_coroutine/output_control.phpt
@@ -1,0 +1,46 @@
+--TEST--
+output_control: ob_* in coroutine
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+// #co1
+go(function () {
+    ob_start();
+    echo "foo\n";
+    $ob_1 = (ob_get_status(true));
+    // yield and it will switch to #co2
+    co::sleep(0.1);
+    // resume to ob_1
+    assert($ob_1 === (ob_get_status(true)));
+    ob_start(); // ob_2
+    echo "bar\n";
+    assert(ob_get_status()['level'] === 1);
+    ob_start(); // ob_3
+    // yield and it will switch to #co3
+    co::sleep(0.2);
+    // resume to ob_3
+    assert(ob_get_status()['level'] === 2);
+    echo "baz\n";
+    assert(ob_get_clean() === "baz\n"); // clean ob_3
+    echo ob_get_clean(); // ob_1, ob_2, expect foo\n bar\n;
+});
+
+// #co2
+go(function () {
+    assert(ob_get_status(true) === []); //empty
+    assert(!ob_get_contents());
+    co::sleep(0.001);
+    assert(!ob_get_clean());
+});
+
+// #co3
+go(function () {
+    co::sleep(0.2);
+    assert(ob_get_status(true) === []); //empty
+});
+?>
+--EXPECT--
+foo
+bar


### PR DESCRIPTION
现在支持在协程中使用ob_*系列函数
协程挂起和恢复时会保存和切换全局OG
此修改避免了由于ob操作中存在业务逻辑代码, 切换协程导致的全局缓冲区错乱.

**在用户层感知下, 每个协程具有独立的缓冲区, 互不影响.**

注: 协程销毁时如果有缓冲未输出, 底层会自动输出缓冲区内容以释放内存.