### PR TITLE
编译报警： swoole_serialize.c:1316:16: 警告：变量‘index’被设定但未被使用

### DIFF
--- a/swoole_serialize.c
+++ b/swoole_serialize.c
@@ -1344,6 +1344,7 @@ static void* swoole_unserialize_object(void *buffer, zval *return_value, zend_uc
         {
             zend_hash_next_index_insert(Z_OBJPROP_P(return_value), data);
         }
+        (void)index;
     }
     ZEND_HASH_FOREACH_END();
     zval_dtor(&property);


### PR DESCRIPTION
~/swoole-src/swoole_serialize.c: 在函数‘swoole_unserialize_object’中:
~/swoole-src/swoole_serialize.c:1316:16: 警告：变量‘index’被设定但未被使用 [-Wunused-but-set-variable]
     zend_ulong index;

参考PHP源码中内核中sesson.c:2392 处理方式