### PR TITLE
Trim trailing whitespaces

### DIFF
--- a/tests/swoole_coroutine/destruct/destruct1.phpt
+++ b/tests/swoole_coroutine/destruct/destruct1.phpt
@@ -11,18 +11,18 @@ class T
 {
     function __construct()
     {
-      
+
     }
     function test()
     {
-        echo "call function \n";
+        echo "call function\n";
     }
 
     function __destruct()
-    {    
+    {
         go(function () {
             echo "coro start\n";
-            co::sleep(1.0);       
+            co::sleep(1.0);
             echo "coro exit\n";
         });
     }
@@ -34,7 +34,7 @@ unset($t);
 echo "end\n";
 ?>
 --EXPECT--
-call function 
+call function
 coro start
 end
 coro exit

--- a/tests/swoole_coroutine/destruct/destruct2.phpt
+++ b/tests/swoole_coroutine/destruct/destruct2.phpt
@@ -11,18 +11,18 @@ class T
 {
     function __construct()
     {
-      
+
     }
     function test()
     {
-        echo "call function \n";
+        echo "call function\n";
     }
 
     function __destruct()
-    {    
+    {
         go(function () {
             echo "coro start\n";
-            co::sleep(1.0);       
+            co::sleep(1.0);
             echo "coro exit\n";
         });
     }
@@ -33,7 +33,7 @@ $t->test();
 echo "end\n";
 ?>
 --EXPECTF--
-call function 
+call function
 end
 
 Fatal error: go(): can not use coroutine in __destruct after php_request_shutdown %s

--- a/tests/swoole_coroutine/forbidden_case/array_map.phpt
+++ b/tests/swoole_coroutine/forbidden_case/array_map.phpt
@@ -10,16 +10,16 @@ use Swoole\Coroutine as co;
 co::create(function() {
     array_map("test",array("func start\n"));
     echo "co end\n";
-});    
+});
 function test($p) {
     echo $p;
     co::sleep(1);
-    echo "func end \n";
+    echo "func end\n";
 }
 echo "main end\n";
 ?>
 --EXPECT--
 func start
 main end
-func end 
+func end
 co end

--- a/tests/swoole_coroutine_util/resume5.phpt
+++ b/tests/swoole_coroutine_util/resume5.phpt
@@ -21,13 +21,13 @@ go(function () {
     co::yield();
     echo "after yield\n";
 });
-echo "main \n";
+echo "main\n";
 
 ?>
 --EXPECTF--
 start to create coro
 coro 2
 before yield
-main 
+main
 resume
 after yield


### PR DESCRIPTION
Hello, this patch trims few remaining test files for convenience since the trailing whitespaces are not part of the tests and also for convenience of editing code in some editors where trailing whitespace gets trimmed automatically. 

Thank you.