### PR TITLE
the return value of swScoket_wait_multi should be same as swSocket_wait

### DIFF
--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -160,7 +160,7 @@ int swSocket_wait_multi(int *list_of_fd, int n_fd, int timeout_ms, int events)
         else
         {
             sw_free(event_list);
-            return ret;
+            return SW_OK;
         }
     }
     sw_free(event_list);


### PR DESCRIPTION
如果其返回值与swSocket_wait保持一致，应该会更好吧