### PR TITLE
Fix client memory error

### DIFF
--- a/src/network/Client.c
+++ b/src/network/Client.c
@@ -458,6 +458,7 @@ static int swClient_close(swClient *cli)
         return SW_ERR;
     }
     cli->socket->closed = 1;
+    cli->released = 1;
 
     int fd = cli->socket->fd;
     assert(fd != 0);
@@ -531,8 +532,6 @@ static int swClient_close(swClient *cli)
     {
         cli->socket->active = 0;
     }
-
-    cli->released = 1;
 
     return close(fd);
 }

--- a/swoole_client.c
+++ b/swoole_client.c
@@ -430,10 +430,7 @@ static void client_onClose(swClient *cli)
 {
     SWOOLE_GET_TSRMLS;
     zval *zobject = (zval *) cli->object;
-    if (!cli->released)
-    {
-        php_swoole_client_free(zobject, cli TSRMLS_CC);
-    }
+    php_swoole_client_free(zobject, cli TSRMLS_CC);
     client_execute_callback(zobject, SW_CLIENT_CB_onClose);
     sw_zval_ptr_dtor(&zobject);
 }
@@ -1875,7 +1872,6 @@ static PHP_METHOD(swoole_client, close)
     if (force || !cli->keep || swConnection_error(SwooleG.error) == SW_CLOSE)
     {
         ret = cli->close(cli);
-        php_swoole_client_free(getThis(), cli TSRMLS_CC);
     }
     else
     {

--- a/swoole_client_coro.c
+++ b/swoole_client_coro.c
@@ -462,15 +462,13 @@ static void client_onClose(swClient *cli)
     SWOOLE_GET_TSRMLS;
     zval *zobject = cli->object;
     zend_update_property_bool(swoole_client_coro_class_entry_ptr, zobject, ZEND_STRL("connected"), 0 TSRMLS_CC);
-    if (cli->released)
-    {
-        return;
-    }
-
-    swDebug("client onClose");
-
     php_swoole_client_free(zobject, cli TSRMLS_CC);
-    client_execute_callback(zobject, SW_CLIENT_CB_onClose);
+
+    swoole_client_coro_property *ccp = swoole_get_property(zobject, 1);
+    if (ccp->iowait == SW_CLIENT_CORO_STATUS_WAIT)
+    {
+        client_execute_callback(zobject, SW_CLIENT_CB_onClose);
+    }
 }
 
 static void client_onError(swClient *cli)

--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -524,10 +524,9 @@ static void http_client_onClose(swClient *cli)
         sw_zval_free(hcc->onResponse);
         hcc->onResponse = NULL;
     }
-    if (!cli->released)
-    {
-        http_client_free(zobject TSRMLS_CC);
-    }
+
+    http_client_free(zobject TSRMLS_CC);
+
     http_client_execute_callback(zobject, SW_CLIENT_CB_onClose);
     sw_zval_ptr_dtor(&zobject);
 }
@@ -1594,7 +1593,6 @@ static PHP_METHOD(swoole_http_client, close)
     if (!cli->keep || swConnection_error(SwooleG.error) == SW_CLOSE)
     {
         ret = cli->close(cli);
-        http_client_free(getThis() TSRMLS_CC);
     }
     else
     {


### PR DESCRIPTION
由于在#363bd34的修改将cli->released = 1 和 返回判断 统一放到了swClient_close中, 导致原有的一些内存释放出现错误, 需要对所有相关代码进行修改, 涉及到五个client, 因为它们都有自己的onClose逻辑


- swoole_client
- swoole_client_coro
- swoole_http_client
- swoole_http_client_coro
- swoole_http_v2_client_coro


1. 把所有的free操作统一放在onClose中, 只要连接关闭了, 就触发内存释放

2. 在协程中, 之前依赖了cli的released来判断是否有协程需要resume, 现在逻辑变更, cli的内存被释放, 需要依靠其它更可靠的方式来判断

   - swoole_client_coro使用`ccp->iowait == SW_CLIENT_CORO_STATUS_WAIT`来判断

   - http_client_coro则使用`http->state != HTTP_CLIENT_STATE_BUSY`来判断
   - http2_coro则用`!hcc || hcc->iowait == 0`来判断

   完全移除了released判断依赖

**所有单元测试通过, valgrind测试不再有内存读写错误**

还有更多bug修复和代码清理需要在此pr之后, 否则无法正常运行