### PR TITLE
Fix problems in websocket disconnect method

### DIFF
--- a/include/websocket.h
+++ b/include/websocket.h
@@ -46,7 +46,6 @@ enum swWebsocketStatus
     WEBSOCKET_STATUS_HANDSHAKE = 2,
     WEBSOCKET_STATUS_ACTIVE = 3,
     WEBSOCKET_STATUS_CLOSING    = 4,
-    WEBSOCKET_STATUS_CLOSED     = 5,
 };
 
 typedef struct

--- a/src/protocol/WebSocket.c
+++ b/src/protocol/WebSocket.c
@@ -308,7 +308,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
             send_frame.str[1] = payload_length;
 
             // Get payload and return it as it is
-            strncpy(send_frame.str + SW_WEBSOCKET_HEADER_LEN,
+            memcpy(send_frame.str + SW_WEBSOCKET_HEADER_LEN,
                 frame.str + length - payload_length, payload_length);
             send_frame.length = payload_length + SW_WEBSOCKET_HEADER_LEN;
             swConnection_send(conn, send_frame.str, send_frame.length, 0);

--- a/tests/swoole_websocket_server/websocket_disconnect.phpt
+++ b/tests/swoole_websocket_server/websocket_disconnect.phpt
@@ -50,13 +50,17 @@ $response = $cli->sendRecv("shutdown");
 
 $byteArray = unpack('C*', $response);
 
-assert($byteArray[0] == 0x0F);	// Test Status Code
-assert($byteArray[1] == 0xA0);
+assert($byteArray[1] == 0x0F);	// Test Status Code bit 1 = 15
+assert($byteArray[2] == 0xA0);  // Test Status Code bit 2 = 160
 
+echo $byteArray[1]."\n";
+echo $byteArray[2]."\n"
 echo substr($response, 2);
 
 ?>
 
 --EXPECT--
+15
+160
 shutdown received
 --CLEAN--


### PR DESCRIPTION
1. C89 for variable declaration.
2. Disconnect method args type.
3. Remove websocket status WEBSOCKET_STATUS_CLOSED, use 0 as closed status.
4. Unit test bytes array index fix.
5. Some other details.