### PR TITLE
fixed swoole_get_local_mac not supported on macOS.

### DIFF
--- a/php_swoole.h
+++ b/php_swoole.h
@@ -88,6 +88,11 @@ extern zend_module_entry swoole_module_entry;
 #	define PHP_SWOOLE_API
 #endif
 
+#ifdef __APPLE__
+#define SIOCGIFHWADDR SIOCGIFCONF
+#define ifr_hwaddr ifr_addr
+#endif
+
 #define SWOOLE_PROPERTY_MAX     32
 #define SWOOLE_OBJECT_MAX       10000000
 


### PR DESCRIPTION
解决macos下swoole_get_local_mac不支持的问题