### PR TITLE
Modify: remove unnecessary bzero() initialization

### DIFF
--- a/src/reactor/epoll.c
+++ b/src/reactor/epoll.c
@@ -78,7 +78,6 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
         swWarn("malloc[0] failed.");
         return SW_ERR;
     }
-    bzero(reactor_object, sizeof(swReactorEpoll));
     reactor->object = reactor_object;
     reactor->max_event_num = max_event_num;
 


### PR DESCRIPTION
Because the following code assigns a value to the member of reactor_object.