### PR TITLE
fix swServer_start_check bug

### DIFF
--- a/src/network/server.c
+++ b/src/network/server.c
@@ -218,7 +218,7 @@ static int swServer_start_check(swServer *serv)
         return SW_ERR;
     }
     //dgram
-    if (!serv->have_dgram_sock && serv->onPacket == NULL)
+    if (serv->have_dgram_sock && serv->onPacket == NULL)
     {
         swWarn("onPacket event callback must be set.");
         return SW_ERR;


### PR DESCRIPTION
when start the http server, it throw error:
```
WARNING swServer_start_check: onPacket event callback must be set.
PHP Fatal error:  Swoole\Server::start(): failed to start server. Error: swServer_start_check: onPacket event callback must be set.
```