### PR TITLE
Extends

### DIFF
--- a/swoole_mysql.c
+++ b/swoole_mysql.c
@@ -366,8 +366,6 @@ static int swoole_mysql_onWrite(swReactor *reactor, swEvent *event);
 static int swoole_mysql_onError(swReactor *reactor, swEvent *event);
 static void swoole_mysql_onConnect(mysql_client *client TSRMLS_DC);
 
-swString *mysql_request_buffer = NULL;
-
 void swoole_mysql_init(int module_number TSRMLS_DC)
 {
     SWOOLE_INIT_CLASS_ENTRY(swoole_mysql_ce, "swoole_mysql", "Swoole\\MySQL", swoole_mysql_methods);
@@ -2132,16 +2130,6 @@ void mysql_column_info(mysql_field *field)
 
 static PHP_METHOD(swoole_mysql, __construct)
 {
-    if (!mysql_request_buffer)
-    {
-        mysql_request_buffer = swString_new(SW_MYSQL_QUERY_INIT_SIZE);
-        if (!mysql_request_buffer)
-        {
-            swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
-            RETURN_FALSE;
-        }
-    }
-
     mysql_client *client = emalloc(sizeof(mysql_client));
     bzero(client, sizeof(mysql_client));
     swoole_set_object(getThis(), client);

--- a/swoole_mysql.h
+++ b/swoole_mysql.h
@@ -385,6 +385,8 @@ typedef struct _mysql_client
 
 } mysql_client;
 
+#define mysql_request_buffer (SwooleTG.buffer_stack)
+
 #define mysql_uint2korr(A)  (uint16_t) (((uint16_t) ((zend_uchar) (A)[0])) +\
                                ((uint16_t) ((zend_uchar) (A)[1]) << 8))
 #define mysql_uint3korr(A)  (uint32_t) (((uint32_t) ((zend_uchar) (A)[0])) +\

--- a/swoole_mysql_coro.c
+++ b/swoole_mysql_coro.c
@@ -148,7 +148,7 @@ static int swoole_mysql_coro_onError(swReactor *reactor, swEvent *event);
 static void swoole_mysql_coro_onConnect(mysql_client *client TSRMLS_DC);
 static void swoole_mysql_coro_onTimeout(swTimer *timer, swTimer_node *tnode);
 
-extern swString *mysql_request_buffer;
+
 
 void swoole_mysql_coro_init(int module_number TSRMLS_DC)
 {
@@ -571,16 +571,6 @@ static int swoole_mysql_coro_close(zval *this)
 static PHP_METHOD(swoole_mysql_coro, __construct)
 {
     coro_check(TSRMLS_C);
-
-    if (!mysql_request_buffer)
-    {
-        mysql_request_buffer = swString_new(SW_MYSQL_QUERY_INIT_SIZE);
-        if (!mysql_request_buffer)
-        {
-            swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
-            RETURN_FALSE;
-        }
-    }
 
     mysql_client *client = emalloc(sizeof(mysql_client));
     bzero(client, sizeof(mysql_client));

--- a/tests/swoole_mysql_coro/aborted_clients.phpt
+++ b/tests/swoole_mysql_coro/aborted_clients.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql-close/reconnect/aborted-client-num
+swoole_mysql_coro: mysql-close/reconnect/aborted-client-num
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/fetch.phpt
+++ b/tests/swoole_mysql_coro/fetch.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: use fetch to get data
+swoole_mysql_coro: use fetch to get data
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/fetch_mode.phpt
+++ b/tests/swoole_mysql_coro/fetch_mode.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: use fetch to get data
+swoole_mysql_coro: use fetch to get data
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/fetch_mode_twice.phpt
+++ b/tests/swoole_mysql_coro/fetch_mode_twice.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: call fetch twice
+swoole_mysql_coro: call fetch twice
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/illegal_extends.phpt
+++ b/tests/swoole_mysql_coro/illegal_extends.phpt
@@ -1,0 +1,59 @@
+--TEST--
+swoole_mysql_coro: illegal child class
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/../include/bootstrap.php';
+require_once __DIR__ . '/../include/swoole.inc';
+
+class swoole_invalid_mysql_coro extends \Swoole\Coroutine\MySQL
+{
+
+    public function __construct()
+    {
+        // miss parent::__construct
+    }
+
+    public function connect($server_config)
+    {
+        // miss parent::connect
+        return true;
+    }
+
+    public function connectRaw(array $server_config)
+    {
+        return parent::connect($server_config);
+    }
+
+    public function __destruct()
+    {
+        // miss parent::__destruct
+    }
+
+}
+
+go(function () {
+    $db = new swoole_invalid_mysql_coro;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER1,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB1,
+        'strict_type' => true
+    ];
+
+    // invalid connect
+    assert($db->connect($server));
+    assert(!$db->connected);
+    assert(!$db->query('select 1'));
+
+    // right implementation
+    assert($db->connectRaw($server));
+    assert($db->query('select 1')[0][1] === 1);
+});
+
+?>
+--EXPECTF--
+Warning: Swoole\Coroutine\MySQL::query(): mysql connection#%d is closed. in %s on line %d

--- a/tests/swoole_mysql_coro/prepare_insert.phpt
+++ b/tests/swoole_mysql_coro/prepare_insert.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql prepare (insert)
+swoole_mysql_coro: mysql prepare (insert)
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/prepare_select.phpt
+++ b/tests/swoole_mysql_coro/prepare_select.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql prepare (select)
+swoole_mysql_coro: mysql prepare (select)
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/procedure.phpt
+++ b/tests/swoole_mysql_coro/procedure.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: procedure without fetch mode
+swoole_mysql_coro: procedure without fetch mode
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/procedure_in_fetch.phpt
+++ b/tests/swoole_mysql_coro/procedure_in_fetch.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: procedure in fetch mode
+swoole_mysql_coro: procedure in fetch mode
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/procedure_single.phpt
+++ b/tests/swoole_mysql_coro/procedure_single.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql procedure single
+swoole_mysql_coro: mysql procedure single
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/query.phpt
+++ b/tests/swoole_mysql_coro/query.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql client
+swoole_mysql_coro: mysql client
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/query_timeout.phpt
+++ b/tests/swoole_mysql_coro/query_timeout.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql query timeout
+swoole_mysql_coro: mysql query timeout
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/simple_query.phpt
+++ b/tests/swoole_mysql_coro/simple_query.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql simple query
+swoole_mysql_coro: mysql simple query
 
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>

--- a/tests/swoole_mysql_coro/statement_destruct.phpt
+++ b/tests/swoole_mysql_coro/statement_destruct.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: mysql prepare (destruct)
+swoole_mysql_coro: mysql prepare (destruct)
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--

--- a/tests/swoole_mysql_coro/without_fetch.phpt
+++ b/tests/swoole_mysql_coro/without_fetch.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: just execute (test memory leak)
+swoole_mysql_coro: just execute (test memory leak)
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--


### PR DESCRIPTION
- 替换`mysql_request_buffer` 为 `SwooleTG.buffer_stack`
- 使用 `create_object` 和 `free_obj` 代替 `__construct` 和 `__destruct`
- 补充相关BUG的单元测试一例