### PR TITLE
修改携程客户端client报错提示问题

### DIFF
--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -934,7 +934,10 @@ static PHP_METHOD(swoole_client_coro, recv)
     }
     if (retval < 0)
     {
-        swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", cli->errMsg, (SwooleG.error = cli->errCode));
+        if (cli->errCode != 60)
+        {
+            swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", cli->errMsg, (SwooleG.error = cli->errCode));
+        }
         zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), cli->errCode);
         RETURN_FALSE;
     }


### PR DESCRIPTION
当出现用户设置了timeout且出现了timeout的时候，说明用户已经知晓该处调用可能出现超时，做了后续处理。底层不该再因为超时跑出日志，否在在爬虫应用中，一不小心就出现了因为timeout日志爆满