### PR TITLE
improve futex_wait code

### DIFF
--- a/swoole_atomic.c
+++ b/swoole_atomic.c
@@ -57,11 +57,14 @@ static sw_inline int swoole_futex_wait(sw_atomic_t *atomic, double timeout)
     {
         ret = syscall(SYS_futex, atomic, FUTEX_WAIT, 0, NULL, NULL, 0);
     }
-    if (ret == SW_OK)
+    if (ret == SW_OK && sw_atomic_cmp_set(atomic, 1, 0))
     {
-        sw_atomic_cmp_set(atomic, 1, 0);
+        return SW_OK;
     }
-    return ret;
+    else
+    {
+        return -1; 
+    }
 }
 
 static sw_inline int swoole_futex_wakeup(sw_atomic_t *atomic, int n)


### PR DESCRIPTION
to avoid a spurious wake-up and  unlikely contention in a case where one thread immediately call swoole_futex_wait after the call to `syscall(SYS_futex, atomic, FUTEX_WAIT, 0, NULL, NULL, 0)`  return just，we should validate the return value of  `sw_atomic_cmp_set(atomic,1,0)` ,  and following is the description of futex mannual:

 Note that a wake-up can also be caused by common futex usage patterns in unrelated code that happened to have previously used the futex word's memory location (e.g., typical futex-based implementations of Pthreads mutexes  can  cause  this  under  some  conditions). Therefore,  callers  should  always conservatively assume that a return value of 0 can mean a spurious wake-up, and use the futex word's value (i.e., the  user-space synchronization scheme) to decide whether to continue to block or not.

thanks !