### PR TITLE
fix async_thread join bug

### DIFF
--- a/src/network/async_thread.cc
+++ b/src/network/async_thread.cc
@@ -249,12 +249,15 @@ private:
             }
             else
             {
-                unique_lock<mutex> lock(_mutex);
-                ++n_waiting;
-                _cv.wait(lock);
-                --n_waiting;
+                if (running)
+                {
+                    unique_lock<mutex> lock(_mutex);
+                    ++n_waiting;
+                    _cv.wait(lock);
+                    --n_waiting;
+                }
             }
-            if (running )
+            if (running)
             {
                 goto _accept;
             }


### PR DESCRIPTION
async_thread_pool 在执行shutdown里 _cv.notify_all 时，有可能子线程还没创建完毕，导致子线程wait得不到唤醒，主线程也被挂起。

```
<?php 
    $wFile = __DIR__ . '/tmp';
    $wData = str_repeat('A', 1 * 128);
    swoole_async::writeFile($wFile, $wData, function ($file) use ($wData)
    {
        echo "SUCCESS\n";
    });
    swoole_event::wait();
```