### PR TITLE
Upgrade bug

### DIFF
--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1945,7 +1945,15 @@ int http_client_parser_on_message_complete(php_http_parser *parser)
     //http status code
     zend_update_property_long(swoole_http_client_class_entry_ptr, zobject, ZEND_STRL("statusCode"), http->parser.status_code TSRMLS_CC);
 
-    return 0;
+    if (parser->upgrade)
+    {
+        // return 1 will finish the parser and means yes we support it.
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 static PHP_METHOD(swoole_http_client, execute)

--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1917,6 +1917,13 @@ int http_client_parser_on_message_complete(php_http_parser *parser)
     http_client* http = (http_client*) parser->data;
     zval* zobject = (zval*) http->cli->object;
 
+    if (parser->upgrade && !http->upgrade)
+    {
+        // not support, continue.
+        parser->upgrade = 0;
+        return 0;
+    }
+
 #ifdef SW_HAVE_ZLIB
     if (http->gzip && http->body->length > 0)
     {

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -1396,7 +1396,14 @@ static PHP_METHOD(swoole_http_client_coro, __destruct)
     {
         if (hcc->message_queue)
         {
-            swLinkedList_free(hcc->message_queue);
+            swLinkedList *queue = hcc->message_queue;
+            zval *zframe;
+            while (queue->num != 0)
+            {
+                zframe = (zval *) swLinkedList_shift(queue);
+                efree(zframe);
+            }
+            sw_free(queue);
         }
         efree(hcc);
         swoole_set_property(getThis(), 0, NULL);

--- a/thirdparty/php_http_parser.c
+++ b/thirdparty/php_http_parser.c
@@ -1340,10 +1340,13 @@ size_t php_http_parser_execute (php_http_parser *parser,
         }
 
         /* Exit, the rest of the connect is in a different protocol. */
-//        if (parser->upgrade) {
-//          CALLBACK2(message_complete);
-//          return (p - data);
-//        }
+        if (parser->upgrade) {
+          CALLBACK2(message_complete);
+          // WARNING: Swoole changes!
+          // swoole only support websocket upgrade
+          // so we return 0 to continue but return else to finish it
+          // return (p - data);
+        }
 
         if (parser->flags & F_SKIPBODY) {
           CALLBACK2(message_complete);


### PR DESCRIPTION
之前对parser的改动不正确, 在此更正:
upgrade处, 利用CALLBACK2宏返回值为非0时会结束解析并返回, 为0时会继续执行的逻辑
即 
- 为0时表示不支持升级, 继续解析现有数据
- 为1时表示支持升级, 结束当前数据解析并返回