### PR TITLE
Fix bug in query 'CALL' statement & prepare, add more tests

### DIFF
--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -1081,6 +1081,11 @@ static PHP_METHOD(swoole_mysql_coro, prepare)
         RETURN_FALSE;
     }
 
+    if (client->buffer)
+    {
+        swString_clear(client->buffer);
+    }
+
     client->cmd = SW_MYSQL_COM_STMT_PREPARE;
     client->state = SW_MYSQL_STATE_READ_START;
 

--- a/tests/swoole_mysql_coro/err_instead_of_eof.phpt
+++ b/tests/swoole_mysql_coro/err_instead_of_eof.phpt
@@ -1,0 +1,24 @@
+--TEST--
+swoole_mysql_coro: ERR Instead of EOF 
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB
+    ];
+    $db->connect($server);
+
+    $res = $db->query("EXPLAIN SELECT * FROM dual;");
+    assert(!$res);
+    assert($db->errno === 1096);
+    assert($db->error === "No tables used");
+});
+?>
+--EXPECT--

--- a/tests/swoole_mysql_coro/procedure_with_query_and_prepare.phpt
+++ b/tests/swoole_mysql_coro/procedure_with_query_and_prepare.phpt
@@ -1,0 +1,36 @@
+--TEST--
+swoole_mysql_coro: query 'CALL' statement & prepare (#2117)
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+go(function () {
+    $db = new Swoole\Coroutine\Mysql;
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'user' => MYSQL_SERVER_USER,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB
+    ];
+
+    $clear = <<<SQL
+    DROP PROCEDURE IF EXISTS `sp_whoami`
+SQL;
+    $procedure = <<<SQL
+  CREATE DEFINER=`root`@`localhost` PROCEDURE `sp_whoami`()
+  BEGIN
+    SELECT user();
+  END
+SQL;
+
+    $db->connect($server);
+    if ($db->query($clear) && $db->query($procedure)) {
+        $db->query('CALL sp_whoami()');
+        $stmt = $db->prepare('CALL sp_whoami()');
+        $ret = $stmt->execute();
+        assert(strpos(current($ret[0]), MYSQL_SERVER_USER) !== false);
+    }
+});
+?>
+--EXPECT--


### PR DESCRIPTION
同之前的bug一样，`prepare` 也需要清除buffer，否则也会因为未消费的OK_Packet导致出错。

复现代码：
```
$db->query("CALL sp_test()");
$stmt = $db->prepare("CALL sp_test()");
var_dump($stmt->execute());
```

OK_Packet包和COM_STMT_PREPARE_OK_Packet包又极其相似，只是包体长度不同。

```
+----------+------------+-------------------------------------------------------+
| P#6      | L7         | 11                                          OK_Packet |
+----------+------------+-----------+-----------+------------+------------------+
| 00000000 | 07 00 00 06 00 00 00 02 00 00 00                | ...........      |
+----------+------------+-----------+-----------+------------+------------------+

+----------+------------+-------------------------------------------------------+
| P#1      | L12        | 16                         COM_STMT_PREPARE_OK_Packet |
+----------+------------+-----------+-----------+------------+------------------+
| 00000000 | 0c 00 00 01 00 01 00 00 00 00 00 00 00 00 00 00 | ................ |
+----------+------------+-----------+-----------+------------+------------------+
```