### PR TITLE
Implement full duplex coroutine socket

### DIFF
--- a/include/socket.h
+++ b/include/socket.h
@@ -255,7 +255,7 @@ protected:
                     SW_LOG_ERROR, SW_ERROR_CO_HAS_BEEN_BOUND,
                     "Socket#%d has already been bound to another coroutine#%ld, "
                     "%s of the same socket in multiple coroutines at the same time is not allowed.\n",
-                    socket->fd, cid, (event == SW_EVENT_READ ? "reading" : (SW_EVENT_WRITE ? "writing" : "reading or writing"))
+                    socket->fd, cid, (event == SW_EVENT_READ ? "reading" : (event == SW_EVENT_WRITE ? "writing" : "reading or writing"))
                 );
                 exit(255);
             }

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -306,11 +306,13 @@ enum swBool_type
 
 enum swEvent_type
 {
-    SW_EVENT_DEAULT = 256,
-    SW_EVENT_READ = 1u << 9,
-    SW_EVENT_WRITE = 1u << 10,
-    SW_EVENT_ERROR = 1u << 11,
-    SW_EVENT_ONCE = 1u << 12,
+    SW_EVENT_NULL   = 0,
+    SW_EVENT_DEAULT = 1u << 8,
+    SW_EVENT_READ   = 1u << 9,
+    SW_EVENT_WRITE  = 1u << 10,
+    SW_EVENT_RDWR   = SW_EVENT_READ | SW_EVENT_WRITE,
+    SW_EVENT_ERROR  = 1u << 11,
+    SW_EVENT_ONCE   = 1u << 12,
 };
 
 enum swPipe_type
@@ -2034,6 +2036,12 @@ typedef struct _swTimer_node swTimer_node;
 typedef void (*swTimerCallback)(swTimer *, swTimer_node *);
 typedef void (*swTimerDtor)(swTimer_node *);
 
+enum swTimer_type
+{
+    SW_TIMER_TYPE_KERNEL,
+    SW_TIMER_TYPE_PHP,
+};
+
 struct _swTimer_node
 {
     swHeap_node *heap_node;
@@ -2043,17 +2051,8 @@ struct _swTimer_node
     int64_t interval;
     uint64_t round;
     long id;
-    int type;                 //0 normal node 1 node for client_coro
+    enum swTimer_type type;
     uint8_t remove;
-};
-
-enum swTimer_type
-{
-    SW_TIMER_TYPE_KERNEL,
-    SW_TIMER_TYPE_PHP,
-    SW_TIMER_TYPE_CORO_READ,
-    SW_TIMER_TYPE_CORO_WRITE,
-    SW_TIMER_TYPE_CORO_ALL,
 };
 
 struct _swTimer

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -214,7 +214,7 @@ static bool client_coro_close(zval *zobject)
     if (cli)
     {
         zend_update_property_bool(Z_OBJCE_P(zobject), zobject, ZEND_STRL("connected"), 0);
-        if (!cli->has_bound())
+        if (!cli->get_bound_cid())
         {
 #ifdef SWOOLE_SOCKETS_SUPPORT
             zval *zsocket = (zval *) swoole_get_property(zobject, client_property_socket);
@@ -694,7 +694,7 @@ static PHP_METHOD(swoole_client_coro, connect)
         sw_coro_socket_set(cli, zset);
     }
 
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     cli->set_timeout(timeout == 0 ? PHPCoroutine::socket_connect_timeout : timeout);
     if (!cli->connect(host, port, sock_flag))
     {
@@ -737,20 +737,24 @@ static PHP_METHOD(swoole_client_coro, send)
 
     //clear errno
     SwooleG.error = 0;
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     double persistent_timeout = cli->get_timeout();
     cli->set_timeout(timeout);
-    int ret = cli->send_all(data, data_len);
+    ssize_t ret = cli->send_all(data, data_len);
     cli->set_timeout(persistent_timeout);
     if (ret < 0)
     {
-        swoole_php_sys_error(E_WARNING, "failed to send(%d) %zu bytes.", cli->socket->fd, data_len);
-        SwooleG.error = cli->errCode;
-        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
+        swoole_php_sys_error(E_WARNING, "failed to send %zu bytes to fd#%d.", data_len, cli->socket->fd);
+        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = cli->errCode));
         RETVAL_FALSE;
     }
     else
     {
+        if (ret < data_len && cli->errCode)
+        {
+            swoole_php_sys_error(E_WARNING, "expected sent %zu bytes to fd #%d but actually %zu bytes.", data_len, cli->socket->fd, ret);
+            zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = cli->errCode));
+        }
         RETURN_LONG(ret);
     }
 }
@@ -784,7 +788,7 @@ static PHP_METHOD(swoole_client_coro, sendto)
         }
         cli->socket->active = 1;
     }
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     SW_CHECK_RETURN(cli->sendto(ip, port, data, len));
 }
 
@@ -816,7 +820,7 @@ static PHP_METHOD(swoole_client_coro, recvfrom)
     }
 
     zend_string *retval = zend_string_alloc(length + 1, 0);
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     // cli->set_timeout(timeout, true); TODO
     ssize_t n_bytes = cli->recvfrom(retval->val, length);
     if (n_bytes < 0)
@@ -867,13 +871,12 @@ static PHP_METHOD(swoole_client_coro, sendfile)
     }
     //clear errno
     SwooleG.error = 0;
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     int ret = cli->sendfile(file, offset, length);
     if (ret < 0)
     {
-        SwooleG.error = errno;
-        swoole_php_error(E_WARNING, "sendfile() failed. Error: %s [%d]", strerror(SwooleG.error), SwooleG.error);
-        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
+        swoole_php_error(E_WARNING, "sendfile() failed. Error: %s [%d]", cli->errMsg, (SwooleG.error = cli->errCode));
+        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), cli->errCode);
         RETVAL_FALSE;
     }
     else
@@ -896,13 +899,11 @@ static PHP_METHOD(swoole_client_coro, recv)
     {
         RETURN_FALSE;
     }
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     ssize_t retval ;
     if (cli->open_length_check || cli->open_eof_check)
     {
-        cli->set_timer(Socket::TIMER_LV_GLOBAL, timeout);
-        retval = cli->recv_packet();
-        cli->del_timer(Socket::TIMER_LV_GLOBAL);
+        retval = cli->recv_packet(timeout);
         if (retval > 0)
         {
             RETVAL_STRINGL(cli->read_buffer->str, retval);
@@ -917,7 +918,7 @@ static PHP_METHOD(swoole_client_coro, recv)
         cli->set_timeout(persistent_timeout);
         if (retval > 0)
         {
-            result->val[retval] = 0;
+            result->val[retval] = '\0';
             result->len = retval;
             RETURN_STR(result);
         }
@@ -928,9 +929,8 @@ static PHP_METHOD(swoole_client_coro, recv)
     }
     if (retval < 0)
     {
-        SwooleG.error = cli->errCode;
-        swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", strerror(SwooleG.error), SwooleG.error);
-        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
+        swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", cli->errMsg, (SwooleG.error = cli->errCode));
+        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), cli->errCode);
         RETURN_FALSE;
     }
     else if (retval == 0)
@@ -961,9 +961,8 @@ static PHP_METHOD(swoole_client_coro, peek)
     ret = cli->peek(buf, buf_len);
     if (ret < 0)
     {
-        SwooleG.error = errno;
-        swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", strerror(SwooleG.error), SwooleG.error);
-        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
+        swoole_php_error(E_WARNING, "peek() failed. Error: %s [%d]", cli->errMsg, (SwooleG.error = cli->errCode));
+        zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), cli->errCode);
         efree(buf);
         RETURN_FALSE;
     }
@@ -1120,7 +1119,7 @@ static PHP_METHOD(swoole_client_coro, enableSSL)
     {
         sw_coro_socket_set_ssl(cli, zset);
     }
-    PHPCoroutine::check_bind("client", cli->has_bound());
+    PHPCoroutine::check_bind("client", cli->get_bound_cid());
     if (cli->ssl_handshake() == false)
     {
         RETURN_FALSE;

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -750,7 +750,7 @@ static PHP_METHOD(swoole_client_coro, send)
     }
     else
     {
-        if (ret < data_len && cli->errCode)
+        if ((ret < 0 || (size_t) ret < data_len) && cli->errCode)
         {
             swoole_php_sys_error(E_WARNING, "expected sent %zu bytes to fd #%d but actually %zu bytes.", data_len, cli->socket->fd, ret);
             zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = cli->errCode));

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -97,7 +97,7 @@ public:
             }
         } while (parser.state != s_start_res);
         // websocket stick package
-        if (parser.upgrade && retval > parsed_n + 1 + SW_WEBSOCKET_HEADER_LEN)
+        if (parser.upgrade && (size_t) retval > parsed_n + 1 + SW_WEBSOCKET_HEADER_LEN)
         {
             buffer->length = retval - parsed_n - 1;
             memmove(buffer->str, buffer->str + parsed_n + 1, buffer->length);

--- a/tests/include/functions.php
+++ b/tests/include/functions.php
@@ -151,14 +151,19 @@ function tcp_type_length(string $type = 'n'): int
     return $map[$type] ?? 0;
 }
 
-function tcp_length(string $head, string $type = 'n'): int
+function tcp_head(int $length, string $type = 'n') : string
 {
-    return unpack($type, $head)[1];
+    return pack($type, $length);
 }
 
 function tcp_pack(string $data, string $type = 'n'): string
 {
     return pack($type, strlen($data)) . $data;
+}
+
+function tcp_length(string $head, string $type = 'n'): int
+{
+    return unpack($type, $head)[1];
 }
 
 function tcp_unpack(string $data, string $type = 'n'): string
@@ -610,7 +615,7 @@ class ProcessManager
     protected $atomic;
     protected $alone = false;
     protected $freePorts = [];
-    protected $randomData = [];
+    protected $randomData = [[]];
 
     /**
      * wait wakeup 1s default
@@ -681,17 +686,29 @@ class ProcessManager
         return $this->freePorts[$index];
     }
 
-    public function initRandomData($size, $len = 32)
+    public function initRandomData(int $size, int $len = 32)
     {
-        for ($n = $size; $n--;) {
-            $this->randomData[] = get_safe_random($len);
+        $this->initRandomDataEx(1, $size, $len);
+    }
+
+    public function getRandomData(): string
+    {
+        return $this->getRandomDataEx(0);
+    }
+
+    public function initRandomDataEx(int $block_num, int $size, int $len)
+    {
+        for ($b = 0; $b < $block_num; $b++) {
+            for ($n = $size; $n--;) {
+                $this->randomData[$b][] = get_safe_random($len);
+            }
         }
     }
 
-    public function getRandomData($index = null): string
+    public function getRandomDataEx(int $block_id)
     {
-        if (!empty($this->randomData)) {
-            return array_shift($this->randomData);
+        if (!empty($this->randomData[$block_id])) {
+            return array_shift($this->randomData[$block_id]);
         } else {
             throw new \RuntimeException('Out of the bound');
         }

--- a/tests/swoole_client_coro/bug_2346.phpt
+++ b/tests/swoole_client_coro/bug_2346.phpt
@@ -23,15 +23,14 @@ $pm->parentFunc = function () use ($pm) {
             assert(@!$client->recv(0.2));
             assert($client->errCode === SOCKET_ETIMEDOUT);
             assert(approximate(0.2, microtime(true) - $s));
-
             // -1 & 0.3
             go(function () use ($client) {
                 co::sleep(0.3);
                 $client->close();
             });
-            assert(@$client->recv(-1) === ''); // connection closed
+            assert(@!$client->recv(-1)); // connection closed
+            assert($client->errCode === SOCKET_ECONNRESET);
             assert(approximate(0.5, microtime(true) - $s));
-
             // canceled
             echo "DONE\n";
         }

--- a/tests/swoole_client_coro/close_in_other_co.phpt
+++ b/tests/swoole_client_coro/close_in_other_co.phpt
@@ -5,7 +5,6 @@ swoole_client_coro: close in other coroutine
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';
-
 $cid = go(function () {
     $sock = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     assert($sock->bind('127.0.0.1', 9601));
@@ -20,9 +19,9 @@ $client = new Swoole\Coroutine\Client(SWOOLE_SOCK_TCP);
 
 go(function () use ($client) {
     $client->connect('127.0.0.1', 9601);
-    $data = $client->recv();
+    $data = @$client->recv();
     //socket is closed
-    assert($data === "");
+    assert(!$data && $client->errCode === SOCKET_ECONNRESET);
 });
 
 go(function () use ($client, $cid) {
@@ -33,5 +32,7 @@ go(function () use ($client, $cid) {
 });
 
 swoole_event_wait();
+echo "DONE\n";
 ?>
 --EXPECT--
+DONE

--- a/tests/swoole_feature/cross_close/client.phpt
+++ b/tests/swoole_feature/cross_close/client.phpt
@@ -19,7 +19,10 @@ $pm->parentFunc = function () use ($pm) {
             $pm->kill();
             echo "DONE\n";
         });
-        assert($cli->recv(-1) === '');
+        assert(!($ret = @$cli->recv(-1)));
+        if ($ret === false) {
+            assert($cli->errCode === SOCKET_ECONNRESET);
+        }
         echo "CLOSED\n";
         assert(!$cli->connected);
     });

--- a/tests/swoole_feature/cross_close/full_duplex.phpt
+++ b/tests/swoole_feature/cross_close/full_duplex.phpt
@@ -1,0 +1,71 @@
+--TEST--
+swoole_feature: cross_close: full duplex
+--SKIPIF--
+<?php require __DIR__ . '/../../include/config.php'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+ini_set('swoole.display_errors', false); // TODO: remove it
+
+function set_socket_buffer_size($php_socket, int $size)
+{
+    socket_set_option($php_socket, SOL_SOCKET, SO_SNDBUF, $size);
+    socket_set_option($php_socket, SOL_SOCKET, SO_RCVBUF, $size);
+}
+
+$pm = new ProcessManager();
+$pm->parentFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $cli = new Co\Client(SWOOLE_SOCK_TCP);
+        assert($cli->connect('127.0.0.1', $pm->getFreePort()));
+        assert($cli->connected);
+        set_socket_buffer_size($cli->getSocket(), 8192);
+        go(function () use ($pm, $cli) {
+            Co::sleep(0.001);
+            echo "CLOSE\n";
+            $cli->close();
+            $pm->kill();
+            echo "DONE\n";
+        });
+        go(function () use ($cli) {
+            echo "SEND\n";
+            $size = 16 * 1024 * 1024;
+            assert($cli->send(str_repeat('S', $size)) < $size);
+            assert(!$cli->connected);
+            echo "SEND CLOSED\n";
+        });
+        go(function () use ($cli) {
+            echo "RECV\n";
+            assert(!$cli->recv(-1));
+            assert(!$cli->connected);
+            echo "RECV CLOSED\n";
+        });
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $server = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        assert($server->bind('127.0.0.1', $pm->getFreePort()));
+        assert($server->listen());
+        go(function () use ($pm, $server) {
+            if (assert(($conn = $server->accept()) && $conn instanceof Co\Socket)) {
+                switch_process();
+                co::sleep(5);
+                $conn->close();
+            }
+            $server->close();
+        });
+        $pm->wakeup();
+    });
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+SEND
+RECV
+CLOSE
+SEND CLOSED
+RECV CLOSED
+DONE

--- a/tests/swoole_feature/cross_close/full_duplex_by_server.phpt
+++ b/tests/swoole_feature/cross_close/full_duplex_by_server.phpt
@@ -59,10 +59,10 @@ $pm->childFunc = function () use ($pm) {
 $pm->childFirst();
 $pm->run();
 ?>
---EXPECT--
+--EXPECTF--
 SEND
 RECV
 CLOSE
-SEND CLOSED
-RECV CLOSED
+%s CLOSED
+%s CLOSED
 DONE

--- a/tests/swoole_feature/cross_close/full_duplex_by_server.phpt
+++ b/tests/swoole_feature/cross_close/full_duplex_by_server.phpt
@@ -1,0 +1,68 @@
+--TEST--
+swoole_feature: cross_close: full duplex and close by server
+--SKIPIF--
+<?php require __DIR__ . '/../../include/config.php'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+ini_set('swoole.display_errors', false); // TODO: remove it
+
+function set_socket_buffer_size($php_socket, int $size)
+{
+    socket_set_option($php_socket, SOL_SOCKET, SO_SNDBUF, $size);
+    socket_set_option($php_socket, SOL_SOCKET, SO_RCVBUF, $size);
+}
+
+$pm = new ProcessManager();
+$pm->parentFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $cli = new Co\Client(SWOOLE_SOCK_TCP);
+        assert($cli->connect('127.0.0.1', $pm->getFreePort()));
+        assert($cli->connected);
+        set_socket_buffer_size($cli->getSocket(), 65536);
+        go(function () use ($cli) {
+            echo "SEND\n";
+            $size = 16 * 1024 * 1024;
+            assert($cli->send(str_repeat('S', $size)) < $size);
+            assert($cli->errCode === SOCKET_EPIPE);
+            echo "SEND CLOSED\n";
+        });
+        go(function () use ($cli) {
+            echo "RECV\n";
+            assert(!$cli->recv(-1));
+            assert($cli->errCode === SOCKET_ECONNRESET);
+            echo "RECV CLOSED\n";
+        });
+        $pm->wakeup();
+    });
+    Swoole\Event::wait();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $server = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        assert($server->bind('127.0.0.1', $pm->getFreePort()));
+        assert($server->listen());
+        go(function () use ($pm, $server) {
+            if (assert(($conn = $server->accept()) && $conn instanceof Co\Socket)) {
+                $pm->wait();
+                echo "CLOSE\n";
+                $conn->close();
+                switch_process();
+            }
+            $server->close();
+        });
+        $pm->wakeup();
+    });
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+SEND
+RECV
+CLOSE
+SEND CLOSED
+RECV CLOSED
+DONE

--- a/tests/swoole_feature/full_duplex/socket.phpt
+++ b/tests/swoole_feature/full_duplex/socket.phpt
@@ -1,0 +1,134 @@
+--TEST--
+swoole_feature: full_duplex: socket
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+const CHUNK_SIZE = 128 * 1024; // 128K
+const CHUNK_NUM = 8; // 1M
+const BUFFER_SIZE = CHUNK_SIZE / 2; // 64K
+
+function set_socket_buffer_size($php_socket, int $size)
+{
+    socket_set_option($php_socket, SOL_SOCKET, SO_SNDBUF, $size);
+    socket_set_option($php_socket, SOL_SOCKET, SO_RCVBUF, $size);
+}
+
+$pm = new ProcessManager;
+$pm->initRandomDataEx(MAX_CONCURRENCY_LOW, MAX_REQUESTS_LOW, CHUNK_SIZE);
+$pm->parentFunc = function ($pid) use ($pm) {
+    global $closer;
+    $closer = go(function () {
+        $closer = co::getCid();
+        $timer = Swoole\Timer::after(10 * 1000, function () use ($closer) {
+            echo "TIMEOUT\n";
+            co::resume($closer);
+        });
+        co::yield();
+        if (Swoole\Timer::exists($timer)) {
+            Swoole\Timer::clear($timer);
+        }
+        global $sockets;
+        foreach ($sockets as $socket) {
+            $socket->close();
+        }
+    });
+    for ($c = 0; $c < MAX_CONCURRENCY_LOW; $c++) {
+        go(function () use ($pm, $c) {
+            global $sockets;
+            $sockets[] = $socket = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+            $ret = $socket->connect('127.0.0.1', $pm->getFreePort(), -1);
+            if (!assert($ret)) {
+                throw new RuntimeException('connect failed');
+            } else {
+                set_socket_buffer_size($socket->getSocket(), BUFFER_SIZE);
+            }
+            // read
+            go(function () use ($pm, $socket, $c) {
+                for ($n = 0; $n < MAX_REQUESTS_LOW; $n++) {
+                    // id
+                    if (!$socket->send(tcp_head($c))) {
+                        break;
+                    }
+                    // length
+                    if (!$socket->send(tcp_head(CHUNK_SIZE * CHUNK_NUM, 'N'))) {
+                        break;
+                    }
+                    // data
+                    $data = $pm->getRandomDataEx($c);
+                    for ($p = CHUNK_NUM; $p--;) {
+                        $send_n = 0;
+                        do {
+                            $n_bytes = $socket->send(substr($data, $send_n));
+                            if (!$n_bytes) {
+                                break;
+                            }
+                            $send_n += $n_bytes;
+                        } while ($send_n !== CHUNK_SIZE);
+                    }
+                }
+            });
+            // write
+            go(function () use ($pm, $socket) {
+                while ($data = $socket->recv(tcp_type_length(), -1)) {
+                    global $count, $closer;
+                    @$count[tcp_length($data)]++;
+                    if (array_sum($count) === MAX_CONCURRENCY_LOW * MAX_REQUESTS_LOW * CHUNK_NUM) {
+                        phpt_var_dump($count);
+                        co::resume($closer);
+                    }
+                }
+            });
+        });
+    }
+    swoole_event::wait();
+    $pm->kill();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $server = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        assert($server->bind('127.0.0.1', $pm->getFreePort()));
+        assert($server->listen(MAX_CONCURRENCY));
+        while ($conn = $server->accept(-1)) {
+            if (!assert($conn instanceof Co\Socket)) {
+                throw new RuntimeException('accept failed');
+            } else {
+                set_socket_buffer_size($conn->getSocket(), BUFFER_SIZE);
+            }
+            go(function () use ($pm, $conn) {
+                while (true) {
+                    // id
+                    $head = $conn->recv(tcp_type_length(), -1);
+                    if (!$head || ($id = tcp_length($head)) < 0) {
+                        break;
+                    }
+                    // length
+                    $length = tcp_length($conn->recv(tcp_type_length('N'), -1), 'N');
+                    // data
+                    $verify = $pm->getRandomDataEx($id);
+                    do {
+                        $data = '';
+                        $need_n = CHUNK_SIZE;
+                        do {
+                            $data .= $conn->recv($need_n, -1);
+                            $need_n = CHUNK_SIZE - strlen($data);
+                        } while ($need_n !== 0);
+                        if (!assert($data === $verify)) {
+                            break;
+                        }
+                        $length -= strlen($data);
+                        $conn->send(tcp_head($id));
+                    } while ($length > 0);
+                }
+            });
+        }
+    });
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
+ 协程读写分离, 支持并发读写(全双工)
+ 通过栈上定时器的方式来解决多次yield操作的超时问题
+ 发生SSL重协商时, 会忽略重协商所需外的其它事件触发, 直到重协商完成
+ 添加`http_socket`和`recv_http_response`, 抽离http_parser(后期应将相关代码从socket.cc抽离至client.cc)