### PR TITLE
save errno in signal async handler function

### DIFF
--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -122,6 +122,8 @@ void swSignal_add(int signo, swSignalHander func)
 
 static void swSignal_async_handler(int signo)
 {
+    int save_errno = errno;
+
     if (SwooleG.main_reactor)
     {
         SwooleG.main_reactor->singal_no = signo;
@@ -137,6 +139,8 @@ static void swSignal_async_handler(int signo)
         swSignal_callback(signo);
         _lock = 0;
     }
+
+    errno = save_errno;
 }
 
 void swSignal_callback(int signo)


### PR DESCRIPTION
In nginx, or libevent, signal async handler function will save errno to protect errno being modified unexpected.