### PR TITLE
fix kqueue nanoseconds

### DIFF
--- a/src/reactor/kqueue.c
+++ b/src/reactor/kqueue.c
@@ -291,7 +291,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
         if (reactor->timeout_msec > 0)
         {
             t.tv_sec = reactor->timeout_msec / 1000;
-            t.tv_nsec = (reactor->timeout_msec - t.tv_sec * 1000) * 1000;
+            t.tv_nsec = (reactor->timeout_msec - t.tv_sec * 1000) * 1000 * 1000;
             t_ptr = &t;
         }
         else


### PR DESCRIPTION
timeout
Sometimes it is useful to set an upper time limit for kevent() to block. That way, it will return, no matter if none of the events was triggered. For this purpose we need the timespec structure, which is defined in sys/time.h:

struct timespec {
            time_t tv_sec;        /* seconds */
            long   tv_nsec;       /* and nanoseconds */
};
