### PR TITLE
原方法 socket->set_timeout(connect_timeout,true);无法实现连接超时

### DIFF
--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -647,7 +647,7 @@ bool http_client::connect()
         set();
 
         // connect
-        socket->set_timeout(connect_timeout, true);
+        socket->set_timeout(connect_timeout);
         if (!socket->connect(addr, port))
         {
             zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), socket->errCode);


### PR DESCRIPTION
原方法 socket->set_timeout(connect_timeout,true);无法实现连接超时
例如：
$cli = new Swoole\Coroutine\Http\Client('login.wx.qq.com', 99,true);
    $cli->setHeaders([
        'Host' => "login.wx.qq.com",
        "User-Agent" => 'Chrome/49.0.2587.3',
        'Accept' => 'text/html,application/xhtml+xml,application/xml',
        'Accept-Encoding' => 'gzip',
    ]);
    $cli->set([ 'connect_timeout' => 0.1]);
    $cli->get('/jslogin?appid=wx782c26e4c19acffb&redirect_uri=https%3A%2F%2Fwx.qq.com%2Fcgi-bin%2Fmmwebwx-bin%2Fwebwxnewloginpage&fun=new&lang=zh_CN&_=1545705992252');
    echo $cli->body;
    $cli->close();

故意向一个不存在的端口连接，则无法完整正常超时