### PR TITLE
Improve log quality, better bug reports guide.

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,6 +1,6 @@
 Please answer these questions before submitting your issue. Thanks!
 
-1. What did you do? If possible, provide a recipe for reproducing the error.
+1. What did you do? If possible, provide a simple script for reproducing the error.
 
 
 
@@ -12,17 +12,10 @@ Please answer these questions before submitting your issue. Thanks!
 
 
 
-4. What version of Swoole are you using (`php --ri swoole`)?
-
+4. What version of Swoole are you using (show your `php --ri swoole`)?
 
 
 
 5. What is your machine environment used (including version of kernel & php & gcc) ?
-
-
-
-6. If you are using ssl, what is your openssl version?
-
-
 
 

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -85,6 +85,19 @@ int daemon(int nochdir, int noclose);
 #endif
 
 /*----------------------------------------------------------------------------*/
+
+#define SWOOLE_VERSION "4.2.1"
+#define SWOOLE_BUG_REPORT \
+    "A bug occurred in Swoole-v" SWOOLE_VERSION ", please report it.\n"\
+    "The Swoole developers probably don't know about it,\n"\
+    "and unless you report it, chances are it won't be fixed.\n"\
+    "You can read How to report a bug doc before submitting any bug reports:\n"\
+    ">> https://github.com/swoole/swoole-src/issues/2000\n"\
+    "Please do not send bug reports in the mailing list or personal letters.\n"\
+    "The issue page is also suitable to submit feature requests.\n"
+
+/*----------------------------------------------------------------------------*/
+
 #ifndef ulong
 #define ulong unsigned long
 #endif

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -67,7 +67,7 @@ BEGIN_EXTERN_C()
 #include <ext/standard/basic_functions.h>
 #include <ext/standard/php_http.h>
 
-#define PHP_SWOOLE_VERSION  "4.2.1"
+#define PHP_SWOOLE_VERSION SWOOLE_VERSION
 #define PHP_SWOOLE_CHECK_CALLBACK
 #define PHP_SWOOLE_ENABLE_FASTCALL
 #define PHP_SWOOLE_CLIENT_USE_POLL
@@ -146,6 +146,8 @@ extern swoole_object_array swoole_objects;
 #ifdef SW_USE_HTTP2
 #if !defined(HAVE_NGHTTP2)
 #error "Enable http2 support, require nghttp2 library."
+#else
+#include <nghttp2/nghttp2ver.h>
 #endif
 #endif
 

--- a/src/network/manager.c
+++ b/src/network/manager.c
@@ -193,7 +193,11 @@ static void swManager_check_exit_status(swServer *serv, int worker_id, pid_t pid
 {
     if (status != 0)
     {
-        swWarn("worker#%d abnormal exit, status=%d, signal=%d", worker_id, WEXITSTATUS(status), WTERMSIG(status));
+        swWarn(
+            "worker#%d abnormal exit, status=%d, signal=%d" "%s",
+            worker_id, WEXITSTATUS(status), WTERMSIG(status),
+            WTERMSIG(status) == SIGSEGV ? "\n" SWOOLE_BUG_REPORT : ""
+        );
         if (serv->onWorkerError != NULL)
         {
             serv->onWorkerError(serv, worker_id, pid, WEXITSTATUS(status), WTERMSIG(status));

--- a/src/network/process_pool.c
+++ b/src/network/process_pool.c
@@ -740,7 +740,11 @@ int swProcessPool_wait(swProcessPool *pool)
             }
             if (!WIFEXITED(status))
             {
-                swWarn("worker#%d abnormal exit, status=%d, signal=%d", exit_worker->id, WEXITSTATUS(status),  WTERMSIG(status));
+                swWarn(
+                    "worker#%d abnormal exit, status=%d, signal=%d" "%s",
+                    exit_worker->id, WEXITSTATUS(status),  WTERMSIG(status),
+                    WTERMSIG(status) == SIGSEGV ? "\n" SWOOLE_BUG_REPORT : ""
+                );
             }
             new_pid = swProcessPool_spawn(pool, exit_worker);
             if (new_pid < 0)

--- a/swoole.c
+++ b/swoole.c
@@ -898,7 +898,7 @@ PHP_MINIT_FUNCTION(swoole)
     REGISTER_LONG_CONSTANT("SWOOLE_EVENT_READ", SW_EVENT_READ, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("SWOOLE_EVENT_WRITE", SW_EVENT_WRITE, CONST_CS | CONST_PERSISTENT);
 
-    REGISTER_STRINGL_CONSTANT("SWOOLE_VERSION", PHP_SWOOLE_VERSION, sizeof(PHP_SWOOLE_VERSION) - 1, CONST_CS | CONST_PERSISTENT);
+    REGISTER_STRINGL_CONSTANT("SWOOLE_VERSION", SWOOLE_VERSION, sizeof(SWOOLE_VERSION) - 1, CONST_CS | CONST_PERSISTENT);
 
     SWOOLE_DEFINE(ERROR_MALLOC_FAIL);
     SWOOLE_DEFINE(ERROR_SYSTEM_CALL_FAIL);
@@ -1172,7 +1172,7 @@ PHP_MINFO_FUNCTION(swoole)
 {
     php_info_print_table_start();
     php_info_print_table_header(2, "swoole support", "enabled");
-    php_info_print_table_row(2, "Version", PHP_SWOOLE_VERSION);
+    php_info_print_table_row(2, "Version", SWOOLE_VERSION);
     php_info_print_table_row(2, "Author", "Swoole Group[email: team@swoole.com]");
 
 #ifdef SW_COROUTINE
@@ -1218,10 +1218,18 @@ PHP_MINFO_FUNCTION(swoole)
     php_info_print_table_row(2, "sockets", "enabled");
 #endif
 #ifdef SW_USE_OPENSSL
+#ifdef OPENSSL_VERSION_TEXT
+    php_info_print_table_row(2, "openssl", OPENSSL_VERSION_TEXT);
+#else
     php_info_print_table_row(2, "openssl", "enabled");
 #endif
+#endif
 #ifdef SW_USE_HTTP2
+#ifdef NGHTTP2_VERSION
+    php_info_print_table_row(2, "http2", NGHTTP2_VERSION);
+#else
     php_info_print_table_row(2, "http2", "enabled");
+#endif
 #endif
 #ifdef SW_USE_RINGBUFFER
     php_info_print_table_row(2, "ringbuffer", "enabled");
@@ -1341,7 +1349,7 @@ PHP_RSHUTDOWN_FUNCTION(swoole)
 
 PHP_FUNCTION(swoole_version)
 {
-    SW_RETURN_STRING(PHP_SWOOLE_VERSION, 1);
+    SW_RETURN_STRING(SWOOLE_VERSION, 1);
 }
 
 static uint32_t hashkit_one_at_a_time(const char *key, size_t key_length)

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -931,7 +931,7 @@ static int http_client_coro_send_request(zval *zobject, http_client_coro_propert
         }
     }
 
-    swTrace("[%d]: %s\n", (int)http_client_buffer->length, http_client_buffer->str);
+    swTrace("[%zu]:<<EOF\n%.*s\nEOF", http_client_buffer->length, (int) http_client_buffer->length, http_client_buffer->str);
 
     if (!hcc->socket->send(http_client_buffer->str, http_client_buffer->length))
     {


### PR DESCRIPTION
SIGSEGV是一个**必须被上报的错误**, 由于很多开发者并不了解coredump和不清除BUG反馈的途径, Swoole应该在产生错误时提供必要的相关信息来引导开发者上报. 且coredump产生时, 我们**必须知道对应的Swoole版本**, 将它内置在日志中, 能够更好的过滤已解决的BUG, 而不必反复询问开发者所使用的版本.
现在的错误日志在收到SIGSEGV时可能是这样的, 提示内容参考了PHP官方的bug reports:
![image](https://user-images.githubusercontent.com/25978241/45927944-30c00b00-bf6e-11e8-91e8-319e607f986a.png)

在处理issue时我们常见到千篇一律的问题, 创建一个便于浏览bug reports的指导显然很有必要, 它最好是双语的, 并且有一个便于记忆的url, 已经建立在 https://github.com/swoole/swoole-src/issues/2000

openssl的版本信息并不总是那么有用, 在issue模板中我们应该删去, 在`php --ri swoole`时提供详实的依赖却很有必要, 现在它可能是这样的:

```shell
swoole

swoole support => enabled
Version => 4.2.1
Author => Swoole Group[email: team@swoole.com]
coroutine => enabled
debug => enabled
trace-log => enabled
kqueue => enabled
rwlock => enabled
sockets => enabled
openssl => OpenSSL 1.1.1-pre8 (beta) 20 Jun 2018
http2 => 1.32.0
pcre => enabled
zlib => enabled
brotli => enabled
mysqlnd => enabled
async redis => enabled
coroutine postgresql => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.aio_thread_num => 2 => 2
swoole.display_errors => On => On
swoole.use_namespace => On => On
swoole.use_shortname => On => On
swoole.fast_serialize => Off => Off
swoole.unixsock_buffer_size => 8388608 => 8388608
```

