### PR TITLE
Fix Coroutine_Http_Client http_proxy use Authorization

### DIFF
--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -164,8 +164,27 @@ bool Socket::socks5_handshake()
 bool Socket::http_proxy_handshake()
 {
     //CONNECT
-    int n = snprintf(http_proxy->buf, sizeof(http_proxy->buf), "CONNECT %*s:%d HTTP/1.1\r\n\r\n",
-            http_proxy->l_target_host, http_proxy->target_host, http_proxy->target_port);
+    int n;
+    if (http_proxy->password)
+    {
+        if (strlen(http_proxy->buf) > 0) 
+        {
+            char _authBuf[600];
+            snprintf(_authBuf, sizeof(_authBuf), "CONNECT %*s:%d HTTP/1.1\r\n%s\r\n\r\n",
+                http_proxy->l_target_host, http_proxy->target_host, http_proxy->target_port, http_proxy->buf);
+            n = snprintf(http_proxy->buf, sizeof(http_proxy->buf), "%s", _authBuf);
+        }
+        else
+        {
+            n = snprintf(http_proxy->buf, sizeof(http_proxy->buf), "CONNECT %*s:%d HTTP/1.1\r\n\r\n",
+                    http_proxy->l_target_host, http_proxy->target_host, http_proxy->target_port);
+        }
+    }
+    else
+    {
+        n = snprintf(http_proxy->buf, sizeof(http_proxy->buf), "CONNECT %*s:%d HTTP/1.1\r\n\r\n",
+                    http_proxy->l_target_host, http_proxy->target_host, http_proxy->target_port);
+    }
     if (send(http_proxy->buf, n) <= 0)
     {
         return false;

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -285,9 +285,9 @@ static int http_client_coro_execute(zval *zobject, http_client_coro_property *hc
                 {
                     char _buf1[128];
                     char _buf2[256];
-                    int _n1 = snprintf(_buf1, sizeof(_buf1), "%*s:%*s", http->cli->http_proxy->l_user,
-                            http->cli->http_proxy->user, http->cli->http_proxy->l_password,
-                            http->cli->http_proxy->password);
+                    int _n1 = snprintf(_buf1, sizeof(_buf1), "%*s:%*s", hcc->socket->http_proxy->l_user,
+                            hcc->socket->http_proxy->user, hcc->socket->http_proxy->l_password,
+                            hcc->socket->http_proxy->password);
                     zend_string *str = php_base64_encode((const unsigned char *) _buf1, _n1);
                     int _n2 = snprintf(_buf2, sizeof(_buf2), "Basic %*s", (int)str->len, str->val);
                     zend_string_free(str);

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -280,7 +280,6 @@ static int http_client_coro_execute(zval *zobject, http_client_coro_property *hc
             php_swoole_client_coro_check_setting(hcc->socket, zset);
             if (hcc->socket->http_proxy)
             {
-                zval *zrequest_headers = sw_zend_read_property(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("requestHeaders"), 0);
                 if (hcc->socket->http_proxy->password)
                 {
                     char _buf1[128];
@@ -289,9 +288,9 @@ static int http_client_coro_execute(zval *zobject, http_client_coro_property *hc
                             hcc->socket->http_proxy->user, hcc->socket->http_proxy->l_password,
                             hcc->socket->http_proxy->password);
                     zend_string *str = php_base64_encode((const unsigned char *) _buf1, _n1);
-                    int _n2 = snprintf(_buf2, sizeof(_buf2), "Basic %*s", (int)str->len, str->val);
+                    snprintf(_buf2, sizeof(_buf2), "Basic %*s", (int)str->len, str->val);
+                    snprintf(hcc->socket->http_proxy->buf, sizeof(hcc->socket->http_proxy->buf), "Proxy-Authorization:Basic %*s", (int)str->len, str->val);
                     zend_string_free(str);
-                    add_assoc_stringl_ex(zrequest_headers, ZEND_STRL("Proxy-Authorization"), _buf2, _n2);
                 }
             }
         }


### PR DESCRIPTION
通过Squid自建的代理服务器，在 swoole_http_client_coro.cc 中添加header不能成功验证用户，socket connect时因身份验证失败，http_code返回407。

另外，在header中添加的Proxy-Authorization，会发送到被请求服务器，没有用，所以去掉了。

因为爬虫项目只用到了这块，所以没有去检查其他的代码。

> 第一个提交是修复错误；
第二个提交是往headers中添加 Proxy-Authorization 不能认证通过；

测试代码如下：
```
$cli = new \Swoole\Coroutine\Http\Client('www.baidu.com', 80);
$cli->setHeaders([
    'Host' => 'www.baidu.com',
    "User-Agent" => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36',
    //'Proxy-Authorization' => 'Basic '. base64_encode('ruesin:ruesin'),
]);
$cli->set([
    'http_proxy_host' =>  '123.12.3.56',
    'http_proxy_port' =>  '3128',
    'http_proxy_user' => 'ruesin',
    'http_proxy_password' => 'ruesin',
    'timeout' => 5,
    //'ssl_verify_peer' => false
]);
$cli->get('/');
var_dump($cli->setting);
var_dump($cli->headers);
var_dump($cli->errCode);
var_dump(socket_strerror($cli->errCode));
var_dump($cli->statusCode);
echo $cli->body;
$cli->close();
```
