### PR TITLE
Http client reuse

### DIFF
--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -1210,6 +1210,62 @@ static int http_client_send_http_request(zval *zobject TSRMLS_DC)
     return ret;
 }
 
+void http_client_clear(http_client *http)
+{
+    // clear timeout timer
+    if (http->timer)
+    {
+        swTimer_del(&SwooleG.timer, http->timer);
+        http->timer = NULL;
+    }
+
+    // Tie up the loose ends
+    if (http->download)
+    {
+        close(http->file_fd);
+        http->download = 0;
+        http->file_fd = 0;
+#ifdef SW_HAVE_ZLIB
+        if (http->gzip_buffer)
+        {
+            swString_free(http->gzip_buffer);
+            http->gzip_buffer = NULL;
+        }
+#endif
+    }
+#ifdef SW_HAVE_ZLIB
+    if (http->gzip)
+    {
+        inflateEnd(&http->gzip_stream);
+        http->gzip = 0;
+    }
+#endif
+}
+
+void http_client_reset(zval *zobject TSRMLS_DC)
+{
+    http_client *http = swoole_get_object(zobject);
+
+    // not keep_alive, try close it actively, and it will destroy the http_client
+    if (http->keep_alive == 0 && http->state != HTTP_CLIENT_STATE_WAIT_CLOSE && !http->upgrade)
+    {
+        zval *retval = NULL;
+        sw_zend_call_method_with_0_params(&zobject, swoole_http_client_class_entry_ptr, NULL, "close", &retval);
+        if (retval)
+        {
+            sw_zval_ptr_dtor(&retval);
+        }
+    }
+    else
+    // we will reuse this http client, so reset it
+    {
+        // reset attributes
+        http->completed = 0;
+        http->header_completed = 0;
+        http->state = HTTP_CLIENT_STATE_READY;
+    }
+}
+
 void http_client_free(zval *object TSRMLS_DC)
 {
     http_client *http = swoole_get_object(object);

--- a/swoole_http_client.c
+++ b/swoole_http_client.c
@@ -697,6 +697,7 @@ static void http_client_onReceive(swClient *cli, char *data, uint32_t length)
         return;
     }
 
+    swConnection *conn = cli->socket; // get connection pointer first because it's on Reactor so that it always be safe
     zval *retval = NULL;
     http_client_property *hcc = swoole_get_property(zobject, 0);
     zval *zcallback = hcc->onResponse;
@@ -749,7 +750,8 @@ static void http_client_onReceive(swClient *cli, char *data, uint32_t length)
     }
     sw_zval_free(zcallback);
 
-    if (cli->socket->active == 0)
+    // maybe close in callback, check it
+    if (conn->active == 0)
     {
         return;
     }

--- a/swoole_http_client.h
+++ b/swoole_http_client.h
@@ -147,6 +147,8 @@ int http_client_parser_on_headers_complete(php_http_parser *parser);
 int http_client_parser_on_message_complete(php_http_parser *parser);
 
 http_client* http_client_create(zval *object TSRMLS_DC);
+void http_client_clear(http_client *http);
+void http_client_reset(zval *zobject TSRMLS_DC);
 void http_client_free(zval *object TSRMLS_DC);
 
 static sw_inline void http_client_create_token(int length, char *buf)

--- a/swoole_http_client.h
+++ b/swoole_http_client.h
@@ -148,7 +148,8 @@ int http_client_parser_on_message_complete(php_http_parser *parser);
 
 http_client* http_client_create(zval *object TSRMLS_DC);
 void http_client_clear(http_client *http);
-void http_client_reset(zval *zobject TSRMLS_DC);
+int http_client_check_keep(http_client *http);
+void http_client_reset(http_client *http);
 void http_client_free(zval *object TSRMLS_DC);
 
 static sw_inline void http_client_create_token(int length, char *buf)

--- a/swoole_http_client_coro.c
+++ b/swoole_http_client_coro.c
@@ -791,7 +791,10 @@ static void http_client_coro_onReceive(swClient *cli, char *data, uint32_t lengt
             hcc->defer_status = HTTP_CLIENT_STATE_DEFER_DONE;
             hcc->defer_result = 0;
             http_client_clear(http);
-            http_client_reset(zobject TSRMLS_CC);
+            if (http_client_check_keep(http))
+            {
+                http_client_reset(http);
+            }
             return;
         }
         else
@@ -817,7 +820,10 @@ static void http_client_coro_onReceive(swClient *cli, char *data, uint32_t lengt
         hcc->defer_status = HTTP_CLIENT_STATE_DEFER_DONE;
         hcc->defer_result = 1;
         http_client_clear(http);
-        http_client_reset(zobject TSRMLS_CC);
+        if (http_client_check_keep(http))
+        {
+            http_client_reset(http);
+        }
         return;
     }
     else
@@ -859,7 +865,10 @@ static void http_client_coro_onReceive(swClient *cli, char *data, uint32_t lengt
     begin_resume:
     {
         http_client_clear(http);
-        http_client_reset(zobject TSRMLS_CC);
+        if (http_client_check_keep(http))
+        {
+            http_client_reset(http);
+        }
 
         php_context *sw_current_context = swoole_get_property(zobject, http_client_coro_property_context);
         hcc->cid = 0;
@@ -873,7 +882,6 @@ static void http_client_coro_onReceive(swClient *cli, char *data, uint32_t lengt
         }
         sw_zval_ptr_dtor(&zdata);
     }
-
 }
 
 static void http_client_coro_onConnect(swClient *cli)

--- a/tests/swoole_http_client_coro/multi_and_reuse.phpt
+++ b/tests/swoole_http_client_coro/multi_and_reuse.phpt
@@ -1,0 +1,48 @@
+--TEST--
+multi_and_reuse: reuse defer client
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../include/bootstrap.php';
+go(function () {
+    function createDeferCli(string $host, bool $ssl = false): Swoole\Coroutine\Http\Client
+    {
+        $cli = new Swoole\Coroutine\Http\Client($host, $ssl ? 443 : 80, $ssl);
+        $cli->set(['timeout' => 10]);
+        $cli->setHeaders([
+            'Host' => $host,
+            'User-Agent' => 'Chrome/49.0.2587.3',
+            'Accept' => 'text/html,application/xhtml+xml,application/xml',
+            'Accept-Encoding' => 'gzip',
+        ]);
+        $cli->setDefer(true);
+
+        return $cli;
+    }
+
+    $baidu = createDeferCli('www.baidu.com', true);
+    $qq = createDeferCli('www.qq.com');
+
+    //first
+    $baidu->get('/');
+    $qq->get('/');
+    $baidu->recv(10);
+    $qq->recv(10);
+    assert($baidu->statusCode === 200);
+    assert(stripos($baidu->body, 'baidu') !== false);
+    assert($qq->statusCode === 200);
+    assert(stripos($qq->body, 'tencent') !== false);
+
+    //reuse
+    $baidu->get('/duty/');
+    $qq->get('/contract.shtml');
+    $baidu->recv(10);
+    $qq->recv(10);
+    assert($baidu->statusCode === 200);
+    assert(stripos($baidu->body, 'baidu') !== false);
+    assert($qq->statusCode === 200);
+    assert(stripos($qq->body, 'tencent') !== false);
+});
+?>
+--EXPECT--


### PR DESCRIPTION
没有修改任何逻辑, 只是对代码进行了封装复用, 已跑完单元测试

增加三个函数:
http_client_clear
http_client_check_keep (异步client的no-keep关闭只能在回调之后)
http_client_reset

并修复了之前由于coro_client缺失清理代码导致的bug
如使用defer特性时, http_client状态和属性的内存未作清理等, 导致defer的客户端不能再次使用.

\+ 该bug单元测试一枚