### PR TITLE
Fix building extension from php-src/ext directory

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -256,15 +256,20 @@ if test "$PHP_SWOOLE" != "no"; then
     fi
 
     if test "$PHP_SOCKETS" = "yes"; then
-        AC_CHECK_HEADERS([$phpincludedir/ext/sockets/php_sockets.h], [
-            AC_DEFINE(SW_SOCKETS, 1, [enable sockets support])
+        AC_MSG_CHECKING([for php_sockets.h])
 
-            dnl Some systems build and package PHP socket extension separately
-            dnl and php_config.h doesn't have HAVE_SOCKETS defined.
-            AC_DEFINE(HAVE_SOCKETS, 1, [Whether sockets extension is enabled])
-        ],
-            [AC_MSG_ERROR([cannot find $phpincludedir/ext/sockets/php_sockets.h. Please check if sockets extension installed])]
-        )
+        AS_IF([test -f $abs_srcdir/ext/sockets/php_sockets.h], [AC_MSG_RESULT([ok, found in $abs_srcdir])],
+            [test -f $phpincludedir/ext/sockets/php_sockets.h], [AC_MSG_RESULT([ok, found in $phpincludedir])],
+            [AC_MSG_ERROR([cannot find php_sockets.h. Please check if sockets extension is installed.])
+        ])
+
+        AC_DEFINE(SW_SOCKETS, 1, [enable sockets support])
+
+        dnl Some systems build and package PHP socket extension separately
+        dnl and php_config.h doesn't have HAVE_SOCKETS defined.
+        AC_DEFINE(HAVE_SOCKETS, 1, [whether sockets extension is enabled])
+
+        PHP_ADD_EXTENSION_DEP(swoole, sockets, true)
     fi
 
     if test "$PHP_HTTP2" = "yes"; then


### PR DESCRIPTION
Hello, this patch addresses #1853 

When building extensions directly from the php-src/ext directory, for example to build the extension statically into PHP directly, PHP header files are located in the $abs_srcdir directory.

This patch adds additional check for checking file locations of the socket extension.

Additional macro `PHP_ADD_EXTENSION_DEP` call is added for more proper initialization order. In case, sockets extension is a dependency, it must be initialized before swoole.

Probably some more additional checks should be made, but I think this should for for many cases so far. In case of issues, let me know.

Thanks.