### PR TITLE
fix swoole::clear_dns_cache bug

### DIFF
--- a/src/coroutine/hook.cc
+++ b/src/coroutine/hook.cc
@@ -51,7 +51,10 @@ void swoole::set_dns_cache_capacity(size_t capacity)
 
 void swoole::clear_dns_cache()
 {
-    dns_cache->clear();
+    if (dns_cache)
+    {
+        dns_cache->clear();
+    }
 }
 
 extern "C"

--- a/tests/swoole_function/swoole_clear_dns_cache.phpt
+++ b/tests/swoole_function/swoole_clear_dns_cache.phpt
@@ -1,0 +1,11 @@
+--TEST--
+swoole_function: test swoole_clear_dns_cache
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+swoole_clear_dns_cache();
+?>
+--EXPECT--


### PR DESCRIPTION
LRUCache 未初始化, 调用 swoole::clear_dns_cache 时  Segmentation fault