### PR TITLE
zif_handler to save function pointer

### DIFF
--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -98,14 +98,17 @@ static struct
 static php_stream_wrapper ori_php_plain_files_wrapper;
 static php_stream_ops ori_php_stream_stdio_ops;
 
+#if PHP_VERSION_ID < 70200
+typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+#endif
 static zend_function *ori_sleep;
-static void (*ori_sleep_handler)(INTERNAL_FUNCTION_PARAMETERS);
+static zif_handler ori_sleep_handler;
 static zend_function *ori_usleep;
-static void (*ori_usleep_handler)(INTERNAL_FUNCTION_PARAMETERS);
+static zif_handler ori_usleep_handler;
 static zend_function *ori_time_nanosleep;
-static void (*ori_time_nanosleep_handler)(INTERNAL_FUNCTION_PARAMETERS);
+static zif_handler ori_time_nanosleep_handler;
 static zend_function *ori_time_sleep_until;
-static void (*ori_time_sleep_until_handler)(INTERNAL_FUNCTION_PARAMETERS);
+static zif_handler ori_time_sleep_until_handler;
 
 extern "C"
 {


### PR DESCRIPTION
Issue introduce in 6a215798698277530ce95324465e6dd047c0ab37

zif_handler is defined since 7.2, and have changed in 7.3

7.2: typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
7.3: typedef void (ZEND_FASTCALL *zif_handler)(INTERNAL_FUNCTION_PARAMETERS);

The change may introduce segfault with 7.3 (different stack layout).