### PR TITLE
协程client连接失败的时候，废弃错误警报

### DIFF
--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -731,7 +731,6 @@ static PHP_METHOD(swoole_client_coro, connect)
     if (!cli->connect(host, port, sock_flag))
     {
         zend_update_property_long(swoole_client_coro_class_entry_ptr, getThis(), ZEND_STRL("errCode"), cli->errCode);
-        swoole_php_error(E_WARNING, "connect to server[%s:%d] failed. Error: %s[%d]", host, (int )port, cli->errMsg, cli->errCode);
         RETURN_FALSE;
     }
     zend_update_property_bool(swoole_client_coro_class_entry_ptr, getThis(), ZEND_STRL("connected"), 1);


### PR DESCRIPTION
原因在于：
- 已经有返回值用于判断连接状态
- $client->errorCode可以得到错误原因
- 在生产环境中，远程服务器出错或者是错误关闭时，即使client客户端做了容错处理，swoole层抛出的警报依旧不断，会触发运维层的日志告警处理，因此不合理