### PR TITLE
Fix missing HAVE_SOCKETS definition

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -256,7 +256,15 @@ if test "$PHP_SWOOLE" != "no"; then
     fi
 
     if test "$PHP_SOCKETS" = "yes"; then
-        AC_DEFINE(SW_SOCKETS, 1, [enable sockets support])
+        AC_CHECK_HEADERS([$phpincludedir/ext/sockets/php_sockets.h], [
+            AC_DEFINE(SW_SOCKETS, 1, [enable sockets support])
+
+            dnl Some systems build and package PHP socket extension separately
+            dnl and php_config.h doesn't have HAVE_SOCKETS defined.
+            AC_DEFINE(HAVE_SOCKETS, 1, [Whether sockets extension is enabled])
+        ],
+            [AC_MSG_ERROR([cannot find $phpincludedir/ext/sockets/php_sockets.h. Please check if sockets extension installed])]
+        )
     fi
 
     if test "$PHP_HTTP2" = "yes"; then


### PR DESCRIPTION
Certain systems such as Ubuntu Linux distribution with 3rd party PHP repositories build and package PHP sockets extension separately where the php_config.h file doesn't have the HAVE_SOCKETS defined. This constant is used in the ext/sockets/php_sockets.h file and therefore compilation fails with error:

```
unknown type name ‘php_socket’; did you mean ‘php_socket_t’
```

For these cases, a simple additional definition can be added via the autotools build system.

This patch also checks for the presence of the PHP socket extension header file and provides informational error message in the `./configure --enable-sockets` step directly if PHP sockets extension isn't present.

This patch fixes #1454 and #1725 