### PR TITLE
修复 swoole hook 连接错误，错误信息不能正确显示问题

### DIFF
--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -382,6 +382,7 @@ static inline int socket_connect(php_stream *stream, Socket *sock, php_stream_xp
     if (sock->connect(host, portno) == false)
     {
         xparam->outputs.error_code = sock->errCode;
+        xparam->outputs.error_text = zend_string_init(sock->errMsg, strlen(sock->errMsg), 0);
         ret = -1;
     }
     else


### PR DESCRIPTION
修正连接出错时不能获取正确的异常信息