### PR TITLE
bugfix：reactor线程启动时缓存创建的bug

### DIFF
--- a/include/Server.h
+++ b/include/Server.h
@@ -516,7 +516,7 @@ struct _swServer
     swEventData *task_result;
 
     /**
-     * use process
+     * user process
      */
     uint16_t user_worker_num;
     swUserWorker_node *user_worker_list;

--- a/src/network/ReactorThread.c
+++ b/src/network/ReactorThread.c
@@ -1234,7 +1234,7 @@ static int swReactorThread_loop(swThreadParam *param)
     SwooleTG.id = reactor_id;
     SwooleTG.type = SW_THREAD_REACTOR;
 
-    if (serv->dispatch_mode == SW_MODE_BASE || serv->dispatch_mode == SW_MODE_THREAD)
+    if (serv->factory_mode == SW_MODE_BASE || serv->factory_mode == SW_MODE_THREAD)
     {
         SwooleTG.buffer_input = swServer_create_worker_buffer(serv);
         if (!SwooleTG.buffer_input)


### PR DESCRIPTION
1.bugfix：reactor线程启动时缓存创建的bug。是否创建应该根据serv->factory_mode判断，错写成了serv->dispatch_mode
2.另外修了一个注释的typo