### PR TITLE
Remove old occurrence of configure.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ modules/*
 /config.status
 /config.sub
 /configure
-/configure.in
 /Makefile.fragments
 /Makefile.global
 /Makefile.objects


### PR DESCRIPTION
Hello, the `configure.ac` is the recommended file to use instead of the old `configure.in` which will be removed in autotools future versions. There was some minor old occurrence in the `.gitignore` file.

Thanks.