### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ go(function () {
     // http2
     $http2_client = new Swoole\Coroutine\Http2\Client('localhost', 9501);
     $http2_client->connect();
-    $http2_request = new Swoole\Http2\Reuqest;
+    $http2_request = new Swoole\Http2\Request;
     $http2_request->method = 'POST';
     $http2_request->data = 'Swoole Http2';
     $http2_client->send($http2_request);


### PR DESCRIPTION
Changed `new Swoole\Http2\Reuqest` to `new Swoole\Http2\Request` in 'Kinds of Clients' section