### PR TITLE
Fix the http coro client bug

### DIFF
--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1312,12 +1312,6 @@ static PHP_METHOD(swoole_http_client, __construct)
     //init
     swoole_set_object(getThis(), NULL);
 
-    zval *headers;
-    SW_MAKE_STD_ZVAL(headers);
-    array_init(headers);
-    zend_update_property(swoole_http_client_class_entry_ptr, getThis(), ZEND_STRL("headers"), headers TSRMLS_CC);
-    sw_zval_ptr_dtor(&headers);
-
     http_client_property *hcc;
     hcc = (http_client_property*) emalloc(sizeof(http_client_property));
     bzero(hcc, sizeof(http_client_property));
@@ -1687,6 +1681,14 @@ int http_client_parser_on_header_value(php_http_parser *parser, const char *at, 
 
     zval* zobject = (zval*) http->cli->object;
     zval *headers = sw_zend_read_property(swoole_http_client_class_entry_ptr, zobject, ZEND_STRL("headers"), 0 TSRMLS_CC);
+    if (!headers || Z_TYPE_P(headers) != IS_ARRAY)
+    {
+        zval *headers;
+        SW_MAKE_STD_ZVAL(headers);
+        array_init(headers);
+        zend_update_property(swoole_http_client_class_entry_ptr, zobject, ZEND_STRL("headers"), headers TSRMLS_CC);
+        sw_zval_ptr_dtor(&headers);
+    }
 
     char *header_name = zend_str_tolower_dup(http->tmp_header_field_name, http->tmp_header_field_name_len);
     sw_add_assoc_stringl_ex(headers, header_name, http->tmp_header_field_name_len + 1, (char *) at, length, 1);
@@ -1725,7 +1727,7 @@ int http_client_parser_on_header_value(php_http_parser *parser, const char *at, 
         char keybuf[SW_HTTP_COOKIE_KEYLEN];
 
         zval *cookies = sw_zend_read_property(swoole_http_client_class_entry_ptr, zobject, ZEND_STRL("cookies"), 1 TSRMLS_CC);
-        if (!cookies || ZVAL_IS_NULL(cookies))
+        if (!cookies || Z_TYPE_P(cookies) != IS_ARRAY)
         {
             SW_MAKE_STD_ZVAL(cookies);
             array_init(cookies);
@@ -1735,7 +1737,7 @@ int http_client_parser_on_header_value(php_http_parser *parser, const char *at, 
         }
 
         zval *set_cookie_headers = sw_zend_read_property(swoole_http_client_class_entry_ptr, zobject, ZEND_STRL("set_cookie_headers"), 1 TSRMLS_CC);
-        if (!set_cookie_headers || ZVAL_IS_NULL(set_cookie_headers))
+        if (!set_cookie_headers || Z_TYPE_P(set_cookie_headers) != IS_ARRAY)
         {
             SW_MAKE_STD_ZVAL(set_cookie_headers);
             array_init(set_cookie_headers);

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -1324,12 +1324,6 @@ static PHP_METHOD(swoole_http_client_coro, __construct)
     //init
     swoole_set_object(getThis(), NULL);
 
-    zval *headers;
-    SW_MAKE_STD_ZVAL(headers);
-    array_init(headers);
-    zend_update_property(swoole_http_client_coro_class_entry_ptr, getThis(), ZEND_STRL("headers"), headers TSRMLS_CC);
-    sw_zval_ptr_dtor(&headers);
-
     http_client_property *hcc;
     hcc = (http_client_property*) emalloc(sizeof(http_client_property));
     bzero(hcc, sizeof(http_client_property));

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -491,7 +491,9 @@ void swoole_http_client_coro_init(int module_number TSRMLS_DC)
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("requestHeaders")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("requestBody")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("uploadFiles")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("downloadFile")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("headers")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("set_cookie_headers")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("cookies")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(swoole_http_client_coro_class_entry_ptr, SW_STRL("body")-1, ZEND_ACC_PUBLIC TSRMLS_CC);
 

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -191,6 +191,21 @@ static int http_client_coro_execute(zval *zobject, char *uri, zend_size_t uri_le
         return SW_ERR;
     }
 
+    // clear all when new request
+    zval *attr;
+    zend_update_property_long(swoole_http_client_coro_class_entry_ptr, zobject, ZEND_STRL("statusCode"), 0 TSRMLS_CC);
+    attr = sw_zend_read_property(swoole_http_client_coro_class_entry_ptr, zobject, ZEND_STRL("headers"), 1 TSRMLS_CC);
+    if (Z_TYPE_P(attr) == IS_ARRAY)
+    {
+        zend_hash_clean(Z_ARRVAL_P(attr));
+    }
+    attr = sw_zend_read_property(swoole_http_client_coro_class_entry_ptr, zobject, ZEND_STRL("set_cookie_headers"), 1 TSRMLS_CC);
+    if (Z_TYPE_P(attr) == IS_ARRAY)
+    {
+        zend_hash_clean(Z_ARRVAL_P(attr));
+    }
+    zend_update_property_string(swoole_http_client_coro_class_entry_ptr, zobject, ZEND_STRL("body"), "" TSRMLS_CC);
+
     http_client *http = swoole_get_object(zobject);
 
     //http is not null when keeping alive

--- a/tests/swoole_http_cilent_coro/disable_keep_alive.phpt
+++ b/tests/swoole_http_cilent_coro/disable_keep_alive.phpt
@@ -1,0 +1,31 @@
+--TEST--
+disable_keep_alive: disable keep alive
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+go(function () {
+    $host = 'www.qq.com';
+    $cli = new \Swoole\Coroutine\Http\Client($host, 80);
+    $cli->set([
+        'timeout' => 10,
+        'keep_alive' => false
+    ]);
+    $cli->setHeaders(['Host' => $host]);
+    $cli->get('/');
+    assert($cli->statusCode === 200);
+
+    assert($cli->get('/contract.shtml') === true);
+    assert($cli->statusCode === 200);
+
+    // failed clear
+    $cli->set([
+        'timeout' => 0.01
+    ]);
+    assert($cli->get('/contract.shtml') === false);
+    assert(empty($cli->headers));
+    assert(empty($cli->body));
+});
+?>
+--EXPECT--


### PR DESCRIPTION
1. keep-alive关闭时应主动关闭连接, 否则很容易在触发onClose前发起新的请求遭遇错误
2. 补全了缺失的类属性
3. 根据文档和用户预期, 连接被关闭时底层应当重新连接, 符合预期
4. 在发起新的请求时, 应清除上一次响应遗留的属性, 这样在发生错误时才能符合用户预期(如headers和body应当为空而不是上一次的值)

增加了一个关于关闭keep_alive 的单元测试