### PR TITLE
fix i?86/aarch64 build check

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -527,7 +527,9 @@ if test "$PHP_SWOOLE" != "no"; then
     AS_CASE([$host_cpu],
       [x86_64*], [SW_CPU="x86_64"],
       [x86*], [SW_CPU="x86"],
+      [i?86*], [SW_CPU="x86"],
       [arm*], [SW_CPU="arm"],
+      [aarch64*], [SW_CPU="arm64"],
       [arm64*], [SW_CPU="arm64"],
       [
         SW_NO_USE_ASM_CONTEXT="yes"


### PR DESCRIPTION
x86-32 cpu name is named "i?86" (which ? is 3, 5 or 6) on gnu autotools, apple named it "x86" so that won't applied to those machines using gnu tools.
Same for "aarch64"(gnu style) and "arm64"(apple style)
Thanks to @andypost find out this problem via [alpinelinux/aports#6826](https://github.com/alpinelinux/aports/pull/6826/commits/574463949fefd0cf2bf71b62cc45231b8524b25c)
also see #2181