### PR TITLE
Fix unexpected swoole sever crash on high concurrency operation

### DIFF
--- a/examples/coroutine/redis_pool.php
+++ b/examples/coroutine/redis_pool.php
@@ -11,13 +11,13 @@ $server->on('Request', function($request, $response) use(&$count, $pool) {
             $response->end("redis connect fail!");
             return;
         }
-        $pool->push($redis);
+        $pool->enqueue($redis);
     }
-    $redis = $pool->pop();
+    $redis = $pool->dequeue();
     $count ++;
     $ret = $redis->set('key', 'value');
     $response->end("swoole response is ok, count = $count, result=" . var_export($ret, true));
-    $pool->push($redis);
+    $pool->enqueue($redis);
 });
 
 $server->start();

--- a/tests/swoole_coroutine_channel/benchmark.phpt
+++ b/tests/swoole_coroutine_channel/benchmark.phpt
@@ -11,7 +11,7 @@ $time = [];
 $time['splQueue'] = microtime(true);
 $queue = new SplQueue;
 for ($i = MAX_LOOPS; $i--;) {
-    $queue->push($i);
+    $queue->enqueue($i);
 }
 $i = MAX_LOOPS;
 while (!$queue->isEmpty()) {
@@ -24,11 +24,11 @@ go(function () use (&$time) {
     $time['channel_raw'] = microtime(true);
     $chan = new Chan(MAX_LOOPS);
     for ($i = MAX_LOOPS; $i--;) {
-        $chan->push($i);
+        $chan->enqueue($i);
     }
     $i = MAX_LOOPS;
     while (!$chan->isEmpty()) {
-        assert((--$i) === $chan->pop());
+        assert((--$i) === $chan->dequeue());
     }
     $time['channel_raw'] = microtime(true) - $time['channel_raw'];
 });
@@ -39,13 +39,13 @@ go(function () use (&$time, $chan) {
     co::sleep(0.1);
     $time['channel_scheduler'] = microtime(true);
     for ($i = MAX_LOOPS; $i--;) {
-        $chan->push($i);
+        $chan->enqueue($i);
     }
-    $chan->push(false);
+    $chan->enqueue(false);
 });
 go(function () use (&$time, $chan) {
     $i = MAX_LOOPS;
-    while (($ret = $chan->pop()) !== false) {
+    while (($ret = $chan->dequeue()) !== false) {
         assert((--$i) === $ret);
     }
     $time['channel_scheduler'] = microtime(true) - $time['channel_scheduler'];

--- a/tests/swoole_coroutine_channel/benchmark.phpt
+++ b/tests/swoole_coroutine_channel/benchmark.phpt
@@ -15,7 +15,7 @@ for ($i = MAX_LOOPS; $i--;) {
 }
 $i = MAX_LOOPS;
 while (!$queue->isEmpty()) {
-    assert((--$i) === $queue->shift());
+    assert((--$i) === $queue->dequeue());
 }
 $time['splQueue'] = microtime(true) - $time['splQueue'];
 
@@ -24,11 +24,11 @@ go(function () use (&$time) {
     $time['channel_raw'] = microtime(true);
     $chan = new Chan(MAX_LOOPS);
     for ($i = MAX_LOOPS; $i--;) {
-        $chan->enqueue($i);
+        $chan->push($i);
     }
     $i = MAX_LOOPS;
     while (!$chan->isEmpty()) {
-        assert((--$i) === $chan->dequeue());
+        assert((--$i) === $chan->pop());
     }
     $time['channel_raw'] = microtime(true) - $time['channel_raw'];
 });
@@ -39,13 +39,13 @@ go(function () use (&$time, $chan) {
     co::sleep(0.1);
     $time['channel_scheduler'] = microtime(true);
     for ($i = MAX_LOOPS; $i--;) {
-        $chan->enqueue($i);
+        $chan->push($i);
     }
-    $chan->enqueue(false);
+    $chan->push(false);
 });
 go(function () use (&$time, $chan) {
     $i = MAX_LOOPS;
-    while (($ret = $chan->dequeue()) !== false) {
+    while (($ret = $chan->pop()) !== false) {
         assert((--$i) === $ret);
     }
     $time['channel_scheduler'] = microtime(true) - $time['channel_scheduler'];

--- a/tests/swoole_redis_coro/pool.phpt
+++ b/tests/swoole_redis_coro/pool.phpt
@@ -48,10 +48,10 @@ $pm->childFunc = function () use ($pm)
                 return;
             }
             $count++;
-            $pool->push($redis);
+            $pool->enqueue($redis);
         }
 
-        $redis = $pool->pop();
+        $redis = $pool->dequeue();
         $ret = $redis->set('key', 'value');
         if ($ret)
         {
@@ -61,7 +61,7 @@ $pm->childFunc = function () use ($pm)
         {
             goto fail;
         }
-        $pool->push($redis);
+        $pool->enqueue($redis);
 
     });
 


### PR DESCRIPTION
`SplQueue` is operated using `enqueue()` and `dequeue()` not with `push()` and `pop()` which is for `Stack`.

`SplQueue` is a `FIFO`, but use of `push/pop` turns it into `Stack` which is `LIFO`, this has caused numerous disconnections that resulted into a swoole server crash.

By fixing this, disconnection from database server does not cause server crash anymore.

Ref.

[SplQueue dequeue](http://php.net/manual/en/splqueue.dequeue.php)
[SplQueue enqueue](http://php.net/manual/en/splqueue.enqueue.php)