### PR TITLE
fix kqueue signal when there's no main reactor

### DIFF
--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -104,7 +104,8 @@ void swSignal_add(int signo, swSignalHander func)
 #ifdef HAVE_KQUEUE
         // SIGCHLD can not be monitored by kqueue, if blocked by SIG_IGN
         // see https://www.freebsd.org/cgi/man.cgi?kqueue
-        if (signo != SIGCHLD)
+        // if there's no main reactor, signals cannot be monitored either
+        if (signo != SIGCHLD && SwooleG.main_reactor)
         {
             swKqueueSignal_set(signo, func);
         }
@@ -170,7 +171,7 @@ void swSignal_clear(void)
             if (signals[i].active)
             {
 #ifdef HAVE_KQUEUE
-                if (signals[i].signo != SIGCHLD)
+                if (signals[i].signo != SIGCHLD && SwooleG.main_reactor)
                 {
                     swKqueueSignal_set(signals[i].signo, NULL);
                 }
@@ -291,14 +292,6 @@ static void swKqueueSignal_set(int signo, swSignalHander callback)
 {
     struct kevent ev;
     swReactor *reactor = SwooleG.main_reactor;
-    if (reactor == NULL)
-    {
-        if (unlikely(callback))
-        {
-            swWarn("kevent set signal[%d] error, main reactor is destroyed", signo);
-        }
-        return;
-    }
     struct
     {
         int fd;


### PR DESCRIPTION
When there's no main reactor, signal events cannot be monitored by kqueue.
Fall back to the original solution if that occurs.