### PR TITLE
Swoole error log

### DIFF
--- a/core-tests/src/pipe.cpp
+++ b/core-tests/src/pipe.cpp
@@ -19,7 +19,7 @@ TEST(pipe, unixsock)
     ret = p.read(&p, buf, sizeof(buf));
     if (ret < 0)
     {
-        swSysError("read() failed.");
+        swSysWarn("read() failed.");
     }
     ASSERT_GT(ret, 0);
     ASSERT_EQ(strcmp("hello world1", buf), 0);

--- a/include/context.h
+++ b/include/context.h
@@ -38,15 +38,17 @@ static bool protect_stack(void *top, size_t stack_size, uint32_t page)
 {
     if (stack_size <= SwooleG.pagesize * (page + 1))
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_CO_PROTECT_STACK_FAILED, "getpagesize() failed.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_CO_PROTECT_STACK_FAILED, "getpagesize() failed");
         return false;
     }
 #ifdef PROT_NONE
     void *protect_page_addr = ((size_t) top & 0xfff) ? (void*) (((size_t) top & ~(size_t) 0xfff) + 0x1000) : top;
     if (-1 == mprotect(protect_page_addr, SwooleG.pagesize * page, PROT_NONE))
     {
-        swSysWarn("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
-                protect_page_addr, SwooleG.pagesize, page);
+        swSysWarn(
+            "mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u",
+            top, protect_page_addr, SwooleG.pagesize, page
+        );
         return false;
     }
     else
@@ -62,13 +64,15 @@ static bool unprotect_stack(void *top, uint32_t page)
 #ifdef PROT_READ
     if (-1 == mprotect(protect_page_addr, SwooleG.pagesize * page, PROT_READ | PROT_WRITE))
     {
-        swSysWarn("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
-                protect_page_addr, SwooleG.pagesize, page);
+        swSysWarn(
+            "mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u",
+            top, protect_page_addr, SwooleG.pagesize, page
+        );
         return false;
     }
     else
     {
-        swDebug("origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top, protect_page_addr, page, SwooleG.pagesize);
+        swDebug("origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u", top, protect_page_addr, page, SwooleG.pagesize);
         return true;
     }
 #endif

--- a/include/context.h
+++ b/include/context.h
@@ -45,7 +45,7 @@ static bool protect_stack(void *top, size_t stack_size, uint32_t page)
     void *protect_page_addr = ((size_t) top & 0xfff) ? (void*) (((size_t) top & ~(size_t) 0xfff) + 0x1000) : top;
     if (-1 == mprotect(protect_page_addr, SwooleG.pagesize * page, PROT_NONE))
     {
-        swSysError("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
+        swSysWarn("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
                 protect_page_addr, SwooleG.pagesize, page);
         return false;
     }
@@ -62,7 +62,7 @@ static bool unprotect_stack(void *top, uint32_t page)
 #ifdef PROT_READ
     if (-1 == mprotect(protect_page_addr, SwooleG.pagesize * page, PROT_READ | PROT_WRITE))
     {
-        swSysError("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
+        swSysWarn("mprotect() failed: origin_addr:%p, align_addr:%p, page_size:%d, protect_page:%u.", top,
                 protect_page_addr, SwooleG.pagesize, page);
         return false;
     }

--- a/include/server.h
+++ b/include/server.h
@@ -735,7 +735,7 @@ static sw_inline swString* swTaskWorker_large_unpack(swEventData *task_result)
     int tmp_file_fd = open(_pkg.tmpfile, O_RDONLY);
     if (tmp_file_fd < 0)
     {
-        swSysWarn("open(%s) failed.", _pkg.tmpfile);
+        swSysWarn("open(%s) failed", _pkg.tmpfile);
         return NULL;
     }
     if (SwooleTG.buffer_stack->size < _pkg.length && swString_extend_align(SwooleTG.buffer_stack, _pkg.length) < 0)

--- a/include/server.h
+++ b/include/server.h
@@ -735,7 +735,7 @@ static sw_inline swString* swTaskWorker_large_unpack(swEventData *task_result)
     int tmp_file_fd = open(_pkg.tmpfile, O_RDONLY);
     if (tmp_file_fd < 0)
     {
-        swSysError("open(%s) failed.", _pkg.tmpfile);
+        swSysWarn("open(%s) failed.", _pkg.tmpfile);
         return NULL;
     }
     if (SwooleTG.buffer_stack->size < _pkg.length && swString_extend_align(SwooleTG.buffer_stack, _pkg.length) < 0)

--- a/include/socket.h
+++ b/include/socket.h
@@ -206,7 +206,7 @@ public:
     {
         if (setsockopt(socket->fd, level, optname, &optval, sizeof(optval)) != 0)
         {
-            swSysError("setsockopt(%d, %d, %d, %d) failed.", socket->fd, level, optname, optval);
+            swSysWarn("setsockopt(%d, %d, %d, %d) failed.", socket->fd, level, optname, optval);
             return false;
         }
         return true;

--- a/include/socket.h
+++ b/include/socket.h
@@ -206,7 +206,7 @@ public:
     {
         if (setsockopt(socket->fd, level, optname, &optval, sizeof(optval)) != 0)
         {
-            swSysWarn("setsockopt(%d, %d, %d, %d) failed.", socket->fd, level, optname, optval);
+            swSysWarn("setsockopt(%d, %d, %d, %d) failed", socket->fd, level, optname, optval);
             return false;
         }
         return true;

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -419,7 +419,7 @@ enum swWorker_status
         SwooleG.error = errno;\
         if (SW_LOG_ERROR >= SwooleG.log_level) {\
             SwooleGS->lock_2.lock(&SwooleGS->lock_2);\
-            size_t _sw_errror_len = sw_snprintf(sw_error,SW_ERROR_MSG_SIZE,"%s(:%d): " str " Error: %s[%d].",__func__,__LINE__,##__VA_ARGS__,strerror(errno),errno);\
+            size_t _sw_errror_len = sw_snprintf(sw_error,SW_ERROR_MSG_SIZE,"%s(:%d): " str ", Error: %s[%d]",__func__,__LINE__,##__VA_ARGS__,strerror(errno),errno);\
             SwooleG.write_log(SW_LOG_WARNING, sw_error, _sw_errror_len);\
             SwooleGS->lock_2.unlock(&SwooleGS->lock_2);\
         }\
@@ -437,7 +437,7 @@ enum swWorker_status
 #define swSysError(str,...) \
     do{\
         SwooleGS->lock_2.lock(&SwooleGS->lock_2);\
-        size_t _sw_errror_len = sw_snprintf(sw_error,SW_ERROR_MSG_SIZE,"%s(:%d): " str " Error: %s[%d].",__func__,__LINE__,##__VA_ARGS__,strerror(errno),errno);\
+        size_t _sw_errror_len = sw_snprintf(sw_error,SW_ERROR_MSG_SIZE,"%s(:%d): " str ", Error: %s[%d]",__func__,__LINE__,##__VA_ARGS__,strerror(errno),errno);\
         SwooleG.write_log(SW_LOG_ERROR, sw_error, _sw_errror_len);\
         SwooleGS->lock_2.unlock(&SwooleGS->lock_2);\
         exit(1);\

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -434,6 +434,15 @@ enum swWorker_status
         exit(1);\
     } while(0)
 
+#define swSysError(str,...) \
+    do{\
+        SwooleGS->lock_2.lock(&SwooleGS->lock_2);\
+        size_t _sw_errror_len = sw_snprintf(sw_error,SW_ERROR_MSG_SIZE,"%s(:%d): " str " Error: %s[%d].",__func__,__LINE__,##__VA_ARGS__,strerror(errno),errno);\
+        SwooleG.write_log(SW_LOG_ERROR, sw_error, _sw_errror_len);\
+        SwooleGS->lock_2.unlock(&SwooleGS->lock_2);\
+        exit(1);\
+    } while(0)
+
 #define swFatalError(code, str,...) \
         SwooleG.fatal_error(code, str, ##__VA_ARGS__)
 

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -414,7 +414,7 @@ enum swWorker_status
         SwooleGS->lock_2.unlock(&SwooleGS->lock_2);\
     }
 
-#define swSysError(str,...) \
+#define swSysWarn(str,...) \
     do{\
         SwooleG.error = errno;\
         if (SW_LOG_ERROR >= SwooleG.log_level) {\

--- a/include/table.h
+++ b/include/table.h
@@ -180,7 +180,7 @@ static sw_inline void swTableRow_set_value(swTableRow *row, swTableColumn * col,
     default:
         if (vlen > (col->size - sizeof(swTable_string_length_t)))
         {
-            swWarn("[key=%s,field=%s]string value is too long.", row->key, col->name->str);
+            swWarn("[key=%s,field=%s]string value is too long", row->key, col->name->str);
             vlen = col->size - sizeof(swTable_string_length_t);
         }
         memcpy(row->data + col->index, &vlen, sizeof(swTable_string_length_t));

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -116,14 +116,18 @@ extern swoole_object_array swoole_objects;
 #undef HAVE_PTRACE
 #endif
 
-#define SW_CHECK_RETURN(s)         if(s<0){RETURN_FALSE;}else{RETURN_TRUE;}
-#define SW_LOCK_CHECK_RETURN(s)    if(s==0){RETURN_TRUE;}else{\
-	zend_update_property_long(NULL, getThis(), SW_STRL("errCode"), s);\
-	RETURN_FALSE;}
+#define SW_CHECK_RETURN(s)      if(s<0){RETURN_FALSE;}else{RETURN_TRUE;}
+#define SW_LOCK_CHECK_RETURN(s) if(s==0){RETURN_TRUE;}else{zend_update_property_long(NULL,getThis(),SW_STRL("errCode"),s);RETURN_FALSE;}
 
-#define swoole_php_fatal_error(level, fmt_str, ...) php_error_docref(NULL, level, (const char *) fmt_str, ##__VA_ARGS__)
-#define swoole_php_error(level, fmt_str, ...)       if (SWOOLE_G(display_errors)) swoole_php_fatal_error(level, fmt_str, ##__VA_ARGS__)
-#define swoole_php_sys_error(level, fmt_str, ...)   if (SWOOLE_G(display_errors)) swoole_php_error(level, fmt_str ", Error: %s[%d]", ##__VA_ARGS__, strerror(errno), errno)
+#define swoole_php_fatal_error(level, fmt_str, ...) \
+        php_error_docref(NULL, level, (const char *) fmt_str, ##__VA_ARGS__)
+
+#define swoole_php_error(level, fmt_str, ...) \
+    if (SWOOLE_G(display_errors) || level == E_ERROR) \
+        swoole_php_fatal_error(level, fmt_str, ##__VA_ARGS__)
+
+#define swoole_php_sys_error(level, fmt_str, ...) \
+        swoole_php_error(level, fmt_str ", Error: %s[%d]", ##__VA_ARGS__, strerror(errno), errno)
 
 #ifdef SW_USE_OPENSSL
 #ifndef HAVE_OPENSSL

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -123,11 +123,11 @@ extern swoole_object_array swoole_objects;
 
 #define swoole_php_fatal_error(level, fmt_str, ...) php_error_docref(NULL, level, (const char *) fmt_str, ##__VA_ARGS__)
 #define swoole_php_error(level, fmt_str, ...)       if (SWOOLE_G(display_errors)) swoole_php_fatal_error(level, fmt_str, ##__VA_ARGS__)
-#define swoole_php_sys_error(level, fmt_str, ...)   if (SWOOLE_G(display_errors)) swoole_php_error(level, fmt_str " Error: %s[%d].", ##__VA_ARGS__, strerror(errno), errno)
+#define swoole_php_sys_error(level, fmt_str, ...)   if (SWOOLE_G(display_errors)) swoole_php_error(level, fmt_str ", Error: %s[%d]", ##__VA_ARGS__, strerror(errno), errno)
 
 #ifdef SW_USE_OPENSSL
 #ifndef HAVE_OPENSSL
-#error "Enable openssl support, require openssl library."
+#error "Enable openssl support, require openssl library"
 #endif
 #endif
 
@@ -141,7 +141,7 @@ extern swoole_object_array swoole_objects;
 #endif
 
 #if PHP_MAJOR_VERSION < 7
-#error "require PHP version 7.0 or later."
+#error "require PHP version 7.0 or later"
 #endif
 
 //--------------------------------------------------------

--- a/src/core/array.c
+++ b/src/core/array.c
@@ -25,7 +25,7 @@ swArray *swArray_new(int page_size, size_t item_size)
     swArray *array = sw_malloc(sizeof(swArray));
     if (array == NULL)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "malloc[0] failed.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "malloc[0] failed");
         return NULL;
     }
     bzero(array, sizeof(swArray));
@@ -34,7 +34,7 @@ swArray *swArray_new(int page_size, size_t item_size)
     if (array->pages == NULL)
     {
         sw_free(array);
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "malloc[1] failed.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "malloc[1] failed");
         return NULL;
     }
 
@@ -73,7 +73,7 @@ int swArray_extend(swArray *array)
     array->pages[array->page_num] = sw_calloc(array->page_size, array->item_size);
     if (array->pages[array->page_num] == NULL)
     {
-        swWarn("malloc[1] failed.");
+        swWarn("malloc[1] failed");
         return SW_ERR;
     }
     array->page_num++;

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -104,7 +104,7 @@ void swoole_init(void)
     struct rlimit rlmt;
     if (getrlimit(RLIMIT_NOFILE, &rlmt) < 0)
     {
-        swSysError("getrlimit() failed");
+        swSysWarn("getrlimit() failed");
     }
     else
     {
@@ -309,7 +309,7 @@ int swoole_mkdir_recursive(const char *dir)
             {
                 if (mkdir(tmp, 0755) == -1)
                 {
-                    swSysError("mkdir(%s) failed", tmp);
+                    swSysWarn("mkdir(%s) failed", tmp);
                     return -1;
                 }
             }
@@ -420,7 +420,7 @@ size_t swoole_sync_writefile(int fd, const void *data, size_t len)
             {
                 continue;
             }
-            swSysError("write(%d, %d) failed.", fd, towrite);
+            swSysWarn("write(%d, %d) failed.", fd, towrite);
             break;
         }
     }
@@ -470,7 +470,7 @@ int swoole_system_random(int min, int max)
 
     if (read(dev_random_fd, next_random_byte, bytes_to_read) < bytes_to_read)
     {
-        swSysError("read() from /dev/urandom failed.");
+        swSysWarn("read() from /dev/urandom failed.");
         return SW_ERR;
     }
     return min + (random_value % (max - min + 1));
@@ -572,7 +572,7 @@ int swoole_tmpfile(char *filename)
 
     if (tmp_fd < 0)
     {
-        swSysError("mkstemp(%s) failed.", filename);
+        swSysWarn("mkstemp(%s) failed.", filename);
         return SW_ERR;
     }
     else
@@ -601,7 +601,7 @@ long swoole_file_size(char *filename)
     struct stat file_stat;
     if (lstat(filename, &file_stat) < 0)
     {
-        swSysError("lstat(%s) failed.", filename);
+        swSysWarn("lstat(%s) failed.", filename);
         SwooleG.error = errno;
         return -1;
     }
@@ -634,7 +634,7 @@ swString* swoole_file_get_contents(char *filename)
     int fd = open(filename, O_RDONLY);
     if (fd < 0)
     {
-        swSysError("open(%s) failed", filename);
+        swSysWarn("open(%s) failed", filename);
         return NULL;
     }
     swString *content = swString_new(filesize);
@@ -658,7 +658,7 @@ swString* swoole_file_get_contents(char *filename)
             }
             else
             {
-                swSysError("pread(%d, %ld, %d) failed.", fd, filesize - readn, readn);
+                swSysWarn("pread(%d, %ld, %d) failed.", fd, filesize - readn, readn);
                 swString_free(content);
                 close(fd);
                 return NULL;
@@ -687,7 +687,7 @@ int swoole_file_put_contents(char *filename, char *content, size_t length)
     int fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0666);
     if (fd < 0)
     {
-        swSysError("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed.", filename);
         return SW_ERR;
     }
 
@@ -709,7 +709,7 @@ int swoole_file_put_contents(char *filename, char *content, size_t length)
             }
             else
             {
-                swSysError("write(%d, %d) failed.", fd, chunk_size);
+                swSysWarn("write(%d, %d) failed.", fd, chunk_size);
                 close(fd);
                 return -1;
             }
@@ -749,7 +749,7 @@ size_t swoole_sync_readfile(int fd, void *buf, size_t len)
             {
                 continue;
             }
-            swSysError("read() failed");
+            swSysWarn("read() failed");
             break;
         }
     }
@@ -880,7 +880,7 @@ void swoole_ioctl_set_block(int sock, int nonblock)
 
     if (ret < 0)
     {
-        swSysError("ioctl(%d, FIONBIO, %d) failed.", sock, nonblock);
+        swSysWarn("ioctl(%d, FIONBIO, %d) failed.", sock, nonblock);
     }
 }
 
@@ -898,7 +898,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (opts < 0)
         {
-            swSysError("fcntl(%d, GETFL) failed.", sock);
+            swSysWarn("fcntl(%d, GETFL) failed.", sock);
         }
 
         if (nonblock)
@@ -918,7 +918,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (ret < 0)
         {
-            swSysError("fcntl(%d, SETFL, opts) failed.", sock);
+            swSysWarn("fcntl(%d, SETFL, opts) failed.", sock);
         }
     }
 
@@ -933,7 +933,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (opts < 0)
         {
-            swSysError("fcntl(%d, GETFL) failed.", sock);
+            swSysWarn("fcntl(%d, GETFL) failed.", sock);
         }
 
         if (cloexec)
@@ -953,7 +953,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (ret < 0)
         {
-            swSysError("fcntl(%d, SETFD, opts) failed.", sock);
+            swSysWarn("fcntl(%d, SETFD, opts) failed.", sock);
         }
     }
 #endif
@@ -1310,7 +1310,7 @@ int swoole_shell_exec(const char *command, pid_t *pid, uint8_t get_error_stream)
 
     if ((child_pid = fork()) == -1)
     {
-        swSysError("fork() failed.");
+        swSysWarn("fork() failed.");
         close(fds[0]);
         close(fds[1]);
         return SW_ERR;

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -172,7 +172,7 @@ pid_t swoole_fork()
 {
     if (swoole_coroutine_is_in())
     {
-        swError("must be forked outside the coroutine");
+        swFatalError(SW_ERROR_OPERATION_NOT_SUPPORT, "must be forked outside the coroutine");
         return -1;
     }
     if (SwooleAIO.init)

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -84,13 +84,13 @@ void swoole_init(void)
     SwooleG.memory_pool = swMemoryGlobal_new(SW_GLOBAL_MEMORY_PAGESIZE, 1);
     if (SwooleG.memory_pool == NULL)
     {
-        printf("[Master] Fatal Error: global memory allocation failure.");
+        printf("[Master] Fatal Error: global memory allocation failure");
         exit(1);
     }
     SwooleGS = SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(SwooleGS_t));
     if (SwooleGS == NULL)
     {
-        printf("[Master] Fatal Error: failed to allocate memory for SwooleGS.");
+        printf("[Master] Fatal Error: failed to allocate memory for SwooleGS");
         exit(2);
     }
 
@@ -131,7 +131,7 @@ void swoole_init(void)
     //create tmp dir
     if (access(tmp_dir, R_OK) < 0 && swoole_mkdir_recursive(tmp_dir) < 0)
     {
-        swWarn("create task tmp dir(%s) failed.", tmp_dir);
+        swWarn("create task tmp dir(%s) failed", tmp_dir);
     }
     if (tmp_dir)
     {
@@ -172,7 +172,7 @@ pid_t swoole_fork()
 {
     if (swoole_coroutine_is_in())
     {
-        swError("must be forked outside the coroutine.");
+        swError("must be forked outside the coroutine");
         return -1;
     }
     if (SwooleAIO.init)
@@ -196,7 +196,7 @@ pid_t swoole_fork()
         SwooleG.memory_pool = swMemoryGlobal_new(SW_GLOBAL_MEMORY_PAGESIZE, 1);
         if (SwooleG.memory_pool == NULL)
         {
-            printf("[Worker] Fatal Error: global memory allocation failure.");
+            printf("[Worker] Fatal Error: global memory allocation failure");
             exit(1);
         }
         /**
@@ -288,7 +288,7 @@ int swoole_mkdir_recursive(const char *dir)
 
     if (len + 1 > PATH_MAX) /* PATH_MAX limit includes string trailing null character */
     {
-        swWarn("mkdir(%s) failed. Path exceeds the limit of %d characters.", dir, PATH_MAX - 1);
+        swWarn("mkdir(%s) failed. Path exceeds the limit of %d characters", dir, PATH_MAX - 1);
         return -1;
     }
     strncpy(tmp, dir, PATH_MAX);
@@ -327,7 +327,7 @@ char* swoole_dirname(char *file)
     char *dirname = sw_strdup(file);
     if (dirname == NULL)
     {
-        swWarn("strdup() failed.");
+        swWarn("strdup() failed");
         return NULL;
     }
 
@@ -420,7 +420,7 @@ size_t swoole_sync_writefile(int fd, const void *data, size_t len)
             {
                 continue;
             }
-            swSysWarn("write(%d, %d) failed.", fd, towrite);
+            swSysWarn("write(%d, %d) failed", fd, towrite);
             break;
         }
     }
@@ -470,7 +470,7 @@ int swoole_system_random(int min, int max)
 
     if (read(dev_random_fd, next_random_byte, bytes_to_read) < bytes_to_read)
     {
-        swSysWarn("read() from /dev/urandom failed.");
+        swSysWarn("read() from /dev/urandom failed");
         return SW_ERR;
     }
     return min + (random_value % (max - min + 1));
@@ -572,7 +572,7 @@ int swoole_tmpfile(char *filename)
 
     if (tmp_fd < 0)
     {
-        swSysWarn("mkstemp(%s) failed.", filename);
+        swSysWarn("mkstemp(%s) failed", filename);
         return SW_ERR;
     }
     else
@@ -601,7 +601,7 @@ long swoole_file_size(char *filename)
     struct stat file_stat;
     if (lstat(filename, &file_stat) < 0)
     {
-        swSysWarn("lstat(%s) failed.", filename);
+        swSysWarn("lstat(%s) failed", filename);
         SwooleG.error = errno;
         return -1;
     }
@@ -622,12 +622,12 @@ swString* swoole_file_get_contents(char *filename)
     }
     else if (filesize == 0)
     {
-        swoole_error_log(SW_LOG_TRACE, SW_ERROR_FILE_EMPTY, "file[%s] is empty.", filename);
+        swoole_error_log(SW_LOG_TRACE, SW_ERROR_FILE_EMPTY, "file[%s] is empty", filename);
         return NULL;
     }
     else if (filesize > SW_MAX_FILE_CONTENT)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_FILE_TOO_LARGE, "file[%s] is too large.", filename);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_FILE_TOO_LARGE, "file[%s] is too large", filename);
         return NULL;
     }
 
@@ -658,7 +658,7 @@ swString* swoole_file_get_contents(char *filename)
             }
             else
             {
-                swSysWarn("pread(%d, %ld, %d) failed.", fd, filesize - readn, readn);
+                swSysWarn("pread(%d, %ld, %d) failed", fd, filesize - readn, readn);
                 swString_free(content);
                 close(fd);
                 return NULL;
@@ -675,19 +675,19 @@ int swoole_file_put_contents(char *filename, char *content, size_t length)
 {
     if (length <= 0)
     {
-        swoole_error_log(SW_LOG_TRACE, SW_ERROR_FILE_EMPTY, "content is empty.");
+        swoole_error_log(SW_LOG_TRACE, SW_ERROR_FILE_EMPTY, "content is empty");
         return SW_ERR;
     }
     if (length > SW_MAX_FILE_CONTENT)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_FILE_TOO_LARGE, "content is too large.");
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_FILE_TOO_LARGE, "content is too large");
         return SW_ERR;
     }
 
     int fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0666);
     if (fd < 0)
     {
-        swSysWarn("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed", filename);
         return SW_ERR;
     }
 
@@ -709,7 +709,7 @@ int swoole_file_put_contents(char *filename, char *content, size_t length)
             }
             else
             {
-                swSysWarn("write(%d, %d) failed.", fd, chunk_size);
+                swSysWarn("write(%d, %d) failed", fd, chunk_size);
                 close(fd);
                 return -1;
             }
@@ -880,7 +880,7 @@ void swoole_ioctl_set_block(int sock, int nonblock)
 
     if (ret < 0)
     {
-        swSysWarn("ioctl(%d, FIONBIO, %d) failed.", sock, nonblock);
+        swSysWarn("ioctl(%d, FIONBIO, %d) failed", sock, nonblock);
     }
 }
 
@@ -898,7 +898,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (opts < 0)
         {
-            swSysWarn("fcntl(%d, GETFL) failed.", sock);
+            swSysWarn("fcntl(%d, GETFL) failed", sock);
         }
 
         if (nonblock)
@@ -918,7 +918,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (ret < 0)
         {
-            swSysWarn("fcntl(%d, SETFL, opts) failed.", sock);
+            swSysWarn("fcntl(%d, SETFL, opts) failed", sock);
         }
     }
 
@@ -933,7 +933,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (opts < 0)
         {
-            swSysWarn("fcntl(%d, GETFL) failed.", sock);
+            swSysWarn("fcntl(%d, GETFL) failed", sock);
         }
 
         if (cloexec)
@@ -953,7 +953,7 @@ void swoole_fcntl_set_option(int sock, int nonblock, int cloexec)
 
         if (ret < 0)
         {
-            swSysWarn("fcntl(%d, SETFD, opts) failed.", sock);
+            swSysWarn("fcntl(%d, SETFD, opts) failed", sock);
         }
     }
 #endif
@@ -1223,7 +1223,7 @@ int swoole_getaddrinfo(swRequest_getaddrinfo *req)
             memcpy((char *) buffer + (i * sizeof(struct sockaddr_in6)), ptr->ai_addr, sizeof(struct sockaddr_in6));
             break;
         default:
-            swWarn("unknown socket family[%d].", ptr->ai_family);
+            swWarn("unknown socket family[%d]", ptr->ai_family);
             break;
         }
         i++;
@@ -1250,7 +1250,7 @@ SW_API int swoole_add_function(const char *name, void* func)
     }
     if (swHashMap_find(SwooleG.functions, (char *) name, strlen(name)) != NULL)
     {
-        swWarn("Function '%s' has already been added.", name);
+        swWarn("Function '%s' has already been added", name);
         return SW_ERR;
     }
     return swHashMap_add(SwooleG.functions, (char *) name, strlen(name), func);
@@ -1310,7 +1310,7 @@ int swoole_shell_exec(const char *command, pid_t *pid, uint8_t get_error_stream)
 
     if ((child_pid = fork()) == -1)
     {
-        swSysWarn("fork() failed.");
+        swSysWarn("fork() failed");
         close(fds[0]);
         close(fds[1]);
         return SW_ERR;

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -104,7 +104,7 @@ void swoole_init(void)
     struct rlimit rlmt;
     if (getrlimit(RLIMIT_NOFILE, &rlmt) < 0)
     {
-        swWarn("getrlimit() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("getrlimit() failed");
     }
     else
     {
@@ -309,7 +309,7 @@ int swoole_mkdir_recursive(const char *dir)
             {
                 if (mkdir(tmp, 0755) == -1)
                 {
-                    swWarn("mkdir(%s) failed. Error: %s[%d]", tmp, strerror(errno), errno);
+                    swSysError("mkdir(%s) failed", tmp);
                     return -1;
                 }
             }
@@ -634,7 +634,7 @@ swString* swoole_file_get_contents(char *filename)
     int fd = open(filename, O_RDONLY);
     if (fd < 0)
     {
-        swWarn("open(%s) failed. Error: %s[%d]", filename, strerror(errno), errno);
+        swSysError("open(%s) failed", filename);
         return NULL;
     }
     swString *content = swString_new(filesize);
@@ -749,7 +749,7 @@ size_t swoole_sync_readfile(int fd, void *buf, size_t len)
             {
                 continue;
             }
-            swWarn("read() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("read() failed");
             break;
         }
     }

--- a/src/core/base.c
+++ b/src/core/base.c
@@ -480,11 +480,11 @@ void swoole_redirect_stdout(int new_fd)
 {
     if (dup2(new_fd, STDOUT_FILENO) < 0)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "dup2(STDOUT_FILENO) failed. Error: %s[%d]", strerror(errno), errno);
+        swSysWarn("dup2(STDOUT_FILENO) failed");
     }
     if (dup2(new_fd, STDERR_FILENO) < 0)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "dup2(STDERR_FILENO) failed. Error: %s[%d]", strerror(errno), errno);
+        swSysWarn("dup2(STDERR_FILENO) failed");
     }
 }
 

--- a/src/core/channel.c
+++ b/src/core/channel.c
@@ -45,7 +45,7 @@ swChannel* swChannel_new(size_t size, int maxlen, int flags)
 
     if (mem == NULL)
     {
-        swWarn("swChannel_create: malloc(%ld) failed.", size);
+        swWarn("swChannel_create: malloc(%ld) failed", size);
         return NULL;
     }
     swChannel *object = mem;
@@ -65,7 +65,7 @@ swChannel* swChannel_new(size_t size, int maxlen, int flags)
         //init lock
         if (swMutex_create(&object->lock, 1) < 0)
         {
-            swWarn("mutex init failed.");
+            swWarn("mutex init failed");
             return NULL;
         }
     }
@@ -75,7 +75,7 @@ swChannel* swChannel_new(size_t size, int maxlen, int flags)
         ret = swPipeNotify_auto(&object->notify_fd, 1, 1);
         if (ret < 0)
         {
-            swWarn("notify_fd init failed.");
+            swWarn("notify_fd init failed");
             return NULL;
         }
     }

--- a/src/core/hashmap.c
+++ b/src/core/hashmap.c
@@ -95,13 +95,13 @@ swHashMap* swHashMap_new(uint32_t bucket_num, swHashMap_dtor dtor)
     swHashMap *hmap = sw_malloc(sizeof(swHashMap));
     if (!hmap)
     {
-        swWarn("malloc[1] failed.");
+        swWarn("malloc[1] failed");
         return NULL;
     }
     swHashMap_node *root = sw_malloc(sizeof(swHashMap_node));
     if (!root)
     {
-        swWarn("malloc[2] failed.");
+        swWarn("malloc[2] failed");
         sw_free(hmap);
         return NULL;
     }
@@ -114,7 +114,7 @@ swHashMap* swHashMap_new(uint32_t bucket_num, swHashMap_dtor dtor)
     root->hh.tbl = (UT_hash_table*) sw_malloc(sizeof(UT_hash_table));
     if (!(root->hh.tbl))
     {
-        swWarn("malloc for table failed.");
+        swWarn("malloc for table failed");
         sw_free(hmap);
         return NULL;
     }
@@ -127,7 +127,7 @@ swHashMap* swHashMap_new(uint32_t bucket_num, swHashMap_dtor dtor)
     root->hh.tbl->buckets = (UT_hash_bucket*) sw_malloc(SW_HASHMAP_INIT_BUCKET_N * sizeof(struct UT_hash_bucket));
     if (!root->hh.tbl->buckets)
     {
-        swWarn("malloc for buckets failed.");
+        swWarn("malloc for buckets failed");
         sw_free(hmap);
         return NULL;
     }
@@ -144,7 +144,7 @@ int swHashMap_add(swHashMap* hmap, char *key, uint16_t key_len, void *data)
     swHashMap_node *node = (swHashMap_node*) sw_malloc(sizeof(swHashMap_node));
     if (node == NULL)
     {
-        swWarn("malloc failed.");
+        swWarn("malloc failed");
         return SW_ERR;
     }
     bzero(node, sizeof(swHashMap_node));

--- a/src/core/list.c
+++ b/src/core/list.c
@@ -21,7 +21,7 @@ swLinkedList* swLinkedList_new(uint8_t type, swDestructor dtor)
     swLinkedList *q = sw_malloc(sizeof(swLinkedList));
     if (q == NULL)
     {
-        swWarn("malloc(%ld) failed.", sizeof(swLinkedList));
+        swWarn("malloc(%ld) failed", sizeof(swLinkedList));
         return NULL;
     }
     bzero(q, sizeof(swLinkedList));
@@ -35,7 +35,7 @@ int swLinkedList_append(swLinkedList *ll, void *data)
     swLinkedList_node *node = sw_malloc(sizeof(swLinkedList_node));
     if (node == NULL)
     {
-        swWarn("malloc(%ld) failed.", sizeof(swLinkedList_node));
+        swWarn("malloc(%ld) failed", sizeof(swLinkedList_node));
         return SW_ERR;
     }
     node->data = data;
@@ -62,7 +62,7 @@ int swLinkedList_prepend(swLinkedList *ll, void *data)
     swLinkedList_node *node = sw_malloc(sizeof(swLinkedList_node));
     if (node == NULL)
     {
-        swWarn("malloc(%ld) failed.", sizeof(swLinkedList_node));
+        swWarn("malloc(%ld) failed", sizeof(swLinkedList_node));
         return SW_ERR;
     }
     node->data = data;

--- a/src/core/ring_queue.c
+++ b/src/core/ring_queue.c
@@ -22,7 +22,7 @@ int swRingQueue_init(swRingQueue *queue, int buffer_size)
     queue->data = sw_calloc(buffer_size, sizeof(void*));
     if (queue->data == NULL)
     {
-        swWarn("malloc failed.");
+        swWarn("malloc failed");
         return -1;
     }
     queue->size = buffer_size;

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -23,7 +23,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
     int file_fd = open(filename, O_RDONLY);
     if (file_fd < 0)
     {
-        swWarn("open(%s) failed. Error: %s[%d]", filename, strerror(errno), errno);
+        swSysError("open(%s) failed", filename);
         return SW_ERR;
     }
 
@@ -32,7 +32,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
         struct stat file_stat;
         if (fstat(file_fd, &file_stat) < 0)
         {
-            swWarn("fstat() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("fstat() failed");
             close(file_fd);
             return SW_ERR;
         }
@@ -106,7 +106,7 @@ int swSocket_wait(int fd, int timeout_ms, int events)
         }
         else if (ret < 0 && errno != EINTR)
         {
-            swWarn("poll() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("poll() failed");
             return SW_ERR;
         }
         else
@@ -153,7 +153,7 @@ int swSocket_wait_multi(int *list_of_fd, int n_fd, int timeout_ms, int events)
         }
         else if (ret < 0 && errno != EINTR)
         {
-            swWarn("poll() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("poll() failed");
             sw_free(event_list);
             return SW_ERR;
         }
@@ -456,13 +456,13 @@ int swSocket_set_timeout(int sock, double timeout)
     ret = setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (void *) &timeo, sizeof(timeo));
     if (ret < 0)
     {
-        swWarn("setsockopt(SO_SNDTIMEO) failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("setsockopt(SO_SNDTIMEO) failed");
         return SW_ERR;
     }
     ret = setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *) &timeo, sizeof(timeo));
     if (ret < 0)
     {
-        swWarn("setsockopt(SO_RCVTIMEO) failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("setsockopt(SO_RCVTIMEO) failed");
         return SW_ERR;
     }
     return SW_OK;

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -499,7 +499,7 @@ int swSocket_create_server(int type, char *address, int port, int backlog)
     int fd = swSocket_create(type);
     if (fd < 0)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "socket() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysWarn("socket() failed");
         return SW_ERR;
     }
 
@@ -511,7 +511,7 @@ int swSocket_create_server(int type, char *address, int port, int backlog)
 
     if (listen(fd, backlog) < 0)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "listen(%s:%d, %d) failed. Error: %s[%d]", address, port, backlog, strerror(errno), errno);
+        swSysWarn("listen(%s:%d, %d) failed", address, port, backlog);
         close(fd);
         return SW_ERR;
     }

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -58,7 +58,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
             if (n <= 0)
             {
                 close(file_fd);
-                swSysWarn("sendfile(%d, %s) failed.", sock, filename);
+                swSysWarn("sendfile(%d, %s) failed", sock, filename);
                 return SW_ERR;
             }
             else
@@ -188,7 +188,7 @@ int swSocket_write_blocking(int __fd, void *__data, int __len)
             }
             else
             {
-                swSysWarn("write %d bytes failed.", __len);
+                swSysWarn("write %d bytes failed", __len);
                 return SW_ERR;
             }
         }
@@ -244,7 +244,7 @@ ssize_t swSocket_udp_sendto(int server_sock, char *dst_ip, int dst_port, char *d
     struct sockaddr_in addr;
     if (inet_aton(dst_ip, &addr.sin_addr) == 0)
     {
-        swWarn("ip[%s] is invalid.", dst_ip);
+        swWarn("ip[%s] is invalid", dst_ip);
         return SW_ERR;
     }
     addr.sin_family = AF_INET;
@@ -258,7 +258,7 @@ ssize_t swSocket_udp_sendto6(int server_sock, char *dst_ip, int dst_port, char *
     bzero(&addr, sizeof(addr));
     if (inet_pton(AF_INET6, dst_ip, &addr.sin6_addr) < 0)
     {
-        swWarn("ip[%s] is invalid.", dst_ip);
+        swWarn("ip[%s] is invalid", dst_ip);
         return SW_ERR;
     }
     addr.sin6_port = (uint16_t) htons(dst_port);
@@ -362,7 +362,7 @@ int swSocket_bind(int sock, int type, char *host, int *port)
     int option = 1;
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int)) != 0)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "setsockopt(%d, SO_REUSEADDR) failed.", sock);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "setsockopt(%d, SO_REUSEADDR) failed", sock);
     }
     //reuse port
 #ifdef HAVE_REUSEPORT
@@ -370,7 +370,7 @@ int swSocket_bind(int sock, int type, char *host, int *port)
     {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &option, sizeof(int)) != 0)
         {
-            swSysWarn("setsockopt(SO_REUSEPORT) failed.");
+            swSysWarn("setsockopt(SO_REUSEPORT) failed");
             SwooleG.reuse_port = 0;
         }
     }
@@ -436,12 +436,12 @@ int swSocket_set_buffer_size(int fd, uint32_t buffer_size)
 {
     if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffer_size, sizeof(buffer_size)) != 0)
     {
-        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_SNDBUF, %d) failed.", fd, buffer_size);
+        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_SNDBUF, %d) failed", fd, buffer_size);
         return SW_ERR;
     }
     if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buffer_size, sizeof(buffer_size)) != 0)
     {
-        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_RCVBUF, %d) failed.", fd, buffer_size);
+        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_RCVBUF, %d) failed", fd, buffer_size);
         return SW_ERR;
     }
     return SW_OK;

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -425,7 +425,7 @@ int swSocket_bind(int sock, int type, char *host, int *port)
     //bind failed
     if (ret < 0)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "bind(%s:%d) failed. Error: %s [%d]", host, *port, strerror(errno), errno);
+        swSysWarn("bind(%s:%d) failed", host, *port);
         return SW_ERR;
     }
 

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -23,7 +23,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
     int file_fd = open(filename, O_RDONLY);
     if (file_fd < 0)
     {
-        swSysError("open(%s) failed", filename);
+        swSysWarn("open(%s) failed", filename);
         return SW_ERR;
     }
 
@@ -32,7 +32,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
         struct stat file_stat;
         if (fstat(file_fd, &file_stat) < 0)
         {
-            swSysError("fstat() failed");
+            swSysWarn("fstat() failed");
             close(file_fd);
             return SW_ERR;
         }
@@ -58,7 +58,7 @@ int swSocket_sendfile_sync(int sock, char *filename, off_t offset, size_t length
             if (n <= 0)
             {
                 close(file_fd);
-                swSysError("sendfile(%d, %s) failed.", sock, filename);
+                swSysWarn("sendfile(%d, %s) failed.", sock, filename);
                 return SW_ERR;
             }
             else
@@ -106,7 +106,7 @@ int swSocket_wait(int fd, int timeout_ms, int events)
         }
         else if (ret < 0 && errno != EINTR)
         {
-            swSysError("poll() failed");
+            swSysWarn("poll() failed");
             return SW_ERR;
         }
         else
@@ -153,7 +153,7 @@ int swSocket_wait_multi(int *list_of_fd, int n_fd, int timeout_ms, int events)
         }
         else if (ret < 0 && errno != EINTR)
         {
-            swSysError("poll() failed");
+            swSysWarn("poll() failed");
             sw_free(event_list);
             return SW_ERR;
         }
@@ -188,7 +188,7 @@ int swSocket_write_blocking(int __fd, void *__data, int __len)
             }
             else
             {
-                swSysError("write %d bytes failed.", __len);
+                swSysWarn("write %d bytes failed.", __len);
                 return SW_ERR;
             }
         }
@@ -370,7 +370,7 @@ int swSocket_bind(int sock, int type, char *host, int *port)
     {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &option, sizeof(int)) != 0)
         {
-            swSysError("setsockopt(SO_REUSEPORT) failed.");
+            swSysWarn("setsockopt(SO_REUSEPORT) failed.");
             SwooleG.reuse_port = 0;
         }
     }
@@ -436,12 +436,12 @@ int swSocket_set_buffer_size(int fd, uint32_t buffer_size)
 {
     if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffer_size, sizeof(buffer_size)) != 0)
     {
-        swSysError("setsockopt(%d, SOL_SOCKET, SO_SNDBUF, %d) failed.", fd, buffer_size);
+        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_SNDBUF, %d) failed.", fd, buffer_size);
         return SW_ERR;
     }
     if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buffer_size, sizeof(buffer_size)) != 0)
     {
-        swSysError("setsockopt(%d, SOL_SOCKET, SO_RCVBUF, %d) failed.", fd, buffer_size);
+        swSysWarn("setsockopt(%d, SOL_SOCKET, SO_RCVBUF, %d) failed.", fd, buffer_size);
         return SW_ERR;
     }
     return SW_OK;
@@ -456,13 +456,13 @@ int swSocket_set_timeout(int sock, double timeout)
     ret = setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (void *) &timeo, sizeof(timeo));
     if (ret < 0)
     {
-        swSysError("setsockopt(SO_SNDTIMEO) failed");
+        swSysWarn("setsockopt(SO_SNDTIMEO) failed");
         return SW_ERR;
     }
     ret = setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *) &timeo, sizeof(timeo));
     if (ret < 0)
     {
-        swSysError("setsockopt(SO_RCVTIMEO) failed");
+        swSysWarn("setsockopt(SO_RCVTIMEO) failed");
         return SW_ERR;
     }
     return SW_OK;

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -32,7 +32,7 @@ swString *swString_new(size_t size)
 
     if (str->str == NULL)
     {
-        swSysError("malloc[2](%ld) failed.", size);
+        swSysWarn("malloc[2](%ld) failed.", size);
         sw_free(str);
         return NULL;
     }
@@ -171,7 +171,7 @@ int swString_extend(swString *str, size_t new_size)
     char *new_str = sw_realloc(str->str, new_size);
     if (new_str == NULL)
     {
-        swSysError("realloc(%ld) failed.", new_size);
+        swSysWarn("realloc(%ld) failed.", new_size);
         return SW_ERR;
     }
 

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -21,7 +21,7 @@ swString *swString_new(size_t size)
     swString *str = sw_malloc(sizeof(swString));
     if (str == NULL)
     {
-        swWarn("malloc[1] failed.");
+        swWarn("malloc[1] failed");
         return NULL;
     }
 
@@ -32,7 +32,7 @@ swString *swString_new(size_t size)
 
     if (str->str == NULL)
     {
-        swSysWarn("malloc[2](%ld) failed.", size);
+        swSysWarn("malloc[2](%ld) failed", size);
         sw_free(str);
         return NULL;
     }
@@ -171,7 +171,7 @@ int swString_extend(swString *str, size_t new_size)
     char *new_str = sw_realloc(str->str, new_size);
     if (new_str == NULL)
     {
-        swSysWarn("realloc(%ld) failed.", new_size);
+        swSysWarn("realloc(%ld) failed", new_size);
         return SW_ERR;
     }
 

--- a/src/coroutine/base.cc
+++ b/src/coroutine/base.cc
@@ -83,7 +83,7 @@ void Coroutine::close()
         on_close(task);
     }
 #ifndef SW_NO_USE_ASM_CONTEXT
-    swTraceLog(SW_TRACE_CONTEXT, "coroutine#%ld stack memory use less than %ld bytes.", get_cid(), ctx.get_stack_usage());
+    swTraceLog(SW_TRACE_CONTEXT, "coroutine#%ld stack memory use less than %ld bytes", get_cid(), ctx.get_stack_usage());
 #endif
     current = origin;
     coroutines.erase(cid);

--- a/src/coroutine/boost.cc
+++ b/src/coroutine/boost.cc
@@ -34,7 +34,7 @@ Context::Context(size_t stack_size, coroutine_func_t fn, void* private_data) :
     swap_ctx_ = NULL;
 
     stack_ = (char*) sw_malloc(stack_size_);
-    swTraceLog(SW_TRACE_COROUTINE, "alloc stack: size=%u, ptr=%p.", stack_size_, stack_);
+    swTraceLog(SW_TRACE_COROUTINE, "alloc stack: size=%u, ptr=%p", stack_size_, stack_);
 
     void* sp = (void*) ((char*) stack_ + stack_size_);
 #ifdef USE_VALGRIND

--- a/src/coroutine/context.cc
+++ b/src/coroutine/context.cc
@@ -37,7 +37,7 @@ Context::Context(size_t stack_size, coroutine_func_t fn, void* private_data) :
     swap_ctx_ = nullptr;
 
     stack_ = (char*) sw_malloc(stack_size_);
-    swTraceLog(SW_TRACE_COROUTINE, "alloc stack: size=%u, ptr=%p.", stack_size_, stack_);
+    swTraceLog(SW_TRACE_COROUTINE, "alloc stack: size=%u, ptr=%p", stack_size_, stack_);
 
     void* sp = (void*) ((char*) stack_ + stack_size_);
 #ifdef USE_VALGRIND

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -950,14 +950,14 @@ bool Socket::bind(std::string address, int port)
     int option = 1;
     if (::setsockopt(socket->fd, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int)) < 0)
     {
-        swSysError("setsockopt(%d, SO_REUSEADDR) failed.", socket->fd);
+        swSysWarn("setsockopt(%d, SO_REUSEADDR) failed.", socket->fd);
     }
 #ifdef HAVE_REUSEPORT
     if (SwooleG.reuse_port)
     {
         if (::setsockopt(socket->fd, SOL_SOCKET, SO_REUSEPORT, &option, sizeof(int)) < 0)
         {
-            swSysError("setsockopt(SO_REUSEPORT) failed.");
+            swSysWarn("setsockopt(SO_REUSEPORT) failed.");
             SwooleG.reuse_port = 0;
         }
     }
@@ -1073,7 +1073,7 @@ Socket* Socket::accept()
     Socket *client_sock = new Socket(conn, this);
     if (unlikely(client_sock->socket == nullptr))
     {
-        swSysError("new Socket() failed");
+        swSysWarn("new Socket() failed");
         set_err(errno);
         delete client_sock;
         return nullptr;
@@ -1208,7 +1208,7 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
     int file_fd = open(filename, O_RDONLY);
     if (file_fd < 0)
     {
-        swSysError("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed.", filename);
         return false;
     }
 
@@ -1217,7 +1217,7 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
         struct stat file_stat;
         if (::fstat(file_fd, &file_stat) < 0)
         {
-            swSysError("fstat(%s) failed.", filename);
+            swSysWarn("fstat(%s) failed.", filename);
             ::close(file_fd);
             return false;
         }
@@ -1256,7 +1256,7 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
         }
         else if (errno != EAGAIN)
         {
-            swSysError("sendfile(%d, %s) failed.", socket->fd, filename);
+            swSysWarn("sendfile(%d, %s) failed.", socket->fd, filename);
             set_err(errno);
             ::close(file_fd);
             return false;
@@ -1605,7 +1605,7 @@ bool Socket::close()
     {
         if (unlikely(::close(socket->fd) != 0))
         {
-            swSysError("close(%d) failed.", socket->fd);
+            swSysWarn("close(%d) failed.", socket->fd);
         }
         socket->fd = -1;
         return true;
@@ -1692,7 +1692,7 @@ Socket::~Socket()
     SW_ASSERT(socket->removed);
     if (unlikely(socket->fd > 0 && ::close(socket->fd) != 0))
     {
-        swSysError("close(%d) failed.", socket->fd);
+        swSysWarn("close(%d) failed.", socket->fd);
     }
     bzero(socket, sizeof(swConnection));
     socket->fd = -1;

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1073,7 +1073,7 @@ Socket* Socket::accept()
     Socket *client_sock = new Socket(conn, this);
     if (unlikely(client_sock->socket == nullptr))
     {
-        swWarn("new Socket() failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("new Socket() failed");
         set_err(errno);
         delete client_sock;
         return nullptr;

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -210,12 +210,12 @@ bool Socket::socks5_handshake()
     method = ctx->buf[1];
     if (version != SW_SOCKS5_VERSION_CODE)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
         return SW_ERR;
     }
     if (method != ctx->method)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_METHOD, "SOCKS authentication method not supported.");
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_METHOD, "SOCKS authentication method not supported");
         return SW_ERR;
     }
     // authentication
@@ -255,12 +255,12 @@ bool Socket::socks5_handshake()
         uchar status = ctx->buf[1];
         if (version != 0x01)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return false;
         }
         if (status != 0x00)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS username/password authentication failed.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS username/password authentication failed");
             return false;
         }
     }
@@ -310,7 +310,7 @@ bool Socket::socks5_handshake()
     version = ctx->buf[0];
     if (version != SW_SOCKS5_VERSION_CODE)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
         return false;
     }
     result = ctx->buf[1];
@@ -327,7 +327,7 @@ bool Socket::socks5_handshake()
     }
     else
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_SERVER_ERROR, "Socks5 server error, reason: %s.", swSocks5_strerror(result));
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_SERVER_ERROR, "Socks5 server error, reason: %s", swSocks5_strerror(result));
         return false;
     }
 }
@@ -950,14 +950,14 @@ bool Socket::bind(std::string address, int port)
     int option = 1;
     if (::setsockopt(socket->fd, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int)) < 0)
     {
-        swSysWarn("setsockopt(%d, SO_REUSEADDR) failed.", socket->fd);
+        swSysWarn("setsockopt(%d, SO_REUSEADDR) failed", socket->fd);
     }
 #ifdef HAVE_REUSEPORT
     if (SwooleG.reuse_port)
     {
         if (::setsockopt(socket->fd, SOL_SOCKET, SO_REUSEPORT, &option, sizeof(int)) < 0)
         {
-            swSysWarn("setsockopt(SO_REUSEPORT) failed.");
+            swSysWarn("setsockopt(SO_REUSEPORT) failed");
             SwooleG.reuse_port = 0;
         }
     }
@@ -1040,7 +1040,7 @@ bool Socket::listen(int backlog)
         ssl_context = swSSL_get_context(&ssl_option);
         if (ssl_context == nullptr)
         {
-            swWarn("swSSL_get_context() error.");
+            swWarn("swSSL_get_context() error");
             return false;
         }
     }
@@ -1208,7 +1208,7 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
     int file_fd = open(filename, O_RDONLY);
     if (file_fd < 0)
     {
-        swSysWarn("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed", filename);
         return false;
     }
 
@@ -1217,7 +1217,7 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
         struct stat file_stat;
         if (::fstat(file_fd, &file_stat) < 0)
         {
-            swSysWarn("fstat(%s) failed.", filename);
+            swSysWarn("fstat(%s) failed", filename);
             ::close(file_fd);
             return false;
         }
@@ -1250,13 +1250,13 @@ bool Socket::sendfile(char *filename, off_t offset, size_t length)
         }
         else if (n == 0)
         {
-            swWarn("sendfile return zero.");
+            swWarn("sendfile return zero");
             ::close(file_fd);
             return false;
         }
         else if (errno != EAGAIN)
         {
-            swSysWarn("sendfile(%d, %s) failed.", socket->fd, filename);
+            swSysWarn("sendfile(%d, %s) failed", socket->fd, filename);
             set_err(errno);
             ::close(file_fd);
             return false;
@@ -1287,7 +1287,7 @@ ssize_t Socket::sendto(char *address, int port, char *data, int len)
     }
     else
     {
-        swWarn("only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6.");
+        swWarn("only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6");
         return -1;
     }
 }
@@ -1390,7 +1390,7 @@ ssize_t Socket::recv_packet(double timeout)
         }
         else if (buf_len > protocol.package_max_length)
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE, "packet[length=%d] is too big.", (int )buf_len);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE, "packet[length=%d] is too big", (int )buf_len);
             return 0;
         }
 
@@ -1605,7 +1605,7 @@ bool Socket::close()
     {
         if (unlikely(::close(socket->fd) != 0))
         {
-            swSysWarn("close(%d) failed.", socket->fd);
+            swSysWarn("close(%d) failed", socket->fd);
         }
         socket->fd = -1;
         return true;
@@ -1692,7 +1692,7 @@ Socket::~Socket()
     SW_ASSERT(socket->removed);
     if (unlikely(socket->fd > 0 && ::close(socket->fd) != 0))
     {
-        swSysWarn("close(%d) failed.", socket->fd);
+        swSysWarn("close(%d) failed", socket->fd);
     }
     bzero(socket, sizeof(swConnection));
     socket->fd = -1;

--- a/src/lock/cond.c
+++ b/src/lock/cond.c
@@ -28,7 +28,7 @@ int swCond_create(swCond *cond)
 {
     if (pthread_cond_init(&cond->_cond, NULL) < 0)
     {
-        swWarn("pthread_cond_init fail. Error: %s [%d]", strerror(errno), errno);
+        swSysError("pthread_cond_init fail");
         return SW_ERR;
     }
     if (swMutex_create(&cond->_lock, 0) < 0)

--- a/src/lock/cond.c
+++ b/src/lock/cond.c
@@ -28,7 +28,7 @@ int swCond_create(swCond *cond)
 {
     if (pthread_cond_init(&cond->_cond, NULL) < 0)
     {
-        swSysError("pthread_cond_init fail");
+        swSysWarn("pthread_cond_init fail");
         return SW_ERR;
     }
     if (swMutex_create(&cond->_lock, 0) < 0)

--- a/src/memory/buffer.c
+++ b/src/memory/buffer.c
@@ -25,7 +25,7 @@ swBuffer* swBuffer_new(int chunk_size)
     swBuffer *buffer = sw_malloc(sizeof(swBuffer));
     if (buffer == NULL)
     {
-        swWarn("malloc for buffer failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("malloc for buffer failed");
         return NULL;
     }
 
@@ -43,7 +43,7 @@ swBuffer_chunk *swBuffer_new_chunk(swBuffer *buffer, uint32_t type, uint32_t siz
     swBuffer_chunk *chunk = sw_malloc(sizeof(swBuffer_chunk));
     if (chunk == NULL)
     {
-        swWarn("malloc for chunk failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("malloc for chunk failed");
         return NULL;
     }
 
@@ -55,7 +55,7 @@ swBuffer_chunk *swBuffer_new_chunk(swBuffer *buffer, uint32_t type, uint32_t siz
         void *buf = sw_malloc(size);
         if (buf == NULL)
         {
-            swWarn("malloc(%d) for data failed. Error: %s[%d]", size, strerror(errno), errno);
+            swSysError("malloc(%d) for data failed", size);
             sw_free(chunk);
             return NULL;
         }

--- a/src/memory/buffer.c
+++ b/src/memory/buffer.c
@@ -25,7 +25,7 @@ swBuffer* swBuffer_new(int chunk_size)
     swBuffer *buffer = sw_malloc(sizeof(swBuffer));
     if (buffer == NULL)
     {
-        swSysError("malloc for buffer failed");
+        swSysWarn("malloc for buffer failed");
         return NULL;
     }
 
@@ -43,7 +43,7 @@ swBuffer_chunk *swBuffer_new_chunk(swBuffer *buffer, uint32_t type, uint32_t siz
     swBuffer_chunk *chunk = sw_malloc(sizeof(swBuffer_chunk));
     if (chunk == NULL)
     {
-        swSysError("malloc for chunk failed");
+        swSysWarn("malloc for chunk failed");
         return NULL;
     }
 
@@ -55,7 +55,7 @@ swBuffer_chunk *swBuffer_new_chunk(swBuffer *buffer, uint32_t type, uint32_t siz
         void *buf = sw_malloc(size);
         if (buf == NULL)
         {
-            swSysError("malloc(%d) for data failed", size);
+            swSysWarn("malloc(%d) for data failed", size);
             sw_free(chunk);
             return NULL;
         }

--- a/src/memory/global_memory.c
+++ b/src/memory/global_memory.c
@@ -102,7 +102,7 @@ static void *swMemoryGlobal_alloc(swMemoryPool *pool, uint32_t size)
     gm->lock.lock(&gm->lock);
     if (size > gm->pagesize - sizeof(swMemoryGlobal_page))
     {
-        swWarn("failed to alloc %d bytes, exceed the maximum size[%d].", size, gm->pagesize - (int) sizeof(swMemoryGlobal_page));
+        swWarn("failed to alloc %d bytes, exceed the maximum size[%d]", size, gm->pagesize - (int) sizeof(swMemoryGlobal_page));
         gm->lock.unlock(&gm->lock);
         return NULL;
     }
@@ -111,7 +111,7 @@ static void *swMemoryGlobal_alloc(swMemoryPool *pool, uint32_t size)
         swMemoryGlobal_page *page = swMemoryGlobal_new_page(gm);
         if (page == NULL)
         {
-            swWarn("swMemoryGlobal_alloc alloc memory error.");
+            swWarn("swMemoryGlobal_alloc alloc memory error");
             gm->lock.unlock(&gm->lock);
             return NULL;
         }
@@ -125,7 +125,7 @@ static void *swMemoryGlobal_alloc(swMemoryPool *pool, uint32_t size)
 
 static void swMemoryGlobal_free(swMemoryPool *pool, void *ptr)
 {
-    swWarn("swMemoryGlobal Allocator don't need to release.");
+    swWarn("swMemoryGlobal Allocator don't need to release");
 }
 
 static void swMemoryGlobal_destroy(swMemoryPool *poll)

--- a/src/memory/malloc.c
+++ b/src/memory/malloc.c
@@ -25,7 +25,7 @@ swMemoryPool* swMalloc_new()
     swMemoryPool *pool = sw_malloc(sizeof(swMemoryPool));
     if (pool == NULL)
     {
-        swSysWarn("mallc(%ld) failed.", sizeof(swMemoryPool));
+        swSysWarn("mallc(%ld) failed", sizeof(swMemoryPool));
         return NULL;
     }
     pool->alloc = swMalloc_alloc;

--- a/src/memory/malloc.c
+++ b/src/memory/malloc.c
@@ -25,7 +25,7 @@ swMemoryPool* swMalloc_new()
     swMemoryPool *pool = sw_malloc(sizeof(swMemoryPool));
     if (pool == NULL)
     {
-        swSysError("mallc(%ld) failed.", sizeof(swMemoryPool));
+        swSysWarn("mallc(%ld) failed.", sizeof(swMemoryPool));
         return NULL;
     }
     pool->alloc = swMalloc_alloc;

--- a/src/memory/ring_buffer.c
+++ b/src/memory/ring_buffer.c
@@ -55,7 +55,7 @@ swMemoryPool *swRingBuffer_new(uint32_t size, uint8_t shared)
     void *mem = (shared == 1) ? sw_shm_malloc(size) : sw_malloc(size);
     if (mem == NULL)
     {
-        swWarn("malloc(%d) failed.", size);
+        swWarn("malloc(%d) failed", size);
         return NULL;
     }
 

--- a/src/memory/shared_memory.c
+++ b/src/memory/shared_memory.c
@@ -122,7 +122,7 @@ void *swShareMemory_mmap_create(swShareMemory *object, size_t size, char *mapfil
     if (!mem)
 #endif
     {
-        swSysError("mmap(%ld) failed", size);
+        swSysWarn("mmap(%ld) failed", size);
         return NULL;
     }
     else
@@ -151,12 +151,12 @@ void *swShareMemory_sysv_create(swShareMemory *object, size_t size, int key)
     //SHM_R | SHM_W
     if ((shmid = shmget(key, size, IPC_CREAT)) < 0)
     {
-        swSysError("shmget(%d, %ld) failed.", key, size);
+        swSysWarn("shmget(%d, %ld) failed.", key, size);
         return NULL;
     }
     if ((mem = shmat(shmid, NULL, 0)) == (void *) -1)
     {
-        swSysError("shmat() failed");
+        swSysWarn("shmat() failed");
         return NULL;
     }
     else

--- a/src/memory/shared_memory.c
+++ b/src/memory/shared_memory.c
@@ -151,7 +151,7 @@ void *swShareMemory_sysv_create(swShareMemory *object, size_t size, int key)
     //SHM_R | SHM_W
     if ((shmid = shmget(key, size, IPC_CREAT)) < 0)
     {
-        swSysWarn("shmget(%d, %ld) failed.", key, size);
+        swSysWarn("shmget(%d, %ld) failed", key, size);
         return NULL;
     }
     if ((mem = shmat(shmid, NULL, 0)) == (void *) -1)

--- a/src/memory/shared_memory.c
+++ b/src/memory/shared_memory.c
@@ -122,7 +122,7 @@ void *swShareMemory_mmap_create(swShareMemory *object, size_t size, char *mapfil
     if (!mem)
 #endif
     {
-        swWarn("mmap(%ld) failed. Error: %s[%d]", size, strerror(errno), errno);
+        swSysError("mmap(%ld) failed", size);
         return NULL;
     }
     else
@@ -156,7 +156,7 @@ void *swShareMemory_sysv_create(swShareMemory *object, size_t size, int key)
     }
     if ((mem = shmat(shmid, NULL, 0)) == (void *) -1)
     {
-        swWarn("shmat() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("shmat() failed");
         return NULL;
     }
     else

--- a/src/memory/table.c
+++ b/src/memory/table.c
@@ -66,13 +66,13 @@ swTable* swTable_new(uint32_t rows_size, float conflict_proportion)
     }
     if (swMutex_create(&table->lock, 1) < 0)
     {
-        swWarn("mutex create failed.");
+        swWarn("mutex create failed");
         return NULL;
     }
     table->iterator = sw_malloc(sizeof(swTable_iterator));
     if (!table->iterator)
     {
-        swWarn("malloc failed.");
+        swWarn("malloc failed");
         return NULL;
     }
     table->columns = swHashMap_new(SW_HASHMAP_INIT_BUCKET_N, (swHashMap_dtor)swTableColumn_free);
@@ -137,7 +137,7 @@ int swTableColumn_add(swTable *table, char *name, int len, int type, int size)
         col->type = SW_TABLE_STRING;
         break;
     default:
-        swWarn("unkown column type.");
+        swWarn("unkown column type");
         swTableColumn_free(col);
         return SW_ERR;
     }

--- a/src/network/async_thread.cc
+++ b/src/network/async_thread.cc
@@ -235,7 +235,7 @@ private:
                         }
                         else
                         {
-                            swSysWarn("sendto swoole_aio_pipe_write failed.");
+                            swSysWarn("sendto swoole_aio_pipe_write failed");
                         }
                     }
                     break;
@@ -298,7 +298,7 @@ static int swAio_init()
 
     if (swMutex_create(&SwooleAIO.lock, 0) < 0)
     {
-        swWarn("create mutex lock error.");
+        swWarn("create mutex lock error");
         return SW_ERR;
     }
 

--- a/src/network/async_thread.cc
+++ b/src/network/async_thread.cc
@@ -85,7 +85,7 @@ public:
             ssize_t n = read(_event->fd, events, sizeof(async_event*) * SW_AIO_EVENT_NUM);
             if (n < 0)
             {
-                swWarn("read() failed. Error: %s[%d]", strerror(errno), errno);
+                swSysError("read() failed");
                 return SW_ERR;
             }
             for (i = 0; i < n / (int) sizeof(async_event*); i++)

--- a/src/network/async_thread.cc
+++ b/src/network/async_thread.cc
@@ -85,7 +85,7 @@ public:
             ssize_t n = read(_event->fd, events, sizeof(async_event*) * SW_AIO_EVENT_NUM);
             if (n < 0)
             {
-                swSysError("read() failed");
+                swSysWarn("read() failed");
                 return SW_ERR;
             }
             for (i = 0; i < n / (int) sizeof(async_event*); i++)
@@ -235,7 +235,7 @@ private:
                         }
                         else
                         {
-                            swSysError("sendto swoole_aio_pipe_write failed.");
+                            swSysWarn("sendto swoole_aio_pipe_write failed.");
                         }
                     }
                     break;

--- a/src/network/client.c
+++ b/src/network/client.c
@@ -122,7 +122,7 @@ int swClient_create(swClient *cli, int type, int async)
 
     if (!cli->socket)
     {
-        swWarn("malloc(%d) failed.", (int ) sizeof(swConnection));
+        swWarn("malloc(%d) failed", (int ) sizeof(swConnection));
         close(sockfd);
         return SW_ERR;
     }
@@ -686,7 +686,7 @@ static int swClient_tcp_connect_async(swClient *cli, char *host, int port, doubl
 
     if (!(cli->onConnect && cli->onError && cli->onClose))
     {
-        swWarn("onConnect/onError/onClose callback have not set.");
+        swWarn("onConnect/onError/onClose callback have not set");
         return SW_ERR;
     }
 
@@ -718,7 +718,7 @@ static int swClient_tcp_connect_async(swClient *cli, char *host, int port, doubl
         ev.buf = sw_malloc(ev.nbytes);
         if (!ev.buf)
         {
-            swWarn("malloc failed.");
+            swWarn("malloc failed");
             return SW_ERR;
         }
 
@@ -786,7 +786,7 @@ static int swClient_tcp_pipe(swClient *cli, int write_fd, int flags)
 {
     if (!cli->async || cli->_sock_type != SOCK_STREAM)
     {
-        swWarn("only async tcp-client can use pipe method.");
+        swWarn("only async tcp-client can use pipe method");
         return SW_ERR;
     }
 
@@ -984,7 +984,7 @@ static int swClient_udp_connect(swClient *cli, char *host, int port, double time
 
         if (bind(cli->socket->fd, (struct sockaddr *) client_addr, sizeof(cli->socket->info.addr.un)) < 0)
         {
-            swSysWarn("bind(%s) failed.", client_addr->sun_path);
+            swSysWarn("bind(%s) failed", client_addr->sun_path);
             return SW_ERR;
         }
     }
@@ -1152,7 +1152,7 @@ static int swClient_onStreamRead(swReactor *reactor, swEvent *event)
             }
             if (swClient_https_proxy_handshake(cli) < 0)
             {
-                swoole_error_log(SW_LOG_NOTICE, SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR, "failed to handshake with http proxy.");
+                swoole_error_log(SW_LOG_NOTICE, SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR, "failed to handshake with http proxy");
                 goto connect_fail;
             }
             else
@@ -1338,7 +1338,7 @@ static int swClient_onStreamRead(swReactor *reactor, swEvent *event)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("Read from socket[%d] failed.", event->fd);
+            swSysWarn("Read from socket[%d] failed", event->fd);
             return SW_OK;
         case SW_CLOSE:
             goto __close;

--- a/src/network/client.c
+++ b/src/network/client.c
@@ -97,7 +97,7 @@ int swClient_create(swClient *cli, int type, int async)
 #endif
     if (sockfd < 0)
     {
-        swSysError("socket() failed");
+        swSysWarn("socket() failed");
         return SW_ERR;
     }
 
@@ -984,7 +984,7 @@ static int swClient_udp_connect(swClient *cli, char *host, int port, double time
 
         if (bind(cli->socket->fd, (struct sockaddr *) client_addr, sizeof(cli->socket->info.addr.un)) < 0)
         {
-            swSysError("bind(%s) failed.", client_addr->sun_path);
+            swSysWarn("bind(%s) failed.", client_addr->sun_path);
             return SW_ERR;
         }
     }
@@ -1338,7 +1338,7 @@ static int swClient_onStreamRead(swReactor *reactor, swEvent *event)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("Read from socket[%d] failed.", event->fd);
+            swSysWarn("Read from socket[%d] failed.", event->fd);
             return SW_OK;
         case SW_CLOSE:
             goto __close;
@@ -1497,7 +1497,7 @@ static int swClient_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swSysError("getsockopt(%d) failed", event->fd);
+        swSysWarn("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 

--- a/src/network/client.c
+++ b/src/network/client.c
@@ -97,7 +97,7 @@ int swClient_create(swClient *cli, int type, int async)
 #endif
     if (sockfd < 0)
     {
-        swWarn("socket() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("socket() failed");
         return SW_ERR;
     }
 
@@ -1497,7 +1497,7 @@ static int swClient_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swWarn("getsockopt(%d) failed. Error: %s[%d]", event->fd, strerror(errno), errno);
+        swSysError("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 

--- a/src/network/connection.c
+++ b/src/network/connection.c
@@ -41,7 +41,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
             int tcp_nodelay = 0;
             if (setsockopt(conn->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &tcp_nodelay, sizeof(int)) != 0)
             {
-                swSysError("setsockopt(TCP_NODELAY) failed");
+                swSysWarn("setsockopt(TCP_NODELAY) failed");
             }
         }
         /**
@@ -49,7 +49,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
          */
         if (swSocket_tcp_nopush(conn->fd, 1) == -1)
         {
-            swSysError("swSocket_tcp_nopush() failed");
+            swSysWarn("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 1;
     }
@@ -75,7 +75,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("sendfile(%s, %ld, %d) failed.", task->filename, (long)task->offset, sendn);
+            swSysWarn("sendfile(%s, %ld, %d) failed.", task->filename, (long)task->offset, sendn);
             swBuffer_pop_chunk(conn->out_buffer, chunk);
             return SW_OK;
         case SW_CLOSE:
@@ -100,7 +100,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
          */
         if (swSocket_tcp_nopush(conn->fd, 0) == -1)
         {
-            swSysError("swSocket_tcp_nopush() failed");
+            swSysWarn("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 0;
 
@@ -112,7 +112,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
             int value = 1;
             if (setsockopt(conn->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &value, sizeof(int)) != 0)
             {
-                swSysError("setsockopt(TCP_NODELAY) failed");
+                swSysWarn("setsockopt(TCP_NODELAY) failed");
             }
         }
 #endif
@@ -143,7 +143,7 @@ int swConnection_buffer_send(swConnection *conn)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("send to fd[%d] failed", conn->fd);
+            swSysWarn("send to fd[%d] failed", conn->fd);
             break;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -252,7 +252,7 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     {
         sw_free(task->filename);
         sw_free(task);
-        swSysError("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed.", filename);
         return SW_OK;
     }
     task->fd = file_fd;
@@ -261,7 +261,7 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     struct stat file_stat;
     if (fstat(file_fd, &file_stat) < 0)
     {
-        swSysError("fstat(%s) failed.", filename);
+        swSysWarn("fstat(%s) failed.", filename);
         error_chunk.store.ptr = task;
         swConnection_sendfile_destructor(&error_chunk);
         return SW_ERR;

--- a/src/network/connection.c
+++ b/src/network/connection.c
@@ -41,7 +41,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
             int tcp_nodelay = 0;
             if (setsockopt(conn->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &tcp_nodelay, sizeof(int)) != 0)
             {
-                swWarn("setsockopt(TCP_NODELAY) failed. Error: %s[%d]", strerror(errno), errno);
+                swSysError("setsockopt(TCP_NODELAY) failed");
             }
         }
         /**
@@ -49,7 +49,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
          */
         if (swSocket_tcp_nopush(conn->fd, 1) == -1)
         {
-            swWarn("swSocket_tcp_nopush() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 1;
     }
@@ -100,7 +100,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
          */
         if (swSocket_tcp_nopush(conn->fd, 0) == -1)
         {
-            swWarn("swSocket_tcp_nopush() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 0;
 
@@ -112,7 +112,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
             int value = 1;
             if (setsockopt(conn->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &value, sizeof(int)) != 0)
             {
-                swWarn("setsockopt(TCP_NODELAY) failed. Error: %s[%d]", strerror(errno), errno);
+                swSysError("setsockopt(TCP_NODELAY) failed");
             }
         }
 #endif
@@ -143,7 +143,7 @@ int swConnection_buffer_send(swConnection *conn)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swWarn("send to fd[%d] failed. Error: %s[%d]", conn->fd, strerror(errno), errno);
+            swSysError("send to fd[%d] failed", conn->fd);
             break;
         case SW_CLOSE:
             conn->close_errno = errno;

--- a/src/network/connection.c
+++ b/src/network/connection.c
@@ -75,7 +75,7 @@ int swConnection_onSendfile(swConnection *conn, swBuffer_chunk *chunk)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("sendfile(%s, %ld, %d) failed.", task->filename, (long)task->offset, sendn);
+            swSysWarn("sendfile(%s, %ld, %d) failed", task->filename, (long)task->offset, sendn);
             swBuffer_pop_chunk(conn->out_buffer, chunk);
             return SW_OK;
         case SW_CLOSE:
@@ -241,7 +241,7 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     swTask_sendfile *task = sw_malloc(sizeof(swTask_sendfile));
     if (task == NULL)
     {
-        swWarn("malloc for swTask_sendfile failed.");
+        swWarn("malloc for swTask_sendfile failed");
         return SW_ERR;
     }
     bzero(task, sizeof(swTask_sendfile));
@@ -252,7 +252,7 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     {
         sw_free(task->filename);
         sw_free(task);
-        swSysWarn("open(%s) failed.", filename);
+        swSysWarn("open(%s) failed", filename);
         return SW_OK;
     }
     task->fd = file_fd;
@@ -261,14 +261,14 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     struct stat file_stat;
     if (fstat(file_fd, &file_stat) < 0)
     {
-        swSysWarn("fstat(%s) failed.", filename);
+        swSysWarn("fstat(%s) failed", filename);
         error_chunk.store.ptr = task;
         swConnection_sendfile_destructor(&error_chunk);
         return SW_ERR;
     }
     if (offset < 0 || (length + offset > file_stat.st_size))
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_INVALID_PARAMS, "length or offset is invalid.");
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_INVALID_PARAMS, "length or offset is invalid");
         error_chunk.store.ptr = task;
         swConnection_sendfile_destructor(&error_chunk);
         return SW_OK;
@@ -285,7 +285,7 @@ int swConnection_sendfile(swConnection *conn, char *filename, off_t offset, size
     swBuffer_chunk *chunk = swBuffer_new_chunk(conn->out_buffer, SW_CHUNK_SENDFILE, 0);
     if (chunk == NULL)
     {
-        swWarn("get out_buffer chunk failed.");
+        swWarn("get out_buffer chunk failed");
         error_chunk.store.ptr = task;
         swConnection_sendfile_destructor(&error_chunk);
         return SW_ERR;

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -98,7 +98,7 @@ static int swDNSResolver_get_server()
 
     if ((fp = fopen(SW_DNS_SERVER_CONF, "rt")) == NULL)
     {
-        swSysError("fopen("SW_DNS_SERVER_CONF") failed");
+        swSysWarn("fopen("SW_DNS_SERVER_CONF") failed");
         return SW_ERR;
     }
 

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -237,7 +237,7 @@ static int swDNSResolver_onReceive(swReactor *reactor, swEvent *event)
     swDNS_lookup_request *request = swHashMap_find(request_map, key, key_len);
     if (request == NULL)
     {
-        swWarn("bad response, request_id=%d.", request_id);
+        swWarn("bad response, request_id=%d", request_id);
         return SW_OK;
     }
 
@@ -311,7 +311,7 @@ int swDNSResolver_request(char *domain, void (*callback)(char *, swDNSResolver_r
     int len = strlen(domain);
     if (len >= sizeof(key))
     {
-        swWarn("domain name is too long.");
+        swWarn("domain name is too long");
         return SW_ERR;
     }
 
@@ -322,20 +322,20 @@ int swDNSResolver_request(char *domain, void (*callback)(char *, swDNSResolver_r
     }
     else if (swHashMap_find(request_map, key, key_len))
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_DNSLOOKUP_DUPLICATE_REQUEST, "duplicate request.");
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_DNSLOOKUP_DUPLICATE_REQUEST, "duplicate request");
         return SW_ERR;
     }
 
     swDNS_lookup_request *request = sw_malloc(sizeof(swDNS_lookup_request));
     if (request == NULL)
     {
-        swWarn("malloc(%d) failed.", (int ) sizeof(swDNS_lookup_request));
+        swWarn("malloc(%d) failed", (int ) sizeof(swDNS_lookup_request));
         return SW_ERR;
     }
     request->domain = sw_strndup(domain, len + 1);
     if (request->domain == NULL)
     {
-        swWarn("strdup(%d) failed.", len + 1);
+        swWarn("strdup(%d) failed", len + 1);
         sw_free(request);
         return SW_ERR;
     }
@@ -344,7 +344,7 @@ int swDNSResolver_request(char *domain, void (*callback)(char *, swDNSResolver_r
 
     if (domain_encode(request->domain, len, _domain_name) < 0)
     {
-        swWarn("invalid domain[%s].", domain);
+        swWarn("invalid domain[%s]", domain);
         sw_free(request->domain);
         sw_free(request);
         return SW_ERR;
@@ -364,7 +364,7 @@ int swDNSResolver_request(char *domain, void (*callback)(char *, swDNSResolver_r
         {
             sw_free(request->domain);
             sw_free(request);
-            swWarn("malloc failed.");
+            swWarn("malloc failed");
             return SW_ERR;
         }
         if (swClient_create(resolver_socket, SW_SOCK_UDP, 0) < 0)

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -98,7 +98,7 @@ static int swDNSResolver_get_server()
 
     if ((fp = fopen(SW_DNS_SERVER_CONF, "rt")) == NULL)
     {
-        swWarn("fopen("SW_DNS_SERVER_CONF") failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("fopen("SW_DNS_SERVER_CONF") failed");
         return SW_ERR;
     }
 

--- a/src/network/process_pool.c
+++ b/src/network/process_pool.c
@@ -48,11 +48,11 @@ static void swProcessPool_killTimeout(swTimer *timer, swTimer_node *tnode)
             }
             if (swKill(reload_worker_pid, SIGKILL) < 0)
             {
-                swSysWarn("swKill(%d, SIGKILL) [%d] failed.", pool->reload_workers[i].pid, i);
+                swSysWarn("swKill(%d, SIGKILL) [%d] failed", pool->reload_workers[i].pid, i);
             }
             else
             {
-                swWarn("swKill(%d, SIGKILL) [%d].", pool->reload_workers[i].pid, i);
+                swWarn("swKill(%d, SIGKILL) [%d]", pool->reload_workers[i].pid, i);
             }
         }
     }
@@ -75,7 +75,7 @@ int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, k
     pool->workers = SwooleG.memory_pool->alloc(SwooleG.memory_pool, worker_num * sizeof(swWorker));
     if (pool->workers == NULL)
     {
-        swSysWarn("malloc[1] failed.");
+        swSysWarn("malloc[1] failed");
         return SW_ERR;
     }
 
@@ -88,7 +88,7 @@ int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, k
         pool->queue = sw_malloc(sizeof(swMsgQueue));
         if (pool->queue == NULL)
         {
-            swSysWarn("malloc[2] failed.");
+            swSysWarn("malloc[2] failed");
             return SW_ERR;
         }
 
@@ -102,7 +102,7 @@ int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, k
         pool->pipes = sw_calloc(worker_num, sizeof(swPipe));
         if (pool->pipes == NULL)
         {
-            swWarn("malloc[2] failed.");
+            swWarn("malloc[2] failed");
             return SW_ERR;
         }
 
@@ -127,7 +127,7 @@ int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, k
 		pool->stream = sw_malloc(sizeof(swStreamInfo));
 		if (pool->stream == NULL)
 		{
-			swWarn("malloc[2] failed.");
+			swWarn("malloc[2] failed");
 			return SW_ERR;
 		}
 		bzero(pool->stream, sizeof(swStreamInfo));
@@ -162,7 +162,7 @@ int swProcessPool_create_unix_socket(swProcessPool *pool, char *socket_file, int
 {
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
-        swWarn("ipc_mode is not SW_IPC_SOCKET.");
+        swWarn("ipc_mode is not SW_IPC_SOCKET");
         return SW_ERR;
     }
     pool->stream->socket_file = sw_strdup(socket_file);
@@ -182,7 +182,7 @@ int swProcessPool_create_tcp_socket(swProcessPool *pool, char *host, int port, i
 {
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
-        swWarn("ipc_mode is not SW_IPC_SOCKET.");
+        swWarn("ipc_mode is not SW_IPC_SOCKET");
         return SW_ERR;
     }
     pool->stream->socket_file = sw_strdup(host);
@@ -205,7 +205,7 @@ int swProcessPool_start(swProcessPool *pool)
 {
     if (pool->ipc_mode == SW_IPC_SOCKET && (pool->stream == NULL || pool->stream->socket == 0))
     {
-        swWarn("must first listen to an tcp port.");
+        swWarn("must first listen to an tcp port");
         return SW_ERR;
     }
 
@@ -301,7 +301,7 @@ int swProcessPool_dispatch(swProcessPool *pool, swEventData *data, int *dst_work
     }
     else
     {
-        swWarn("send %d bytes to worker#%d failed.", sendn, *dst_worker_id);
+        swWarn("send %d bytes to worker#%d failed", sendn, *dst_worker_id);
     }
 
     return ret;
@@ -345,7 +345,7 @@ int swProcessPool_dispatch_blocking(swProcessPool *pool, swEventData *data, int 
     ret = swWorker_send2worker(worker, data, sendn, SW_PIPE_MASTER);
     if (ret < 0)
     {
-        swWarn("send %d bytes to worker#%d failed.", sendn, *dst_worker_id);
+        swWarn("send %d bytes to worker#%d failed", sendn, *dst_worker_id);
     }
     else
     {
@@ -368,7 +368,7 @@ void swProcessPool_shutdown(swProcessPool *pool)
         worker = &pool->workers[i];
         if (swKill(worker->pid, SIGTERM) < 0)
         {
-            swSysWarn("swKill(%d) failed.", worker->pid);
+            swSysWarn("swKill(%d) failed", worker->pid);
             continue;
         }
     }
@@ -377,7 +377,7 @@ void swProcessPool_shutdown(swProcessPool *pool)
         worker = &pool->workers[i];
         if (swWaitpid(worker->pid, &status, 0) < 0)
         {
-            swSysWarn("waitpid(%d) failed.", worker->pid);
+            swSysWarn("waitpid(%d) failed", worker->pid);
         }
     }
     swProcessPool_free(pool);
@@ -496,7 +496,7 @@ static int swProcessPool_worker_loop(swProcessPool *pool, swWorker *worker)
             n = swMsgQueue_pop(pool->queue, (swQueue_data *) &out, sizeof(out.buf));
             if (n < 0 && errno != EINTR)
             {
-                swSysWarn("[Worker#%d] msgrcv() failed.", worker->id);
+                swSysWarn("[Worker#%d] msgrcv() failed", worker->id);
                 break;
             }
         }
@@ -511,7 +511,7 @@ static int swProcessPool_worker_loop(swProcessPool *pool, swWorker *worker)
                 }
                 else
                 {
-                    swSysWarn("accept(%d) failed.", pool->stream->socket);
+                    swSysWarn("accept(%d) failed", pool->stream->socket);
                     break;
                 }
             }
@@ -529,7 +529,7 @@ static int swProcessPool_worker_loop(swProcessPool *pool, swWorker *worker)
             n = read(worker->pipe_worker, &out.buf, sizeof(out.buf));
             if (n < 0 && errno != EINTR)
             {
-                swSysWarn("[Worker#%d] read(%d) failed.", worker->id, worker->pipe_worker);
+                swSysWarn("[Worker#%d] read(%d) failed", worker->id, worker->pipe_worker);
             }
         }
 
@@ -591,7 +591,7 @@ int swProcessPool_set_protocol(swProcessPool *pool, int task_protocol, uint32_t 
         pool->packet_buffer = sw_malloc(max_packet_size);
         if (pool->packet_buffer == NULL)
         {
-            swSysWarn("malloc(%d) failed.", max_packet_size);
+            swSysWarn("malloc(%d) failed", max_packet_size);
             return SW_ERR;
         }
         if (pool->stream)
@@ -628,7 +628,7 @@ static int swProcessPool_worker_loop_ex(swProcessPool *pool, swWorker *worker)
             n = swMsgQueue_pop(pool->queue, outbuf, SW_MSGMAX);
             if (n < 0 && errno != EINTR)
             {
-                swSysWarn("[Worker#%d] msgrcv() failed.", worker->id);
+                swSysWarn("[Worker#%d] msgrcv() failed", worker->id);
                 break;
             }
             data = outbuf->mdata;
@@ -645,7 +645,7 @@ static int swProcessPool_worker_loop_ex(swProcessPool *pool, swWorker *worker)
                 }
                 else
                 {
-                    swSysWarn("accept(%d) failed.", pool->stream->socket);
+                    swSysWarn("accept(%d) failed", pool->stream->socket);
                     break;
                 }
             }
@@ -676,7 +676,7 @@ static int swProcessPool_worker_loop_ex(swProcessPool *pool, swWorker *worker)
             n = read(worker->pipe_worker, pool->packet_buffer, pool->max_packet_size);
             if (n < 0 && errno != EINTR)
             {
-                swSysWarn("[Worker#%d] read(%d) failed.", worker->id, worker->pipe_worker);
+                swSysWarn("[Worker#%d] read(%d) failed", worker->id, worker->pipe_worker);
             }
             data = pool->packet_buffer;
         }
@@ -771,7 +771,7 @@ int swProcessPool_wait(swProcessPool *pool)
             {
                 if (pool->reload_init == 0)
                 {
-                    swInfo("reload workers.");
+                    swInfo("reload workers");
                     pool->reload_init = 1;
                     memcpy(pool->reload_workers, pool->workers, sizeof(swWorker) * pool->worker_num);
                     if (pool->max_wait_time)
@@ -837,7 +837,7 @@ int swProcessPool_wait(swProcessPool *pool)
                     pool->reload_worker_i++;
                     goto kill_worker;
                 }
-                swSysWarn("[Manager]swKill(%d) failed.", pool->reload_workers[pool->reload_worker_i].pid);
+                swSysWarn("[Manager]swKill(%d) failed", pool->reload_workers[pool->reload_worker_i].pid);
                 continue;
             }
         }

--- a/src/network/process_pool.c
+++ b/src/network/process_pool.c
@@ -417,7 +417,7 @@ pid_t swProcessPool_spawn(swProcessPool *pool, swWorker *worker)
         exit(ret_code);
         break;
     case -1:
-        swWarn("fork() failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("fork() failed");
         break;
         //parent
     default:
@@ -763,7 +763,7 @@ int swProcessPool_wait(swProcessPool *pool)
             {
                 if (errno > 0 && errno != EINTR)
                 {
-                    swWarn("[Manager] wait failed. Error: %s [%d]", strerror(errno), errno);
+                    swSysError("[Manager] wait failed");
                 }
                 continue;
             }
@@ -809,7 +809,7 @@ int swProcessPool_wait(swProcessPool *pool)
             new_pid = swProcessPool_spawn(pool, exit_worker);
             if (new_pid < 0)
             {
-                swWarn("Fork worker process failed. Error: %s [%d]", strerror(errno), errno);
+                swSysError("Fork worker process failed");
                 sw_free(pool->reload_workers);
                 return SW_ERR;
             }

--- a/src/network/stream.c
+++ b/src/network/stream.c
@@ -41,7 +41,7 @@ static void swStream_onConnect(swClient *cli)
 static void swStream_onError(swClient *cli)
 {
     swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_CONNECT_FAIL,
-            " connect() failed (%d: %s) while connecting to worker process.", errno, strerror(errno));
+            " connect() failed (%d: %s) while connecting to worker process", errno, strerror(errno));
     swStream_free(cli->object);
 }
 
@@ -95,7 +95,7 @@ swStream* swStream_new(char *dst_host, int dst_port, int type)
 
     if (cli->connect(cli, dst_host, dst_port, -1, 0) < 0)
     {
-        swSysWarn("failed to connect to [%s:%d].", dst_host, dst_port);
+        swSysWarn("failed to connect to [%s:%d]", dst_host, dst_port);
         return NULL;
     }
     else

--- a/src/network/stream.c
+++ b/src/network/stream.c
@@ -95,7 +95,7 @@ swStream* swStream_new(char *dst_host, int dst_port, int type)
 
     if (cli->connect(cli, dst_host, dst_port, -1, 0) < 0)
     {
-        swSysError("failed to connect to [%s:%d].", dst_host, dst_port);
+        swSysWarn("failed to connect to [%s:%d].", dst_host, dst_port);
         return NULL;
     }
     else

--- a/src/network/thread_pool.c
+++ b/src/network/thread_pool.c
@@ -70,7 +70,7 @@ int swThreadPool_dispatch(swThreadPool *pool, void *task, int task_len)
 
     if (ret < 0)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_QUEUE_FULL, "the queue of thread pool is full.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_QUEUE_FULL, "the queue of thread pool is full");
         return SW_ERR;
     }
 

--- a/src/network/thread_pool.c
+++ b/src/network/thread_pool.c
@@ -89,7 +89,7 @@ int swThreadPool_run(swThreadPool *pool)
         pool->params[i].object = pool;
         if (pthread_create(&(swThreadPool_thread(pool,i)->tid), NULL, swThreadPool_loop, &pool->params[i]) < 0)
         {
-            swSysError("pthread_create failed");
+            swSysWarn("pthread_create failed");
             return SW_ERR;
         }
     }

--- a/src/network/thread_pool.c
+++ b/src/network/thread_pool.c
@@ -89,7 +89,7 @@ int swThreadPool_run(swThreadPool *pool)
         pool->params[i].object = pool;
         if (pthread_create(&(swThreadPool_thread(pool,i)->tid), NULL, swThreadPool_loop, &pool->params[i]) < 0)
         {
-            swWarn("pthread_create failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("pthread_create failed");
             return SW_ERR;
         }
     }

--- a/src/network/timer.c
+++ b/src/network/timer.c
@@ -24,7 +24,7 @@ int swTimer_now(struct timeval *time)
     struct timespec _now;
     if (clock_gettime(CLOCK_MONOTONIC, &_now) < 0)
     {
-        swSysWarn("clock_gettime(CLOCK_MONOTONIC) failed.");
+        swSysWarn("clock_gettime(CLOCK_MONOTONIC) failed");
         return SW_ERR;
     }
     time->tv_sec = _now.tv_sec;
@@ -32,7 +32,7 @@ int swTimer_now(struct timeval *time)
 #else
     if (gettimeofday(time, NULL) < 0)
     {
-        swSysWarn("gettimeofday() failed.");
+        swSysWarn("gettimeofday() failed");
         return SW_ERR;
     }
 #endif
@@ -129,14 +129,14 @@ swTimer_node* swTimer_add(swTimer *timer, long _msec, int interval, void *data, 
 
     if (unlikely(_msec <= 0))
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_INVALID_PARAMS, "_msec value[%ld] is invalid.", _msec);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_INVALID_PARAMS, "_msec value[%ld] is invalid", _msec);
         return NULL;
     }
 
     swTimer_node *tnode = sw_malloc(sizeof(swTimer_node));
     if (unlikely(!tnode))
     {
-        swSysWarn("malloc(%ld) failed.", sizeof(swTimer_node));
+        swSysWarn("malloc(%ld) failed", sizeof(swTimer_node));
         return NULL;
     }
 

--- a/src/network/timer.c
+++ b/src/network/timer.c
@@ -24,7 +24,7 @@ int swTimer_now(struct timeval *time)
     struct timespec _now;
     if (clock_gettime(CLOCK_MONOTONIC, &_now) < 0)
     {
-        swSysError("clock_gettime(CLOCK_MONOTONIC) failed.");
+        swSysWarn("clock_gettime(CLOCK_MONOTONIC) failed.");
         return SW_ERR;
     }
     time->tv_sec = _now.tv_sec;
@@ -32,7 +32,7 @@ int swTimer_now(struct timeval *time)
 #else
     if (gettimeofday(time, NULL) < 0)
     {
-        swSysError("gettimeofday() failed.");
+        swSysWarn("gettimeofday() failed.");
         return SW_ERR;
     }
 #endif
@@ -136,7 +136,7 @@ swTimer_node* swTimer_add(swTimer *timer, long _msec, int interval, void *data, 
     swTimer_node *tnode = sw_malloc(sizeof(swTimer_node));
     if (unlikely(!tnode))
     {
-        swSysError("malloc(%ld) failed.", sizeof(swTimer_node));
+        swSysWarn("malloc(%ld) failed.", sizeof(swTimer_node));
         return NULL;
     }
 

--- a/src/os/base.c
+++ b/src/os/base.c
@@ -60,7 +60,7 @@ int swAio_init(void)
     }
     if (swMutex_create(&SwooleAIO.lock, 0) < 0)
     {
-        swWarn("create mutex lock error.");
+        swWarn("create mutex lock error");
         return SW_ERR;
     }
     if (SwooleAIO.thread_num <= 0)
@@ -142,7 +142,7 @@ static int swAio_onTask(swThreadPool *pool, void *task, int task_len)
             }
             else
             {
-                swSysWarn("sendto swoole_aio_pipe_write failed.");
+                swSysWarn("sendto swoole_aio_pipe_write failed");
             }
         }
         break;
@@ -163,7 +163,7 @@ int swAio_dispatch(swAio_event *_event)
     swAio_event *event = (swAio_event *) sw_malloc(sizeof(swAio_event));
     if (event == NULL)
     {
-        swWarn("malloc failed.");
+        swWarn("malloc failed");
         return SW_ERR;
     }
     memcpy(event, _event, sizeof(swAio_event));
@@ -247,7 +247,7 @@ void swAio_handler_read(swAio_event *event)
     int ret = -1;
     if (event->lock && flock(event->fd, LOCK_SH) < 0)
     {
-        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed", event->fd);
         event->ret = -1;
         event->error = errno;
         return;
@@ -263,7 +263,7 @@ void swAio_handler_read(swAio_event *event)
     }
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed", event->fd);
     }
     if (ret < 0)
     {
@@ -276,7 +276,7 @@ void swAio_handler_fgets(swAio_event *event)
 {
     if (event->lock && flock(event->fd, LOCK_SH) < 0)
     {
-        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed", event->fd);
         event->ret = -1;
         event->error = errno;
         return;
@@ -293,7 +293,7 @@ void swAio_handler_fgets(swAio_event *event)
 
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed", event->fd);
     }
 }
 
@@ -303,7 +303,7 @@ void swAio_handler_read_file(swAio_event *event)
     int fd = open(event->req, O_RDONLY);
     if (fd < 0)
     {
-        swSysWarn("open(%s, O_RDONLY) failed.", (char * )event->req);
+        swSysWarn("open(%s, O_RDONLY) failed", (char * )event->req);
         event->ret = ret;
         event->error = errno;
         return;
@@ -311,7 +311,7 @@ void swAio_handler_read_file(swAio_event *event)
     struct stat file_stat;
     if (fstat(fd, &file_stat) < 0)
     {
-        swSysWarn("fstat(%s) failed.", (char * )event->req);
+        swSysWarn("fstat(%s) failed", (char * )event->req);
         _error: close(fd);
         event->ret = ret;
         event->error = errno;
@@ -328,7 +328,7 @@ void swAio_handler_read_file(swAio_event *event)
      */
     if (event->lock && flock(fd, LOCK_SH) < 0)
     {
-        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed", event->fd);
         goto _error;
     }
     /**
@@ -360,7 +360,7 @@ void swAio_handler_read_file(swAio_event *event)
      */
     if (event->lock && flock(fd, LOCK_UN) < 0)
     {
-        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed", event->fd);
     }
     close(fd);
     event->error = 0;
@@ -372,14 +372,14 @@ void swAio_handler_write_file(swAio_event *event)
     int fd = open(event->req, event->flags, 0644);
     if (fd < 0)
     {
-        swSysWarn("open(%s, %d) failed.", (char * )event->req, event->flags);
+        swSysWarn("open(%s, %d) failed", (char * )event->req, event->flags);
         event->ret = ret;
         event->error = errno;
         return;
     }
     if (event->lock && flock(fd, LOCK_EX) < 0)
     {
-        swSysWarn("flock(%d, LOCK_EX) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_EX) failed", event->fd);
         event->ret = ret;
         event->error = errno;
         close(fd);
@@ -390,12 +390,12 @@ void swAio_handler_write_file(swAio_event *event)
     {
         if (fsync(fd) < 0)
         {
-            swSysWarn("fsync(%d) failed.", event->fd);
+            swSysWarn("fsync(%d) failed", event->fd);
         }
     }
     if (event->lock && flock(fd, LOCK_UN) < 0)
     {
-        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed", event->fd);
     }
     close(fd);
     event->ret = written;
@@ -407,7 +407,7 @@ void swAio_handler_write(swAio_event *event)
     int ret = -1;
     if (event->lock && flock(event->fd, LOCK_EX) < 0)
     {
-        swSysWarn("flock(%d, LOCK_EX) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_EX) failed", event->fd);
         return;
     }
     if (event->offset == 0)
@@ -422,12 +422,12 @@ void swAio_handler_write(swAio_event *event)
     {
         if (fsync(event->fd) < 0)
         {
-            swSysWarn("fsync(%d) failed.", event->fd);
+            swSysWarn("fsync(%d) failed", event->fd);
         }
     }
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed", event->fd);
     }
     if (ret < 0)
     {

--- a/src/os/base.c
+++ b/src/os/base.c
@@ -97,7 +97,7 @@ static int swAio_onCompleted(swReactor *reactor, swEvent *event)
     int n = read(event->fd, events, sizeof(swAio_event*) * SW_AIO_EVENT_NUM);
     if (n < 0)
     {
-        swSysError("read() failed");
+        swSysWarn("read() failed");
         return SW_ERR;
     }
     for (i = 0; i < n / sizeof(swAio_event*); i++)
@@ -142,7 +142,7 @@ static int swAio_onTask(swThreadPool *pool, void *task, int task_len)
             }
             else
             {
-                swSysError("sendto swoole_aio_pipe_write failed.");
+                swSysWarn("sendto swoole_aio_pipe_write failed.");
             }
         }
         break;
@@ -201,7 +201,7 @@ int swoole_daemon(int nochdir, int noclose)
 
     if (!nochdir && chdir("/") != 0)
     {
-        swSysError("chdir() failed");
+        swSysWarn("chdir() failed");
         return -1;
     }
 
@@ -210,14 +210,14 @@ int swoole_daemon(int nochdir, int noclose)
         int fd = open("/dev/null", O_RDWR);
         if (fd < 0)
         {
-            swSysError("open() failed");
+            swSysWarn("open() failed");
             return -1;
         }
 
         if (dup2(fd, 0) < 0 || dup2(fd, 1) < 0 || dup2(fd, 2) < 0)
         {
             close(fd);
-            swSysError("dup2() failed");
+            swSysWarn("dup2() failed");
             return -1;
         }
 
@@ -227,7 +227,7 @@ int swoole_daemon(int nochdir, int noclose)
     pid = fork();
     if (pid < 0)
     {
-        swSysError("fork() failed");
+        swSysWarn("fork() failed");
         return -1;
     }
     if (pid > 0)
@@ -236,7 +236,7 @@ int swoole_daemon(int nochdir, int noclose)
     }
     if (setsid() < 0)
     {
-        swSysError("setsid() failed");
+        swSysWarn("setsid() failed");
         return -1;
     }
     return 0;
@@ -247,7 +247,7 @@ void swAio_handler_read(swAio_event *event)
     int ret = -1;
     if (event->lock && flock(event->fd, LOCK_SH) < 0)
     {
-        swSysError("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
         event->ret = -1;
         event->error = errno;
         return;
@@ -263,7 +263,7 @@ void swAio_handler_read(swAio_event *event)
     }
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysError("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
     }
     if (ret < 0)
     {
@@ -276,7 +276,7 @@ void swAio_handler_fgets(swAio_event *event)
 {
     if (event->lock && flock(event->fd, LOCK_SH) < 0)
     {
-        swSysError("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
         event->ret = -1;
         event->error = errno;
         return;
@@ -293,7 +293,7 @@ void swAio_handler_fgets(swAio_event *event)
 
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysError("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
     }
 }
 
@@ -303,7 +303,7 @@ void swAio_handler_read_file(swAio_event *event)
     int fd = open(event->req, O_RDONLY);
     if (fd < 0)
     {
-        swSysError("open(%s, O_RDONLY) failed.", (char * )event->req);
+        swSysWarn("open(%s, O_RDONLY) failed.", (char * )event->req);
         event->ret = ret;
         event->error = errno;
         return;
@@ -311,7 +311,7 @@ void swAio_handler_read_file(swAio_event *event)
     struct stat file_stat;
     if (fstat(fd, &file_stat) < 0)
     {
-        swSysError("fstat(%s) failed.", (char * )event->req);
+        swSysWarn("fstat(%s) failed.", (char * )event->req);
         _error: close(fd);
         event->ret = ret;
         event->error = errno;
@@ -328,7 +328,7 @@ void swAio_handler_read_file(swAio_event *event)
      */
     if (event->lock && flock(fd, LOCK_SH) < 0)
     {
-        swSysError("flock(%d, LOCK_SH) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_SH) failed.", event->fd);
         goto _error;
     }
     /**
@@ -360,7 +360,7 @@ void swAio_handler_read_file(swAio_event *event)
      */
     if (event->lock && flock(fd, LOCK_UN) < 0)
     {
-        swSysError("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
     }
     close(fd);
     event->error = 0;
@@ -372,14 +372,14 @@ void swAio_handler_write_file(swAio_event *event)
     int fd = open(event->req, event->flags, 0644);
     if (fd < 0)
     {
-        swSysError("open(%s, %d) failed.", (char * )event->req, event->flags);
+        swSysWarn("open(%s, %d) failed.", (char * )event->req, event->flags);
         event->ret = ret;
         event->error = errno;
         return;
     }
     if (event->lock && flock(fd, LOCK_EX) < 0)
     {
-        swSysError("flock(%d, LOCK_EX) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_EX) failed.", event->fd);
         event->ret = ret;
         event->error = errno;
         close(fd);
@@ -390,12 +390,12 @@ void swAio_handler_write_file(swAio_event *event)
     {
         if (fsync(fd) < 0)
         {
-            swSysError("fsync(%d) failed.", event->fd);
+            swSysWarn("fsync(%d) failed.", event->fd);
         }
     }
     if (event->lock && flock(fd, LOCK_UN) < 0)
     {
-        swSysError("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
     }
     close(fd);
     event->ret = written;
@@ -407,7 +407,7 @@ void swAio_handler_write(swAio_event *event)
     int ret = -1;
     if (event->lock && flock(event->fd, LOCK_EX) < 0)
     {
-        swSysError("flock(%d, LOCK_EX) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_EX) failed.", event->fd);
         return;
     }
     if (event->offset == 0)
@@ -422,12 +422,12 @@ void swAio_handler_write(swAio_event *event)
     {
         if (fsync(event->fd) < 0)
         {
-            swSysError("fsync(%d) failed.", event->fd);
+            swSysWarn("fsync(%d) failed.", event->fd);
         }
     }
     if (event->lock && flock(event->fd, LOCK_UN) < 0)
     {
-        swSysError("flock(%d, LOCK_UN) failed.", event->fd);
+        swSysWarn("flock(%d, LOCK_UN) failed.", event->fd);
     }
     if (ret < 0)
     {

--- a/src/os/base.c
+++ b/src/os/base.c
@@ -97,7 +97,7 @@ static int swAio_onCompleted(swReactor *reactor, swEvent *event)
     int n = read(event->fd, events, sizeof(swAio_event*) * SW_AIO_EVENT_NUM);
     if (n < 0)
     {
-        swWarn("read() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("read() failed");
         return SW_ERR;
     }
     for (i = 0; i < n / sizeof(swAio_event*); i++)
@@ -201,7 +201,7 @@ int swoole_daemon(int nochdir, int noclose)
 
     if (!nochdir && chdir("/") != 0)
     {
-        swWarn("chdir() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("chdir() failed");
         return -1;
     }
 
@@ -210,14 +210,14 @@ int swoole_daemon(int nochdir, int noclose)
         int fd = open("/dev/null", O_RDWR);
         if (fd < 0)
         {
-            swWarn("open() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("open() failed");
             return -1;
         }
 
         if (dup2(fd, 0) < 0 || dup2(fd, 1) < 0 || dup2(fd, 2) < 0)
         {
             close(fd);
-            swWarn("dup2() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("dup2() failed");
             return -1;
         }
 
@@ -227,7 +227,7 @@ int swoole_daemon(int nochdir, int noclose)
     pid = fork();
     if (pid < 0)
     {
-        swWarn("fork() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("fork() failed");
         return -1;
     }
     if (pid > 0)
@@ -236,7 +236,7 @@ int swoole_daemon(int nochdir, int noclose)
     }
     if (setsid() < 0)
     {
-        swWarn("setsid() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("setsid() failed");
         return -1;
     }
     return 0;

--- a/src/os/msg_queue.c
+++ b/src/os/msg_queue.c
@@ -25,7 +25,7 @@ int swMsgQueue_free(swMsgQueue *q)
 {
     if (msgctl(q->msg_id, IPC_RMID, 0) < 0)
     {
-        swSysError("msgctl(%d, IPC_RMID) failed.", q->msg_id);
+        swSysWarn("msgctl(%d, IPC_RMID) failed.", q->msg_id);
         return SW_ERR;
     }
     return SW_OK;
@@ -53,7 +53,7 @@ int swMsgQueue_create(swMsgQueue *q, int blocking, key_t msg_key, int perms)
     msg_id = msgget(msg_key, IPC_CREAT | perms);
     if (msg_id < 0)
     {
-        swSysError("msgget() failed.");
+        swSysWarn("msgget() failed.");
         return SW_ERR;
     }
     else
@@ -75,7 +75,7 @@ int swMsgQueue_pop(swMsgQueue *q, swQueue_data *data, int length)
         SwooleG.error = errno;
         if (errno != ENOMSG && errno != EINTR)
         {
-            swSysError("msgrcv(%d, %d, %ld) failed.", q->msg_id, length, data->mtype);
+            swSysWarn("msgrcv(%d, %d, %ld) failed.", q->msg_id, length, data->mtype);
         }
     }
     return ret;
@@ -101,7 +101,7 @@ int swMsgQueue_push(swMsgQueue *q, swQueue_data *in, int length)
             }
             else
             {
-                swSysError("msgsnd(%d, %d, %ld) failed.", q->msg_id, length, in->mtype);
+                swSysWarn("msgsnd(%d, %d, %ld) failed.", q->msg_id, length, in->mtype);
                 return -1;
             }
         }
@@ -138,7 +138,7 @@ int swMsgQueue_set_capacity(swMsgQueue *q, int queue_bytes)
     __stat.msg_qbytes = queue_bytes;
     if (msgctl(q->msg_id, IPC_SET, &__stat))
     {
-        swSysError("msgctl(msqid=%d, IPC_SET, msg_qbytes=%d) failed.", q->msg_id, queue_bytes);
+        swSysWarn("msgctl(msqid=%d, IPC_SET, msg_qbytes=%d) failed.", q->msg_id, queue_bytes);
         return -1;
     }
     return 0;

--- a/src/os/msg_queue.c
+++ b/src/os/msg_queue.c
@@ -25,7 +25,7 @@ int swMsgQueue_free(swMsgQueue *q)
 {
     if (msgctl(q->msg_id, IPC_RMID, 0) < 0)
     {
-        swSysWarn("msgctl(%d, IPC_RMID) failed.", q->msg_id);
+        swSysWarn("msgctl(%d, IPC_RMID) failed", q->msg_id);
         return SW_ERR;
     }
     return SW_OK;
@@ -53,7 +53,7 @@ int swMsgQueue_create(swMsgQueue *q, int blocking, key_t msg_key, int perms)
     msg_id = msgget(msg_key, IPC_CREAT | perms);
     if (msg_id < 0)
     {
-        swSysWarn("msgget() failed.");
+        swSysWarn("msgget() failed");
         return SW_ERR;
     }
     else
@@ -75,7 +75,7 @@ int swMsgQueue_pop(swMsgQueue *q, swQueue_data *data, int length)
         SwooleG.error = errno;
         if (errno != ENOMSG && errno != EINTR)
         {
-            swSysWarn("msgrcv(%d, %d, %ld) failed.", q->msg_id, length, data->mtype);
+            swSysWarn("msgrcv(%d, %d, %ld) failed", q->msg_id, length, data->mtype);
         }
     }
     return ret;
@@ -101,7 +101,7 @@ int swMsgQueue_push(swMsgQueue *q, swQueue_data *in, int length)
             }
             else
             {
-                swSysWarn("msgsnd(%d, %d, %ld) failed.", q->msg_id, length, in->mtype);
+                swSysWarn("msgsnd(%d, %d, %ld) failed", q->msg_id, length, in->mtype);
                 return -1;
             }
         }
@@ -138,7 +138,7 @@ int swMsgQueue_set_capacity(swMsgQueue *q, int queue_bytes)
     __stat.msg_qbytes = queue_bytes;
     if (msgctl(q->msg_id, IPC_SET, &__stat))
     {
-        swSysWarn("msgctl(msqid=%d, IPC_SET, msg_qbytes=%d) failed.", q->msg_id, queue_bytes);
+        swSysWarn("msgctl(msqid=%d, IPC_SET, msg_qbytes=%d) failed", q->msg_id, queue_bytes);
         return -1;
     }
     return 0;

--- a/src/os/sendfile.c
+++ b/src/os/sendfile.c
@@ -68,7 +68,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
     }
     else
     {
-        swSysError("sendfile failed");
+        swSysWarn("sendfile failed");
         return SW_ERR;
     }
     return SW_OK;
@@ -87,7 +87,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
         ret = write(out_fd, buf, n);
         if (ret < 0)
         {
-            swSysError("write() failed.");
+            swSysWarn("write() failed.");
         }
         else
         {
@@ -97,7 +97,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
     }
     else
     {
-        swSysError("pread() failed.");
+        swSysWarn("pread() failed.");
         return SW_ERR;
     }
 }

--- a/src/os/sendfile.c
+++ b/src/os/sendfile.c
@@ -87,7 +87,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
         ret = write(out_fd, buf, n);
         if (ret < 0)
         {
-            swSysWarn("write() failed.");
+            swSysWarn("write() failed");
         }
         else
         {
@@ -97,7 +97,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
     }
     else
     {
-        swSysWarn("pread() failed.");
+        swSysWarn("pread() failed");
         return SW_ERR;
     }
 }

--- a/src/os/sendfile.c
+++ b/src/os/sendfile.c
@@ -68,7 +68,7 @@ int swoole_sendfile(int out_fd, int in_fd, off_t *offset, size_t size)
     }
     else
     {
-        swWarn("sendfile failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("sendfile failed");
         return SW_ERR;
     }
     return SW_OK;

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -65,7 +65,7 @@ void swSignal_none(void)
     int ret = pthread_sigmask(SIG_BLOCK, &mask, NULL);
     if (ret < 0)
     {
-        swWarn("pthread_sigmask() failed. Error: %s[%d]", strerror(ret), ret);
+        swSysError("pthread_sigmask() failed");
     }
 }
 
@@ -247,13 +247,13 @@ int swSignalfd_setup(swReactor *reactor)
         signal_fd = signalfd(-1, &signalfd_mask, SFD_NONBLOCK | SFD_CLOEXEC);
         if (signal_fd < 0)
         {
-            swWarn("signalfd() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("signalfd() failed");
             return SW_ERR;
         }
         SwooleG.signal_fd = signal_fd;
         if (sigprocmask(SIG_BLOCK, &signalfd_mask, NULL) == -1)
         {
-            swWarn("sigprocmask() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("sigprocmask() failed");
             return SW_ERR;
         }
         reactor->setHandle(reactor, SW_FD_SIGNAL, swSignalfd_onSignal);
@@ -288,7 +288,7 @@ static int swSignalfd_onSignal(swReactor *reactor, swEvent *event)
     n = read(event->fd, &siginfo, sizeof(siginfo));
     if (n < 0)
     {
-        swWarn("read from signalfd failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("read from signalfd failed");
         return SW_OK;
     }
     if (siginfo.ssi_signo >=  SW_SIGNO_MAX)

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -155,7 +155,7 @@ void swSignal_callback(int signo)
 {
     if (signo >= SW_SIGNO_MAX)
     {
-        swWarn("signal[%d] numberis invalid.", signo);
+        swWarn("signal[%d] numberis invalid", signo);
         return;
     }
     swSignalHandler callback = signals[signo].handler;
@@ -171,7 +171,7 @@ swSignalHandler swSignal_get_handler(int signo)
 {
     if (signo >= SW_SIGNO_MAX)
     {
-        swWarn("signal[%d] numberis invalid.", signo);
+        swWarn("signal[%d] numberis invalid", signo);
         return NULL;
     }
     else
@@ -273,7 +273,7 @@ static void swSignalfd_clear()
     {
         if (sigprocmask(SIG_UNBLOCK, &signalfd_mask, NULL) < 0)
         {
-            swSysWarn("sigprocmask(SIG_UNBLOCK) failed.");
+            swSysWarn("sigprocmask(SIG_UNBLOCK) failed");
         }
         close(signal_fd);
         bzero(&signalfd_mask, sizeof(signalfd_mask));
@@ -293,7 +293,7 @@ static int swSignalfd_onSignal(swReactor *reactor, swEvent *event)
     }
     if (siginfo.ssi_signo >=  SW_SIGNO_MAX)
     {
-        swWarn("unknown signal[%d].", siginfo.ssi_signo);
+        swWarn("unknown signal[%d]", siginfo.ssi_signo);
         return SW_OK;
     }
     if (signals[siginfo.ssi_signo].active)

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -65,7 +65,7 @@ void swSignal_none(void)
     int ret = pthread_sigmask(SIG_BLOCK, &mask, NULL);
     if (ret < 0)
     {
-        swSysError("pthread_sigmask() failed");
+        swSysWarn("pthread_sigmask() failed");
     }
 }
 
@@ -247,13 +247,13 @@ int swSignalfd_setup(swReactor *reactor)
         signal_fd = signalfd(-1, &signalfd_mask, SFD_NONBLOCK | SFD_CLOEXEC);
         if (signal_fd < 0)
         {
-            swSysError("signalfd() failed");
+            swSysWarn("signalfd() failed");
             return SW_ERR;
         }
         SwooleG.signal_fd = signal_fd;
         if (sigprocmask(SIG_BLOCK, &signalfd_mask, NULL) == -1)
         {
-            swSysError("sigprocmask() failed");
+            swSysWarn("sigprocmask() failed");
             return SW_ERR;
         }
         reactor->setHandle(reactor, SW_FD_SIGNAL, swSignalfd_onSignal);
@@ -273,7 +273,7 @@ static void swSignalfd_clear()
     {
         if (sigprocmask(SIG_UNBLOCK, &signalfd_mask, NULL) < 0)
         {
-            swSysError("sigprocmask(SIG_UNBLOCK) failed.");
+            swSysWarn("sigprocmask(SIG_UNBLOCK) failed.");
         }
         close(signal_fd);
         bzero(&signalfd_mask, sizeof(signalfd_mask));
@@ -288,7 +288,7 @@ static int swSignalfd_onSignal(swReactor *reactor, swEvent *event)
     n = read(event->fd, &siginfo, sizeof(siginfo));
     if (n < 0)
     {
-        swSysError("read from signalfd failed");
+        swSysWarn("read from signalfd failed");
         return SW_OK;
     }
     if (siginfo.ssi_signo >=  SW_SIGNO_MAX)

--- a/src/os/timer.c
+++ b/src/os/timer.c
@@ -50,7 +50,7 @@ static int swSystemTimer_signal_set(swTimer *timer, long interval)
     struct timeval now;
     if (gettimeofday(&now, NULL) < 0)
     {
-        swSysError("gettimeofday() failed");
+        swSysWarn("gettimeofday() failed");
         return SW_ERR;
     }
     bzero(&timer_set, sizeof(timer_set));
@@ -72,7 +72,7 @@ static int swSystemTimer_signal_set(swTimer *timer, long interval)
 
     if (setitimer(ITIMER_REAL, &timer_set, NULL) < 0)
     {
-        swSysError("setitimer() failed");
+        swSysWarn("setitimer() failed");
         return SW_ERR;
     }
     return SW_OK;

--- a/src/os/timer.c
+++ b/src/os/timer.c
@@ -50,7 +50,7 @@ static int swSystemTimer_signal_set(swTimer *timer, long interval)
     struct timeval now;
     if (gettimeofday(&now, NULL) < 0)
     {
-        swWarn("gettimeofday() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("gettimeofday() failed");
         return SW_ERR;
     }
     bzero(&timer_set, sizeof(timer_set));
@@ -72,7 +72,7 @@ static int swSystemTimer_signal_set(swTimer *timer, long interval)
 
     if (setitimer(ITIMER_REAL, &timer_set, NULL) < 0)
     {
-        swWarn("setitimer() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("setitimer() failed");
         return SW_ERR;
     }
     return SW_OK;

--- a/src/pipe/base.c
+++ b/src/pipe/base.c
@@ -38,7 +38,7 @@ int swPipeBase_create(swPipe *p, int blocking)
     ret = pipe(object->pipes);
     if (ret < 0)
     {
-        swSysError("pipe() failed");
+        swSysWarn("pipe() failed");
         sw_free(object);
         return -1;
     }

--- a/src/pipe/base.c
+++ b/src/pipe/base.c
@@ -38,7 +38,7 @@ int swPipeBase_create(swPipe *p, int blocking)
     ret = pipe(object->pipes);
     if (ret < 0)
     {
-        swWarn("pipe() failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("pipe() failed");
         sw_free(object);
         return -1;
     }

--- a/src/pipe/eventfd.c
+++ b/src/pipe/eventfd.c
@@ -65,7 +65,7 @@ int swPipeEventfd_create(swPipe *p, int blocking, int semaphore, int timeout)
     efd = eventfd(0, flag);
     if (efd < 0)
     {
-        swWarn("eventfd create failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("eventfd create failed");
         sw_free(object);
         return -1;
     }

--- a/src/pipe/eventfd.c
+++ b/src/pipe/eventfd.c
@@ -65,7 +65,7 @@ int swPipeEventfd_create(swPipe *p, int blocking, int semaphore, int timeout)
     efd = eventfd(0, flag);
     if (efd < 0)
     {
-        swSysError("eventfd create failed");
+        swSysWarn("eventfd create failed");
         sw_free(object);
         return -1;
     }

--- a/src/pipe/unix_socket.c
+++ b/src/pipe/unix_socket.c
@@ -98,7 +98,7 @@ int swPipeUnsock_create(swPipe *p, int blocking, int protocol)
     ret = socketpair(AF_UNIX, protocol, 0, object->socks);
     if (ret < 0)
     {
-        swSysError("socketpair() failed");
+        swSysWarn("socketpair() failed");
         sw_free(object);
         return SW_ERR;
     }

--- a/src/pipe/unix_socket.c
+++ b/src/pipe/unix_socket.c
@@ -90,7 +90,7 @@ int swPipeUnsock_create(swPipe *p, int blocking, int protocol)
     swPipeUnsock *object = sw_malloc(sizeof(swPipeUnsock));
     if (object == NULL)
     {
-        swWarn("malloc() failed.");
+        swWarn("malloc() failed");
         return SW_ERR;
     }
     bzero(object, sizeof(swPipeUnsock));

--- a/src/pipe/unix_socket.c
+++ b/src/pipe/unix_socket.c
@@ -98,7 +98,7 @@ int swPipeUnsock_create(swPipe *p, int blocking, int protocol)
     ret = socketpair(AF_UNIX, protocol, 0, object->socks);
     if (ret < 0)
     {
-        swWarn("socketpair() failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("socketpair() failed");
         sw_free(object);
         return SW_ERR;
     }

--- a/src/protocol/base.c
+++ b/src/protocol/base.c
@@ -40,7 +40,7 @@ ssize_t swProtocol_get_package_length(swProtocol *protocol, swConnection *conn, 
     //Protocol length is not legitimate, out of bounds or exceed the allocated length
     if (body_length < 0)
     {
-        swWarn("invalid package, remote_addr=%s:%d, length=%d, size=%d.", swConnection_get_ip(conn), swConnection_get_port(conn), body_length, size);
+        swWarn("invalid package, remote_addr=%s:%d, length=%d, size=%d", swConnection_get_ip(conn), swConnection_get_port(conn), body_length, size);
         return SW_ERR;
     }
     swDebug("length=%d", protocol->package_body_offset + body_length);
@@ -70,7 +70,7 @@ static sw_inline int swProtocol_split_package_by_eof(swProtocol *protocol, swCon
         eof_pos = swoole_strnpos(buffer->str + buffer->offset, buffer->length - buffer->offset, protocol->package_eof, protocol->package_eof_len);
     }
 
-    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[0] count=%d, length=%ld, size=%ld, offset=%ld.", count, buffer->length, buffer->size, (long)buffer->offset);
+    swTraceLog(SW_TRACE_EOF_PROTOCOL, "#[0] count=%d, length=%ld, size=%ld, offset=%ld", count, buffer->length, buffer->size, (long)buffer->offset);
 
     //waiting for more data
     if (eof_pos < 0)
@@ -144,7 +144,7 @@ int swProtocol_recv_check_length(swProtocol *protocol, swConnection *conn, swStr
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("recv(%d, %d) failed.", conn->fd, recv_size);
+            swSysWarn("recv(%d, %d) failed", conn->fd, recv_size);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -210,7 +210,7 @@ int swProtocol_recv_check_length(swProtocol *protocol, swConnection *conn, swStr
             }
             else if (package_length > protocol->package_max_length)
             {
-                swWarn("package is too big, remote_addr=%s:%d, length=%d.", swConnection_get_ip(conn), swConnection_get_port(conn), package_length);
+                swWarn("package is too big, remote_addr=%s:%d, length=%d", swConnection_get_ip(conn), swConnection_get_port(conn), package_length);
                 return SW_ERR;
             }
             //get length success
@@ -263,7 +263,7 @@ int swProtocol_recv_check_eof(swProtocol *protocol, swConnection *conn, swString
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("recv from socket#%d failed.", conn->fd);
+            swSysWarn("recv from socket#%d failed", conn->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;

--- a/src/protocol/base.c
+++ b/src/protocol/base.c
@@ -144,7 +144,7 @@ int swProtocol_recv_check_length(swProtocol *protocol, swConnection *conn, swStr
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("recv(%d, %d) failed.", conn->fd, recv_size);
+            swSysWarn("recv(%d, %d) failed.", conn->fd, recv_size);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -263,7 +263,7 @@ int swProtocol_recv_check_eof(swProtocol *protocol, swConnection *conn, swString
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("recv from socket#%d failed.", conn->fd);
+            swSysWarn("recv from socket#%d failed.", conn->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;

--- a/src/protocol/redis.c
+++ b/src/protocol/redis.c
@@ -63,7 +63,7 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("recv from socket#%d failed.", conn->fd);
+            swSysWarn("recv from socket#%d failed.", conn->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;

--- a/src/protocol/redis.c
+++ b/src/protocol/redis.c
@@ -63,7 +63,7 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("recv from socket#%d failed.", conn->fd);
+            swSysWarn("recv from socket#%d failed", conn->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -97,7 +97,7 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
             else if (buffer->length == buffer->size)
             {
                 package_too_big:
-                swWarn("Package is too big. package_length=%ld.", buffer->length);
+                swWarn("Package is too big. package_length=%ld", buffer->length);
                 return SW_ERR;
             }
             goto recv_data;
@@ -177,6 +177,6 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
         } while(p < pe);
     }
     failed:
-    swWarn("redis protocol error.");
+    swWarn("redis protocol error");
     return SW_ERR;
 }

--- a/src/protocol/socks5.c
+++ b/src/protocol/socks5.c
@@ -56,12 +56,12 @@ int swSocks5_connect(swClient *cli, char *recv_data, int length)
         uchar method = recv_data[1];
         if (version != SW_SOCKS5_VERSION_CODE)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return SW_ERR;
         }
         if (method != ctx->method)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_METHOD, "SOCKS authentication method not supported.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_METHOD, "SOCKS authentication method not supported");
             return SW_ERR;
         }
         //authenticate request
@@ -117,12 +117,12 @@ int swSocks5_connect(swClient *cli, char *recv_data, int length)
         uchar status = recv_data[1];
         if (version != 0x01)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return SW_ERR;
         }
         if (status != 0)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS username/password authentication failed.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS username/password authentication failed");
             return SW_ERR;
         }
         goto send_connect_request;
@@ -132,7 +132,7 @@ int swSocks5_connect(swClient *cli, char *recv_data, int length)
         uchar version = recv_data[0];
         if (version != SW_SOCKS5_VERSION_CODE)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported.");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return SW_ERR;
         }
         uchar result = recv_data[1];
@@ -148,7 +148,7 @@ int swSocks5_connect(swClient *cli, char *recv_data, int length)
         }
         else
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_SERVER_ERROR, "Socks5 server error, reason :%s.", swSocks5_strerror(result));
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_SERVER_ERROR, "Socks5 server error, reason :%s", swSocks5_strerror(result));
         }
         return result;
     }

--- a/src/protocol/ssl.c
+++ b/src/protocol/ssl.c
@@ -385,7 +385,7 @@ int swSSL_set_client_certificate(SSL_CTX *ctx, char *cert_file, int depth)
 
     if (SSL_CTX_load_verify_locations(ctx, cert_file, NULL) == 0)
     {
-        swWarn("SSL_CTX_load_verify_locations(\"%s\") failed.", cert_file);
+        swWarn("SSL_CTX_load_verify_locations(\"%s\") failed", cert_file);
         return SW_ERR;
     }
 
@@ -393,7 +393,7 @@ int swSSL_set_client_certificate(SSL_CTX *ctx, char *cert_file, int depth)
     list = SSL_load_client_CA_file(cert_file);
     if (list == NULL)
     {
-        swWarn("SSL_load_client_CA_file(\"%s\") failed.", cert_file);
+        swWarn("SSL_load_client_CA_file(\"%s\") failed", cert_file);
         return SW_ERR;
     }
 
@@ -416,7 +416,7 @@ int swSSL_set_capath(swSSL_option *cfg, SSL_CTX *ctx)
     {
         if (!SSL_CTX_set_default_verify_paths(ctx))
         {
-            swWarn("Unable to set default verify locations and no CA settings specified.");
+            swWarn("Unable to set default verify locations and no CA settings specified");
             return SW_ERR;
         }
     }
@@ -524,7 +524,7 @@ int swSSL_check_host(swConnection *conn, char *tls_host_name)
             }
         }
 
-        swTrace("SSL subjectAltName: no match.");
+        swTrace("SSL subjectAltName: no match");
         GENERAL_NAMES_free(altnames);
         goto failed;
     }
@@ -619,21 +619,21 @@ int swSSL_get_client_certificate(SSL *ssl, char *buffer, size_t length)
     bio = BIO_new(BIO_s_mem());
     if (bio == NULL)
     {
-        swWarn("BIO_new() failed.");
+        swWarn("BIO_new() failed");
         X509_free(cert);
         return SW_ERR;
     }
 
     if (PEM_write_bio_X509(bio, cert) == 0)
     {
-        swWarn("PEM_write_bio_X509() failed.");
+        swWarn("PEM_write_bio_X509() failed");
         goto failed;
     }
 
     len = BIO_pending(bio);
     if (len < 0 && len > length)
     {
-        swWarn("certificate length[%ld] is too big.", len);
+        swWarn("certificate length[%ld] is too big", len);
         goto failed;
     }
 
@@ -697,7 +697,7 @@ int swSSL_accept(swConnection *conn)
     else if (err == SSL_ERROR_SSL)
     {
         int reason = ERR_GET_REASON(ERR_peek_error());
-        swWarn("bad SSL client[%s:%d], reason=%d.", swConnection_get_ip(conn), swConnection_get_port(conn), reason);
+        swWarn("bad SSL client[%s:%d], reason=%d", swConnection_get_ip(conn), swConnection_get_port(conn), reason);
         return SW_ERROR;
     }
     //EOF was observed
@@ -705,7 +705,7 @@ int swSSL_accept(swConnection *conn)
     {
         return SW_ERROR;
     }
-    swWarn("SSL_do_handshake() failed. Error: %s[%ld|%d].", strerror(errno), err, errno);
+    swWarn("SSL_do_handshake() failed. Error: %s[%ld|%d]", strerror(errno), err, errno);
     return SW_ERROR;
 }
 
@@ -744,7 +744,7 @@ int swSSL_connect(swConnection *conn)
     }
     else if (err == SSL_ERROR_ZERO_RETURN)
     {
-        swDebug("SSL_connect(fd=%d) closed.", conn->fd);
+        swDebug("SSL_connect(fd=%d) closed", conn->fd);
         return SW_ERR;
     }
     else if (err == SSL_ERROR_SYSCALL)
@@ -755,7 +755,7 @@ int swSSL_connect(swConnection *conn)
             return SW_ERR;
         }
     }
-    swWarn("SSL_connect(fd=%d) failed. Error: %s[%ld|%d].", conn->fd, ERR_reason_error_string(err), err, errno);
+    swWarn("SSL_connect(fd=%d) failed. Error: %s[%ld|%d]", conn->fd, ERR_reason_error_string(err), err, errno);
 
     return SW_ERR;
 }
@@ -775,7 +775,7 @@ int swSSL_sendfile(swConnection *conn, int fd, off_t *offset, size_t size)
         {
             if (swConnection_error(errno) == SW_ERROR)
             {
-                swSysWarn("write() failed.");
+                swSysWarn("write() failed");
             }
         }
         else
@@ -787,7 +787,7 @@ int swSSL_sendfile(swConnection *conn, int fd, off_t *offset, size_t size)
     }
     else
     {
-        swSysWarn("pread() failed.");
+        swSysWarn("pread() failed");
         return SW_ERR;
     }
 }
@@ -827,7 +827,7 @@ void swSSL_close(swConnection *conn)
     if (!(n == 1 || sslerr == 0 || sslerr == SSL_ERROR_ZERO_RETURN))
     {
         err = (sslerr == SSL_ERROR_SYSCALL) ? errno : 0;
-        swWarn("SSL_shutdown() failed. Error: %d:%d.", sslerr, err);
+        swWarn("SSL_shutdown() failed. Error: %d:%d", sslerr, err);
     }
 
     SSL_free(conn->ssl);
@@ -905,7 +905,7 @@ static sw_inline void swSSL_connection_error(swConnection *conn)
         break;
 #endif
 
-    swoole_error_log(level, SW_ERROR_SSL_BAD_PROTOCOL, "SSL connection#%d[%s:%d] protocol error[%d].", conn->session_id,
+    swoole_error_log(level, SW_ERROR_SSL_BAD_PROTOCOL, "SSL connection#%d[%s:%d] protocol error[%d]", conn->session_id,
             swConnection_get_ip(conn), swConnection_get_port(conn), reason);
 }
 
@@ -986,7 +986,7 @@ int swSSL_create(swConnection *conn, SSL_CTX* ssl_context, int flags)
     SSL *ssl = SSL_new(ssl_context);
     if (ssl == NULL)
     {
-        swWarn("SSL_new() failed.");
+        swWarn("SSL_new() failed");
         return SW_ERR;
     }
     if (!SSL_set_fd(ssl, conn->fd))
@@ -1025,7 +1025,7 @@ static RSA* swSSL_rsa_key_callback(SSL *ssl, int is_export, int key_length)
     BIGNUM *bn = BN_new();
     if (bn == NULL)
     {
-        swWarn("allocation error generating RSA key.");
+        swWarn("allocation error generating RSA key");
         return NULL;
     }
 

--- a/src/protocol/ssl.c
+++ b/src/protocol/ssl.c
@@ -775,7 +775,7 @@ int swSSL_sendfile(swConnection *conn, int fd, off_t *offset, size_t size)
         {
             if (swConnection_error(errno) == SW_ERROR)
             {
-                swSysError("write() failed.");
+                swSysWarn("write() failed.");
             }
         }
         else
@@ -787,7 +787,7 @@ int swSSL_sendfile(swConnection *conn, int fd, off_t *offset, size_t size)
     }
     else
     {
-        swSysError("pread() failed.");
+        swSysWarn("pread() failed.");
         return SW_ERR;
     }
 }

--- a/src/protocol/websocket.c
+++ b/src/protocol/websocket.c
@@ -197,7 +197,7 @@ int swWebSocket_pack_close_frame(swString *buffer, int code, char* reason, size_
 {
     if (unlikely(length > SW_WEBSOCKET_CLOSE_REASON_MAX_LEN))
     {
-        swWarn("the max length of close reason is %d.", SW_WEBSOCKET_CLOSE_REASON_MAX_LEN);
+        swWarn("the max length of close reason is %d", SW_WEBSOCKET_CLOSE_REASON_MAX_LEN);
         return SW_ERR;
     }
 
@@ -252,7 +252,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
         frame_buffer = conn->websocket_buffer;
         if (frame_buffer == NULL)
         {
-            swWarn("bad frame[opcode=0]. remote_addr=%s:%d.", swConnection_get_ip(conn), swConnection_get_port(conn));
+            swWarn("bad frame[opcode=0]. remote_addr=%s:%d", swConnection_get_ip(conn), swConnection_get_port(conn));
             return SW_ERR;
         }
         offset = length - ws.payload_length;
@@ -261,7 +261,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
         //frame data overflow
         if (frame_buffer->length + frame_length > port->protocol.package_max_length)
         {
-            swWarn("websocket frame is too big, remote_addr=%s:%d.", swConnection_get_ip(conn), swConnection_get_port(conn));
+            swWarn("websocket frame is too big, remote_addr=%s:%d", swConnection_get_ip(conn), swConnection_get_port(conn));
             return SW_ERR;
         }
         //merge incomplete data
@@ -284,7 +284,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
         {
             if (conn->websocket_buffer)
             {
-                swWarn("merging incomplete frame, bad request. remote_addr=%s:%d.", swConnection_get_ip(conn), swConnection_get_port(conn));
+                swWarn("merging incomplete frame, bad request. remote_addr=%s:%d", swConnection_get_ip(conn), swConnection_get_port(conn));
                 return SW_ERR;
             }
             conn->websocket_buffer = swString_dup(data + offset, length - offset);
@@ -298,7 +298,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
     case WEBSOCKET_OPCODE_PING:
         if (length >= (sizeof(buf) - SW_WEBSOCKET_HEADER_LEN))
         {
-            swWarn("ping frame application data is too big. remote_addr=%s:%d.", swConnection_get_ip(conn), swConnection_get_port(conn));
+            swWarn("ping frame application data is too big. remote_addr=%s:%d", swConnection_get_ip(conn), swConnection_get_port(conn));
             return SW_ERR;
         }
         else if (length == SW_WEBSOCKET_HEADER_LEN)
@@ -347,7 +347,7 @@ int swWebSocket_dispatch_frame(swConnection *conn, char *data, uint32_t length)
         return SW_ERR;
 
     default:
-        swWarn("unknown opcode [%d].", ws.header.OPCODE);
+        swWarn("unknown opcode [%d]", ws.header.OPCODE);
         break;
     }
     return SW_OK;

--- a/src/reactor/base.c
+++ b/src/reactor/base.c
@@ -61,7 +61,7 @@ int swReactor_create(swReactor *reactor, int max_event)
     reactor->socket_array = swArray_new(1024, sizeof(swConnection));
     if (!reactor->socket_array)
     {
-        swWarn("create socket array failed.");
+        swWarn("create socket array failed");
         return SW_ERR;
     }
 
@@ -221,7 +221,7 @@ int swReactor_close(swReactor *reactor, int fd)
     }
     bzero(socket, sizeof(swConnection));
     socket->removed = 1;
-    swTraceLog(SW_TRACE_CLOSE, "fd=%d.", fd);
+    swTraceLog(SW_TRACE_CLOSE, "fd=%d", fd);
     return close(fd);
 }
 
@@ -249,7 +249,7 @@ int swReactor_write(swReactor *reactor, int fd, void *buf, int n)
 
     if (n > socket->buffer_size)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE, "data is too large, cannot exceed buffer size.");
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE, "data is too large, cannot exceed buffer size");
         return SW_ERR;
     }
 
@@ -284,7 +284,7 @@ int swReactor_write(swReactor *reactor, int fd, void *buf, int n)
                 buffer = swBuffer_new(sizeof(swEventData));
                 if (!buffer)
                 {
-                    swWarn("create worker buffer failed.");
+                    swWarn("create worker buffer failed");
                     return SW_ERR;
                 }
                 socket->out_buffer = buffer;
@@ -296,14 +296,14 @@ int swReactor_write(swReactor *reactor, int fd, void *buf, int n)
             {
                 if (reactor->set(reactor, fd, socket->fdtype | socket->events) < 0)
                 {
-                    swSysWarn("reactor->set(%d, SW_EVENT_WRITE) failed.", fd);
+                    swSysWarn("reactor->set(%d, SW_EVENT_WRITE) failed", fd);
                 }
             }
             else
             {
                 if (reactor->add(reactor, fd, socket->fdtype | SW_EVENT_WRITE) < 0)
                 {
-                    swSysWarn("reactor->add(%d, SW_EVENT_WRITE) failed.", fd);
+                    swSysWarn("reactor->add(%d, SW_EVENT_WRITE) failed", fd);
                 }
             }
 
@@ -330,7 +330,7 @@ int swReactor_write(swReactor *reactor, int fd, void *buf, int n)
             }
             else
             {
-                swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "socket#%d output buffer overflow.", fd);
+                swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "socket#%d output buffer overflow", fd);
                 swYield();
                 swSocket_wait(fd, SW_SOCKET_OVERFLOW_WAIT, SW_EVENT_WRITE);
             }

--- a/src/reactor/base.c
+++ b/src/reactor/base.c
@@ -296,14 +296,14 @@ int swReactor_write(swReactor *reactor, int fd, void *buf, int n)
             {
                 if (reactor->set(reactor, fd, socket->fdtype | socket->events) < 0)
                 {
-                    swSysError("reactor->set(%d, SW_EVENT_WRITE) failed.", fd);
+                    swSysWarn("reactor->set(%d, SW_EVENT_WRITE) failed.", fd);
                 }
             }
             else
             {
                 if (reactor->add(reactor, fd, socket->fdtype | SW_EVENT_WRITE) < 0)
                 {
-                    swSysError("reactor->add(%d, SW_EVENT_WRITE) failed.", fd);
+                    swSysWarn("reactor->add(%d, SW_EVENT_WRITE) failed.", fd);
                 }
             }
 

--- a/src/reactor/epoll.c
+++ b/src/reactor/epoll.c
@@ -94,7 +94,7 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
     reactor_object->epfd = epoll_create(512);
     if (reactor_object->epfd < 0)
     {
-        swWarn("epoll_create failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("epoll_create failed");
         sw_free(reactor_object);
         return SW_ERR;
     }
@@ -227,7 +227,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swWarn("[Reactor#%d] epoll_wait failed. Error: %s[%d]", reactor_id, strerror(errno), errno);
+                swSysError("[Reactor#%d] epoll_wait failed", reactor_id);
                 return SW_ERR;
             }
             else

--- a/src/reactor/epoll.c
+++ b/src/reactor/epoll.c
@@ -19,11 +19,11 @@
 #ifdef HAVE_EPOLL
 #include <sys/epoll.h>
 #ifndef EPOLLRDHUP
-#error "require linux kernel version 2.6.32 or later."
+#error "require linux kernel version 2.6.32 or later"
 #endif
 
 #ifndef EPOLLONESHOT
-#error "require linux kernel version 2.6.32 or later."
+#error "require linux kernel version 2.6.32 or later"
 #endif
 
 typedef struct swReactorEpoll_s swReactorEpoll;
@@ -75,7 +75,7 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
     swReactorEpoll *reactor_object = sw_malloc(sizeof(swReactorEpoll));
     if (reactor_object == NULL)
     {
-        swWarn("malloc[0] failed.");
+        swWarn("malloc[0] failed");
         return SW_ERR;
     }
     bzero(reactor_object, sizeof(swReactorEpoll));
@@ -86,7 +86,7 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
 
     if (reactor_object->events == NULL)
     {
-        swWarn("malloc[1] failed.");
+        swWarn("malloc[1] failed");
         sw_free(reactor_object);
         return SW_ERR;
     }
@@ -132,7 +132,7 @@ static int swReactorEpoll_add(swReactor *reactor, int fd, int fdtype)
     memcpy(&(e.data.u64), &fd_, sizeof(fd_));
     if (epoll_ctl(object->epfd, EPOLL_CTL_ADD, fd, &e) < 0)
     {
-        swSysWarn("add events[fd=%d#%d, type=%d, events=%d] failed.", fd, reactor->id, fd_.fdtype, e.events);
+        swSysWarn("add events[fd=%d#%d, type=%d, events=%d] failed", fd, reactor->id, fd_.fdtype, e.events);
         swReactor_del(reactor, fd);
         return SW_ERR;
     }
@@ -148,7 +148,7 @@ static int swReactorEpoll_del(swReactor *reactor, int fd)
     swReactorEpoll *object = reactor->object;
     if (epoll_ctl(object->epfd, EPOLL_CTL_DEL, fd, NULL) < 0)
     {
-        swSysWarn("epoll remove fd[%d#%d] failed.", fd, reactor->id);
+        swSysWarn("epoll remove fd[%d#%d] failed", fd, reactor->id);
         return SW_ERR;
     }
 
@@ -181,7 +181,7 @@ static int swReactorEpoll_set(swReactor *reactor, int fd, int fdtype)
     ret = epoll_ctl(object->epfd, EPOLL_CTL_MOD, fd, &e);
     if (ret < 0)
     {
-        swSysWarn("reactor#%d->set(fd=%d|type=%d|events=%d) failed.", reactor->id, fd, fd_.fdtype, e.events);
+        swSysWarn("reactor#%d->set(fd=%d|type=%d|events=%d) failed", reactor->id, fd, fd_.fdtype, e.events);
         return SW_ERR;
     }
     swTraceLog(SW_TRACE_EVENT, "set event[reactor_id=%d, fd=%d, events=%d]", reactor->id, fd, swReactor_events(fdtype));
@@ -257,7 +257,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysWarn("EPOLLIN handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLIN handle failed. fd=%d", event.fd);
                 }
             }
             //write
@@ -267,7 +267,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysWarn("EPOLLOUT handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLOUT handle failed. fd=%d", event.fd);
                 }
             }
             //error
@@ -282,7 +282,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysWarn("EPOLLERR handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLERR handle failed. fd=%d", event.fd);
                 }
             }
             if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/epoll.c
+++ b/src/reactor/epoll.c
@@ -94,7 +94,7 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
     reactor_object->epfd = epoll_create(512);
     if (reactor_object->epfd < 0)
     {
-        swSysError("epoll_create failed");
+        swSysWarn("epoll_create failed");
         sw_free(reactor_object);
         return SW_ERR;
     }
@@ -132,7 +132,7 @@ static int swReactorEpoll_add(swReactor *reactor, int fd, int fdtype)
     memcpy(&(e.data.u64), &fd_, sizeof(fd_));
     if (epoll_ctl(object->epfd, EPOLL_CTL_ADD, fd, &e) < 0)
     {
-        swSysError("add events[fd=%d#%d, type=%d, events=%d] failed.", fd, reactor->id, fd_.fdtype, e.events);
+        swSysWarn("add events[fd=%d#%d, type=%d, events=%d] failed.", fd, reactor->id, fd_.fdtype, e.events);
         swReactor_del(reactor, fd);
         return SW_ERR;
     }
@@ -148,7 +148,7 @@ static int swReactorEpoll_del(swReactor *reactor, int fd)
     swReactorEpoll *object = reactor->object;
     if (epoll_ctl(object->epfd, EPOLL_CTL_DEL, fd, NULL) < 0)
     {
-        swSysError("epoll remove fd[%d#%d] failed.", fd, reactor->id);
+        swSysWarn("epoll remove fd[%d#%d] failed.", fd, reactor->id);
         return SW_ERR;
     }
 
@@ -181,7 +181,7 @@ static int swReactorEpoll_set(swReactor *reactor, int fd, int fdtype)
     ret = epoll_ctl(object->epfd, EPOLL_CTL_MOD, fd, &e);
     if (ret < 0)
     {
-        swSysError("reactor#%d->set(fd=%d|type=%d|events=%d) failed.", reactor->id, fd, fd_.fdtype, e.events);
+        swSysWarn("reactor#%d->set(fd=%d|type=%d|events=%d) failed.", reactor->id, fd, fd_.fdtype, e.events);
         return SW_ERR;
     }
     swTraceLog(SW_TRACE_EVENT, "set event[reactor_id=%d, fd=%d, events=%d]", reactor->id, fd, swReactor_events(fdtype));
@@ -227,7 +227,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swSysError("[Reactor#%d] epoll_wait failed", reactor_id);
+                swSysWarn("[Reactor#%d] epoll_wait failed", reactor_id);
                 return SW_ERR;
             }
             else
@@ -257,7 +257,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysError("EPOLLIN handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLIN handle failed. fd=%d.", event.fd);
                 }
             }
             //write
@@ -267,7 +267,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysError("EPOLLOUT handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLOUT handle failed. fd=%d.", event.fd);
                 }
             }
             //error
@@ -282,7 +282,7 @@ static int swReactorEpoll_wait(swReactor *reactor, struct timeval *timeo)
                 ret = handle(reactor, &event);
                 if (ret < 0)
                 {
-                    swSysError("EPOLLERR handle failed. fd=%d.", event.fd);
+                    swSysWarn("EPOLLERR handle failed. fd=%d.", event.fd);
                 }
             }
             if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/kqueue.c
+++ b/src/reactor/kqueue.c
@@ -130,7 +130,7 @@ static int swReactorKqueue_add(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("add events[fd=%d#%d, type=%d, events=read] failed.", fd, reactor->id, fd_.fdtype);
+            swSysWarn("add events[fd=%d#%d, type=%d, events=read] failed", fd, reactor->id, fd_.fdtype);
             swReactor_del(reactor, fd);
             return SW_ERR;
         }
@@ -143,7 +143,7 @@ static int swReactorKqueue_add(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("add events[fd=%d#%d, type=%d, events=write] failed.", fd, reactor->id, fd_.fdtype);
+            swSysWarn("add events[fd=%d#%d, type=%d, events=write] failed", fd, reactor->id, fd_.fdtype);
             swReactor_del(reactor, fd);
             return SW_ERR;
         }
@@ -176,7 +176,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->set(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->set(%d, SW_EVENT_READ) failed", fd);
             return SW_ERR;
         }
     }
@@ -187,7 +187,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed", fd);
             return SW_ERR;
         }
     }
@@ -199,7 +199,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->set(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->set(%d, SW_EVENT_WRITE) failed", fd);
             return SW_ERR;
         }
     }
@@ -210,7 +210,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed", fd);
             return SW_ERR;
         }
     }
@@ -234,7 +234,7 @@ static int swReactorKqueue_del(swReactor *reactor, int fd)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed", fd);
             return SW_ERR;
         }
     }
@@ -245,7 +245,7 @@ static int swReactorKqueue_del(swReactor *reactor, int fd)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed", fd);
             return SW_ERR;
         }
     }
@@ -329,7 +329,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
 
         for (i = 0; i < n; i++)
         {
-            swTraceLog(SW_TRACE_EVENT, "n %d events.", n);
+            swTraceLog(SW_TRACE_EVENT, "n %d events", n);
             if (object->events[i].udata)
             {
                 //read
@@ -344,7 +344,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysWarn("kqueue event read socket#%d handler failed.", event.fd);
+                        swSysWarn("kqueue event read socket#%d handler failed", event.fd);
                     }
                 }
                 //write
@@ -359,7 +359,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysWarn("kqueue event write socket#%d handler failed.", event.fd);
+                        swSysWarn("kqueue event write socket#%d handler failed", event.fd);
                     }
                 }
                 // signal
@@ -386,7 +386,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
                 }
                 else
                 {
-                    swWarn("unknown event filter[%d].", object->events[i].filter);
+                    swWarn("unknown event filter[%d]", object->events[i].filter);
                 }
                 if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))
                 {

--- a/src/reactor/kqueue.c
+++ b/src/reactor/kqueue.c
@@ -310,7 +310,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swWarn("kqueue[#%d].EP=%d | Error: %s[%d]", reactor->id, object->epfd, strerror(errno), errno);
+                swWarn("kqueue[#%d], epfd=%d", reactor->id, object->epfd);
                 return SW_ERR;
             }
             else

--- a/src/reactor/kqueue.c
+++ b/src/reactor/kqueue.c
@@ -130,7 +130,7 @@ static int swReactorKqueue_add(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("add events[fd=%d#%d, type=%d, events=read] failed.", fd, reactor->id, fd_.fdtype);
+            swSysWarn("add events[fd=%d#%d, type=%d, events=read] failed.", fd, reactor->id, fd_.fdtype);
             swReactor_del(reactor, fd);
             return SW_ERR;
         }
@@ -143,7 +143,7 @@ static int swReactorKqueue_add(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("add events[fd=%d#%d, type=%d, events=write] failed.", fd, reactor->id, fd_.fdtype);
+            swSysWarn("add events[fd=%d#%d, type=%d, events=write] failed.", fd, reactor->id, fd_.fdtype);
             swReactor_del(reactor, fd);
             return SW_ERR;
         }
@@ -176,7 +176,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->set(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->set(%d, SW_EVENT_READ) failed.", fd);
             return SW_ERR;
         }
     }
@@ -187,7 +187,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
             return SW_ERR;
         }
     }
@@ -199,7 +199,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->set(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->set(%d, SW_EVENT_WRITE) failed.", fd);
             return SW_ERR;
         }
     }
@@ -210,7 +210,7 @@ static int swReactorKqueue_set(swReactor *reactor, int fd, int fdtype)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
             return SW_ERR;
         }
     }
@@ -234,7 +234,7 @@ static int swReactorKqueue_del(swReactor *reactor, int fd)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_READ) failed.", fd);
             return SW_ERR;
         }
     }
@@ -245,7 +245,7 @@ static int swReactorKqueue_del(swReactor *reactor, int fd)
         ret = kevent(this->epfd, &e, 1, NULL, 0, NULL);
         if (ret < 0)
         {
-            swSysError("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
+            swSysWarn("kqueue->del(%d, SW_EVENT_WRITE) failed.", fd);
             return SW_ERR;
         }
     }
@@ -344,7 +344,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("kqueue event read socket#%d handler failed.", event.fd);
+                        swSysWarn("kqueue event read socket#%d handler failed.", event.fd);
                     }
                 }
                 //write
@@ -359,7 +359,7 @@ static int swReactorKqueue_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("kqueue event write socket#%d handler failed.", event.fd);
+                        swSysWarn("kqueue event write socket#%d handler failed.", event.fd);
                     }
                 }
                 // signal

--- a/src/reactor/poll.c
+++ b/src/reactor/poll.c
@@ -86,7 +86,7 @@ static int swReactorPoll_add(swReactor *reactor, int fd, int fdtype)
 {
     if (swReactorPoll_exist(reactor, fd))
     {
-        swWarn("fd#%d is already exists.", fd);
+        swWarn("fd#%d is already exists", fd);
         return SW_ERR;
     }
 

--- a/src/reactor/poll.c
+++ b/src/reactor/poll.c
@@ -219,7 +219,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swWarn("poll error. Error: %s[%d]", strerror(errno), errno);
+                swSysError("poll error");
             }
             continue;
         }
@@ -248,7 +248,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swWarn("poll[POLLIN] handler failed. fd=%d. Error: %s[%d]", event.fd, strerror(errno), errno);
+                        swSysError("poll[POLLIN] handler failed. fd=%d", event.fd);
                     }
                 }
                 //out
@@ -258,7 +258,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swWarn("poll[POLLOUT] handler failed. fd=%d. Error: %s[%d]", event.fd, strerror(errno), errno);
+                        swSysError("poll[POLLOUT] handler failed. fd=%d", event.fd);
                     }
                 }
                 //error
@@ -273,7 +273,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swWarn("poll[POLLERR] handler failed. fd=%d. Error: %s[%d]", event.fd, strerror(errno), errno);
+                        swSysError("poll[POLLERR] handler failed. fd=%d", event.fd);
                     }
                 }
                 if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/poll.c
+++ b/src/reactor/poll.c
@@ -219,7 +219,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swSysError("poll error");
+                swSysWarn("poll error");
             }
             continue;
         }
@@ -248,7 +248,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("poll[POLLIN] handler failed. fd=%d", event.fd);
+                        swSysWarn("poll[POLLIN] handler failed. fd=%d", event.fd);
                     }
                 }
                 //out
@@ -258,7 +258,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("poll[POLLOUT] handler failed. fd=%d", event.fd);
+                        swSysWarn("poll[POLLOUT] handler failed. fd=%d", event.fd);
                     }
                 }
                 //error
@@ -273,7 +273,7 @@ static int swReactorPoll_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("poll[POLLERR] handler failed. fd=%d", event.fd);
+                        swSysWarn("poll[POLLERR] handler failed. fd=%d", event.fd);
                     }
                 }
                 if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/select.c
+++ b/src/reactor/select.c
@@ -225,7 +225,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swSysError("select error");
+                swSysWarn("select error");
             }
             continue;
         }
@@ -253,7 +253,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("[Reactor#%d] select event[type=READ, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=READ, fd=%d] handler fail.", reactor->id, event.fd);
                     }
                 }
                 //write
@@ -263,7 +263,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("[Reactor#%d] select event[type=WRITE, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=WRITE, fd=%d] handler fail.", reactor->id, event.fd);
                     }
                 }
                 //error
@@ -273,7 +273,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysError("[Reactor#%d] select event[type=ERROR, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=ERROR, fd=%d] handler fail.", reactor->id, event.fd);
                     }
                 }
                 if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/select.c
+++ b/src/reactor/select.c
@@ -92,7 +92,7 @@ int swReactorSelect_add(swReactor *reactor, int fd, int fdtype)
     swFdList_node *ev = sw_malloc(sizeof(swFdList_node));
     if (ev == NULL)
     {
-        swWarn("malloc(%ld) failed.", sizeof(swFdList_node));
+        swWarn("malloc(%ld) failed", sizeof(swFdList_node));
         return SW_ERR;
     }
 
@@ -144,7 +144,7 @@ int swReactorSelect_set(swReactor *reactor, int fd, int fdtype)
     LL_SEARCH(object->fds, s_ev, &ev, swReactorSelect_cmp);
     if (s_ev == NULL)
     {
-        swWarn("swReactorSelect: sock[%d] not found.", fd);
+        swWarn("swReactorSelect: sock[%d] not found", fd);
         return SW_ERR;
     }
     s_ev->fdtype = fdtype;
@@ -253,7 +253,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysWarn("[Reactor#%d] select event[type=READ, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=READ, fd=%d] handler fail", reactor->id, event.fd);
                     }
                 }
                 //write
@@ -263,7 +263,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysWarn("[Reactor#%d] select event[type=WRITE, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=WRITE, fd=%d] handler fail", reactor->id, event.fd);
                     }
                 }
                 //error
@@ -273,7 +273,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
                     ret = handle(reactor, &event);
                     if (ret < 0)
                     {
-                        swSysWarn("[Reactor#%d] select event[type=ERROR, fd=%d] handler fail.", reactor->id, event.fd);
+                        swSysWarn("[Reactor#%d] select event[type=ERROR, fd=%d] handler fail", reactor->id, event.fd);
                     }
                 }
                 if (!event.socket->removed && (event.socket->events & SW_EVENT_ONCE))

--- a/src/reactor/select.c
+++ b/src/reactor/select.c
@@ -225,7 +225,7 @@ int swReactorSelect_wait(swReactor *reactor, struct timeval *timeo)
         {
             if (swReactor_error(reactor) < 0)
             {
-                swWarn("select error. Error: %s[%d]", strerror(errno), errno);
+                swSysError("select error");
             }
             continue;
         }

--- a/src/server/base.c
+++ b/src/server/base.c
@@ -59,13 +59,13 @@ static int swFactory_dispatch(swFactory *factory, swSendData *task)
         swConnection *conn = swServer_connection_get(serv, task->info.fd);
         if (conn == NULL || conn->active == 0)
         {
-            swWarn("dispatch[type=%d] failed, connection#%d is not active.", task->info.type, task->info.fd);
+            swWarn("dispatch[type=%d] failed, connection#%d is not active", task->info.type, task->info.fd);
             return SW_ERR;
         }
         //server active close, discard data.
         if (conn->closed)
         {
-            swWarn("dispatch[type=%d] failed, connection#%d is closed by server.", task->info.type,
+            swWarn("dispatch[type=%d] failed, connection#%d is closed by server", task->info.type,
                     task->info.fd);
             return SW_OK;
         }
@@ -100,13 +100,13 @@ static int swFactory_notify(swFactory *factory, swDataHead *info)
     swConnection *conn = swServer_connection_get(serv, info->fd);
     if (conn == NULL || conn->active == 0)
     {
-        swWarn("dispatch[type=%d] failed, connection#%d is not active.", info->type, info->fd);
+        swWarn("dispatch[type=%d] failed, connection#%d is not active", info->type, info->fd);
         return SW_ERR;
     }
     //server active close, discard data.
     if (conn->closed)
     {
-        swWarn("dispatch[type=%d] failed, connection#%d is closed by server.", info->type, info->fd);
+        swWarn("dispatch[type=%d] failed, connection#%d is closed by server", info->type, info->fd);
         return SW_OK;
     }
     //converted fd to session_id
@@ -130,7 +130,7 @@ static int swFactory_end(swFactory *factory, int fd)
     swConnection *conn = swWorker_get_connection(serv, fd);
     if (conn == NULL || conn->active == 0)
     {
-        //swWarn("can not close. Connection[%d] not found.", _send.info.fd);
+        //swWarn("can not close. Connection[%d] not found", _send.info.fd);
         return SW_ERR;
     }
     else if (conn->close_force)
@@ -139,7 +139,7 @@ static int swFactory_end(swFactory *factory, int fd)
     }
     else if (conn->closing)
     {
-        swWarn("The connection[%d] is closing.", fd);
+        swWarn("The connection[%d] is closing", fd);
         return SW_ERR;
     }
     else if (conn->closed)

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -68,12 +68,14 @@ static void swManager_kill_timeout_process(swTimer *timer, swTimer_node *tnode)
         }
         if (swKill(pid, SIGKILL) < 0)
         {
-            swSysWarn("swKill(%d, SIGKILL) [%d] failed.", pid, i);
+            swSysWarn("swKill(%d, SIGKILL) [%d] failed", pid, i);
         }
         else
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_WORKER_EXIT_TIMEOUT,
-                    "[Manager] Worker#%d[pid=%d] exit timeout, forced kill.", workers[i].id, pid);
+            swoole_error_log(
+                SW_LOG_WARNING, SW_ERROR_SERVER_WORKER_EXIT_TIMEOUT,
+                "[Manager] Worker#%d[pid=%d] exit timeout, forced kill", workers[i].id, pid
+            );
         }
     }
     errno = 0;
@@ -183,7 +185,7 @@ int swManager_start(swServer *serv)
             pid = swManager_spawn_worker(serv, i);
             if (pid < 0)
             {
-                swError("fork() failed.");
+                swError("fork() failed");
                 return SW_ERR;
             }
             else
@@ -220,7 +222,7 @@ int swManager_start(swServer *serv)
         serv->gs->manager_pid = pid;
         break;
     case -1:
-        swError("fork() failed.");
+        swError("fork() failed");
         return SW_ERR;
     }
     return SW_OK;
@@ -330,14 +332,14 @@ static int swManager_loop(swServer *serv)
             {
                 error: if (errno > 0 && errno != EINTR)
                 {
-                    swSysWarn("wait() failed.");
+                    swSysWarn("wait() failed");
                 }
                 continue;
             }
             //reload task & event workers
             else if (ManagerProcess.reload_all_worker == 1)
             {
-                swInfo("Server is reloading all workers now.");
+                swInfo("Server is reloading all workers now");
                 if (ManagerProcess.reload_init == 0)
                 {
                     ManagerProcess.reload_init = 1;
@@ -362,7 +364,7 @@ static int swManager_loop(swServer *serv)
                         {
                             if (swKill(ManagerProcess.reload_workers[i].pid, SIGTERM) < 0)
                             {
-                                swSysWarn("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[i].pid, i);
+                                swSysWarn("swKill(%d, SIGTERM) [%d] failed", ManagerProcess.reload_workers[i].pid, i);
                             }
                         }
                         ManagerProcess.reload_worker_i = serv->worker_num;
@@ -379,10 +381,10 @@ static int swManager_loop(swServer *serv)
             {
                 if (serv->task_worker_num == 0)
                 {
-                    swWarn("cannot reload task workers, task workers is not started.");
+                    swWarn("cannot reload task workers, task workers is not started");
                     continue;
                 }
-                swInfo("Server is reloading task workers now.");
+                swInfo("Server is reloading task workers now");
                 if (ManagerProcess.reload_init == 0)
                 {
                     memcpy(ManagerProcess.reload_workers, serv->gs->task_workers.workers, sizeof(swWorker) * serv->task_worker_num);
@@ -480,7 +482,7 @@ static int swManager_loop(swServer *serv)
                     ManagerProcess.reload_worker_i++;
                     goto kill_worker;
                 }
-                swSysWarn("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[ManagerProcess.reload_worker_i].pid, ManagerProcess.reload_worker_i);
+                swSysWarn("swKill(%d, SIGTERM) [%d] failed", ManagerProcess.reload_workers[ManagerProcess.reload_worker_i].pid, ManagerProcess.reload_worker_i);
             }
         }
     }
@@ -503,7 +505,7 @@ static int swManager_loop(swServer *serv)
     {
         if (swWaitpid(serv->workers[i].pid, &status, 0) < 0)
         {
-            swSysWarn("waitpid(%d) failed.", serv->workers[i].pid);
+            swSysWarn("waitpid(%d) failed", serv->workers[i].pid);
         }
     }
     //kill all user process
@@ -651,7 +653,7 @@ void swManager_kill_user_worker(swServer *serv)
         }
         if (swWaitpid(user_worker->pid, &__stat_loc, 0) < 0)
         {
-            swSysWarn("waitpid(%d) failed.", user_worker->pid);
+            swSysWarn("waitpid(%d) failed", user_worker->pid);
         }
     }
 }

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -530,7 +530,7 @@ static pid_t swManager_spawn_worker(swServer *serv, int worker_id)
     //fork() failed
     if (pid < 0)
     {
-        swWarn("Fork Worker failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("Fork Worker failed");
         return SW_ERR;
     }
     //worker child processor
@@ -667,7 +667,7 @@ pid_t swManager_spawn_user_worker(swServer *serv, swWorker* worker)
 
     if (pid < 0)
     {
-        swWarn("Fork Worker failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("Fork Worker failed");
         return SW_ERR;
     }
     //child

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -134,7 +134,7 @@ int swManager_start(swServer *serv)
         serv->user_workers = (swWorker *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, serv->user_worker_num * sizeof(swWorker));
         if (serv->user_workers == NULL)
         {
-            swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "gmalloc[server->user_workers] failed.");
+            swSysWarn("gmalloc[server->user_workers] failed");
             return SW_ERR;
         }
         swUserWorker_node *user_worker;

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -68,7 +68,7 @@ static void swManager_kill_timeout_process(swTimer *timer, swTimer_node *tnode)
         }
         if (swKill(pid, SIGKILL) < 0)
         {
-            swSysError("swKill(%d, SIGKILL) [%d] failed.", pid, i);
+            swSysWarn("swKill(%d, SIGKILL) [%d] failed.", pid, i);
         }
         else
         {
@@ -330,7 +330,7 @@ static int swManager_loop(swServer *serv)
             {
                 error: if (errno > 0 && errno != EINTR)
                 {
-                    swSysError("wait() failed.");
+                    swSysWarn("wait() failed.");
                 }
                 continue;
             }
@@ -362,7 +362,7 @@ static int swManager_loop(swServer *serv)
                         {
                             if (swKill(ManagerProcess.reload_workers[i].pid, SIGTERM) < 0)
                             {
-                                swSysError("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[i].pid, i);
+                                swSysWarn("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[i].pid, i);
                             }
                         }
                         ManagerProcess.reload_worker_i = serv->worker_num;
@@ -480,7 +480,7 @@ static int swManager_loop(swServer *serv)
                     ManagerProcess.reload_worker_i++;
                     goto kill_worker;
                 }
-                swSysError("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[ManagerProcess.reload_worker_i].pid, ManagerProcess.reload_worker_i);
+                swSysWarn("swKill(%d, SIGTERM) [%d] failed.", ManagerProcess.reload_workers[ManagerProcess.reload_worker_i].pid, ManagerProcess.reload_worker_i);
             }
         }
     }
@@ -503,7 +503,7 @@ static int swManager_loop(swServer *serv)
     {
         if (swWaitpid(serv->workers[i].pid, &status, 0) < 0)
         {
-            swSysError("waitpid(%d) failed.", serv->workers[i].pid);
+            swSysWarn("waitpid(%d) failed.", serv->workers[i].pid);
         }
     }
     //kill all user process
@@ -530,7 +530,7 @@ static pid_t swManager_spawn_worker(swServer *serv, int worker_id)
     //fork() failed
     if (pid < 0)
     {
-        swSysError("Fork Worker failed");
+        swSysWarn("Fork Worker failed");
         return SW_ERR;
     }
     //worker child processor
@@ -651,7 +651,7 @@ void swManager_kill_user_worker(swServer *serv)
         }
         if (swWaitpid(user_worker->pid, &__stat_loc, 0) < 0)
         {
-            swSysError("waitpid(%d) failed.", user_worker->pid);
+            swSysWarn("waitpid(%d) failed.", user_worker->pid);
         }
     }
 }
@@ -667,7 +667,7 @@ pid_t swManager_spawn_user_worker(swServer *serv, swWorker* worker)
 
     if (pid < 0)
     {
-        swSysError("Fork Worker failed");
+        swSysWarn("Fork Worker failed");
         return SW_ERR;
     }
     //child

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -113,7 +113,7 @@ int swServer_master_onAccept(swReactor *reactor, swEvent *event)
                     swServer_disable_accept(reactor);
                     reactor->disable_accept = 1;
                 }
-                swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "accept() failed. Error: %s[%d]", strerror(errno), errno);
+                swSysWarn("accept() failed");
                 return SW_OK;
             }
         }
@@ -574,7 +574,7 @@ int swServer_start(swServer *serv)
             }
             else
             {
-                swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "open(/dev/null) failed. Error: %s[%d]", strerror(errno), errno);
+                swSysWarn("open(/dev/null) failed");
             }
         }
 
@@ -601,7 +601,7 @@ int swServer_start(swServer *serv)
     serv->workers = (swWorker *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, serv->worker_num * sizeof(swWorker));
     if (serv->workers == NULL)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "gmalloc[server->workers] failed.");
+        swSysWarn("gmalloc[server->workers] failed");
         return SW_ERR;
     }
 

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -853,8 +853,7 @@ int swServer_udp_send(swServer *serv, swSendData *resp)
     int ret = swSocket_sendto_blocking(sock, resp->data, resp->info.len, 0, (struct sockaddr*) &addr_in, sizeof(addr_in));
     if (ret < 0)
     {
-        swWarn("sendto to client[%s:%d] failed. Error: %s [%d]", inet_ntoa(addr_in.sin_addr), resp->info.from_id,
-                strerror(errno), errno);
+        swSysError("sendto to client[%s:%d] failed", inet_ntoa(addr_in.sin_addr), resp->info.from_id);
     }
     return ret;
 }
@@ -1367,7 +1366,7 @@ static void swServer_master_update_time(swServer *serv)
     time_t now = time(NULL);
     if (now < 0)
     {
-        swWarn("get time failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("get time failed");
     }
     else
     {

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -449,7 +449,7 @@ int swServer_worker_init(swServer *serv, swWorker *worker)
         if (sched_setaffinity(getpid(), sizeof(cpu_set), &cpu_set) < 0)
 #endif
         {
-            swSysError("sched_setaffinity() failed.");
+            swSysWarn("sched_setaffinity() failed.");
         }
     }
 #endif
@@ -788,12 +788,12 @@ int swServer_free(swServer *serv)
         swTraceLog(SW_TRACE_SERVER, "terminate heartbeat thread.");
         if (pthread_cancel(serv->heartbeat_pidt) < 0)
         {
-            swSysError("pthread_cancel(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
+            swSysWarn("pthread_cancel(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
         }
         //wait thread
         if (pthread_join(serv->heartbeat_pidt, NULL) < 0)
         {
-            swSysError("pthread_join(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
+            swSysWarn("pthread_join(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
         }
     }
     if (serv->factory_mode == SW_MODE_BASE)
@@ -853,7 +853,7 @@ int swServer_udp_send(swServer *serv, swSendData *resp)
     int ret = swSocket_sendto_blocking(sock, resp->data, resp->info.len, 0, (struct sockaddr*) &addr_in, sizeof(addr_in));
     if (ret < 0)
     {
-        swSysError("sendto to client[%s:%d] failed", inet_ntoa(addr_in.sin_addr), resp->info.from_id);
+        swSysWarn("sendto to client[%s:%d] failed", inet_ntoa(addr_in.sin_addr), resp->info.from_id);
     }
     return ret;
 }
@@ -1366,7 +1366,7 @@ static void swServer_master_update_time(swServer *serv)
     time_t now = time(NULL);
     if (now < 0)
     {
-        swSysError("get time failed");
+        swSysWarn("get time failed");
     }
     else
     {
@@ -1606,7 +1606,7 @@ swListenPort* swServer_add_port(swServer *serv, int type, const char *host, int 
     int sock = swSocket_create(ls->type);
     if (sock < 0)
     {
-        swSysError("create socket failed.");
+        swSysWarn("create socket failed.");
         return NULL;
     }
     //bind address and port
@@ -1770,7 +1770,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
         int sockopt = 1;
         if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &sockopt, sizeof(sockopt)) != 0)
         {
-            swSysError("setsockopt(TCP_NODELAY) failed.");
+            swSysWarn("setsockopt(TCP_NODELAY) failed.");
         }
         connection->tcp_nodelay = 1;
     }
@@ -1780,7 +1780,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     {
         if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &ls->kernel_socket_recv_buffer_size, sizeof(int)) != 0)
         {
-            swSysError("setsockopt(SO_RCVBUF, %d) failed.", ls->kernel_socket_recv_buffer_size);
+            swSysWarn("setsockopt(SO_RCVBUF, %d) failed.", ls->kernel_socket_recv_buffer_size);
         }
     }
 
@@ -1789,7 +1789,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     {
         if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &ls->kernel_socket_send_buffer_size, sizeof(int)) != 0)
         {
-            swSysError("setsockopt(SO_SNDBUF, %d) failed.", ls->kernel_socket_send_buffer_size);
+            swSysWarn("setsockopt(SO_SNDBUF, %d) failed.", ls->kernel_socket_send_buffer_size);
         }
     }
 

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -123,7 +123,7 @@ int swServer_master_onAccept(swReactor *reactor, swEvent *event)
         //too many connection
         if (new_fd >= (int) serv->max_connection)
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_TOO_MANY_SOCKET, "Too many connections [now: %d].", new_fd);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_TOO_MANY_SOCKET, "Too many connections [now: %d]", new_fd);
             close(new_fd);
             return SW_OK;
         }
@@ -185,13 +185,13 @@ static int swServer_start_check(swServer *serv)
     //stream
     if (serv->have_stream_sock && serv->onReceive == NULL)
     {
-        swWarn("onReceive event callback must be set.");
+        swWarn("onReceive event callback must be set");
         return SW_ERR;
     }
     //dgram
     if (serv->have_dgram_sock && serv->onPacket == NULL)
     {
-        swWarn("onPacket event callback must be set.");
+        swWarn("onPacket event callback must be set");
         return SW_ERR;
     }
     //disable notice when use SW_DISPATCH_ROUND and SW_DISPATCH_QUEUE
@@ -212,7 +212,7 @@ static int swServer_start_check(swServer *serv)
     {
         if (serv->onTask == NULL)
         {
-            swWarn("onTask event callback must be set.");
+            swWarn("onTask event callback must be set");
             return SW_ERR;
         }
         if (serv->task_worker_num > SW_CPU_NUM * SW_MAX_WORKER_NCPU)
@@ -254,12 +254,12 @@ static int swServer_start_check(swServer *serv)
     else if (SwooleG.max_sockets > 0 && serv->max_connection > SwooleG.max_sockets)
     {
         serv->max_connection = SwooleG.max_sockets;
-        swWarn("serv->max_connection is exceed the maximum value, it's reset to %u.", SwooleG.max_sockets);
+        swWarn("serv->max_connection is exceed the maximum value, it's reset to %u", SwooleG.max_sockets);
     }
     else if (serv->max_connection > SW_SESSION_LIST_SIZE)
     {
         serv->max_connection = SW_SESSION_LIST_SIZE;
-        swWarn("serv->max_connection is exceed the SW_SESSION_LIST_SIZE, it's reset to %u.", SW_SESSION_LIST_SIZE);
+        swWarn("serv->max_connection is exceed the SW_SESSION_LIST_SIZE, it's reset to %u", SW_SESSION_LIST_SIZE);
     }
     // package max length
     swListenPort *ls;
@@ -347,7 +347,7 @@ swString** swServer_create_worker_buffer(swServer *serv)
     swString **buffers = (swString **) sw_malloc(sizeof(swString*) * buffer_num);
     if (buffers == NULL)
     {
-        swError("malloc for worker buffer_input failed.");
+        swError("malloc for worker buffer_input failed");
         return NULL;
     }
 
@@ -356,7 +356,7 @@ swString** swServer_create_worker_buffer(swServer *serv)
         buffers[i] = swString_new(SW_BUFFER_SIZE_BIG);
         if (buffers[i] == NULL)
         {
-            swError("worker buffer_input init failed.");
+            swError("worker buffer_input init failed");
             return NULL;
         }
     }
@@ -386,7 +386,7 @@ int swServer_create_task_worker(swServer *serv)
     swProcessPool *pool = &serv->gs->task_workers;
     if (swProcessPool_create(pool, serv->task_worker_num, serv->task_max_request, key, ipc_mode) < 0)
     {
-        swWarn("[Master] create task_workers failed.");
+        swWarn("[Master] create task_workers failed");
         return SW_ERR;
     }
 
@@ -416,7 +416,7 @@ int swServer_worker_create(swServer *serv, swWorker *worker)
     worker->send_shm = sw_shm_malloc(serv->buffer_output_size);
     if (worker->send_shm == NULL)
     {
-        swWarn("malloc for worker->store failed.");
+        swWarn("malloc for worker->store failed");
         return SW_ERR;
     }
     swMutex_create(&worker->lock, 1);
@@ -449,7 +449,7 @@ int swServer_worker_init(swServer *serv, swWorker *worker)
         if (sched_setaffinity(getpid(), sizeof(cpu_set), &cpu_set) < 0)
 #endif
         {
-            swSysWarn("sched_setaffinity() failed.");
+            swSysWarn("sched_setaffinity() failed");
         }
     }
 #endif
@@ -544,7 +544,7 @@ int swServer_start(swServer *serv)
     //cann't start 2 servers at the same time, please use process->exec.
     if (!sw_atomic_cmp_set(&serv->gs->start, 0, 1))
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_ONLY_START_ONE, "must only start one server.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_ONLY_START_ONE, "must only start one server");
         return SW_ERR;
     }
     //init loggger
@@ -726,12 +726,12 @@ void swServer_init(swServer *serv)
     serv->stats = (swServerStats *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swServerStats));
     if (serv->stats == NULL)
     {
-        swError("[Master] Fatal Error: failed to allocate memory for swServer->stats.");
+        swError("[Master] Fatal Error: failed to allocate memory for swServer->stats");
     }
     serv->gs = (swServerGS *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swServerGS));
     if (serv->gs == NULL)
     {
-        swError("[Master] Fatal Error: failed to allocate memory for swServer->gs.");
+        swError("[Master] Fatal Error: failed to allocate memory for swServer->gs");
     }
 
     SwooleG.serv = serv;
@@ -771,7 +771,7 @@ int swServer_shutdown(swServer *serv)
 
 int swServer_free(swServer *serv)
 {
-    swTraceLog(SW_TRACE_SERVER, "release service.");
+    swTraceLog(SW_TRACE_SERVER, "release service");
 
     /**
      * shutdown workers
@@ -785,20 +785,20 @@ int swServer_free(swServer *serv)
      */
     if (serv->heartbeat_pidt)
     {
-        swTraceLog(SW_TRACE_SERVER, "terminate heartbeat thread.");
+        swTraceLog(SW_TRACE_SERVER, "terminate heartbeat thread");
         if (pthread_cancel(serv->heartbeat_pidt) < 0)
         {
-            swSysWarn("pthread_cancel(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
+            swSysWarn("pthread_cancel(%ld) failed", (ulong_t )serv->heartbeat_pidt);
         }
         //wait thread
         if (pthread_join(serv->heartbeat_pidt, NULL) < 0)
         {
-            swSysWarn("pthread_join(%ld) failed.", (ulong_t )serv->heartbeat_pidt);
+            swSysWarn("pthread_join(%ld) failed", (ulong_t )serv->heartbeat_pidt);
         }
     }
     if (serv->factory_mode == SW_MODE_BASE)
     {
-        swTraceLog(SW_TRACE_SERVER, "terminate task workers.");
+        swTraceLog(SW_TRACE_SERVER, "terminate task workers");
         if (serv->task_worker_num > 0)
         {
             swProcessPool_shutdown(&serv->gs->task_workers);
@@ -806,7 +806,7 @@ int swServer_free(swServer *serv)
     }
     else if (!serv->single_thread)
     {
-        swTraceLog(SW_TRACE_SERVER, "terminate reactor threads.");
+        swTraceLog(SW_TRACE_SERVER, "terminate reactor threads");
         /**
          * Wait until all the end of the thread
          */
@@ -919,7 +919,7 @@ static int swServer_tcp_send(swServer *serv, int session_id, void *data, uint32_
 
     if (unlikely(swIsMaster()))
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER, "can't send data to the connections in master process.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER, "can't send data to the connections in master process");
         return SW_ERR;
     }
 
@@ -952,11 +952,11 @@ int swServer_master_send(swServer *serv, swSendData *_send)
     {
         if (_send->info.type == SW_EVENT_TCP)
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send %d byte failed, session#%d does not exist.", _send_length, session_id);
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send %d byte failed, session#%d does not exist", _send_length, session_id);
         }
         else
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send event$[%d] failed, session#%d does not exist.", _send->info.type, session_id);
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send event$[%d] failed, session#%d does not exist", _send->info.type, session_id);
         }
         return SW_ERR;
     }
@@ -983,7 +983,7 @@ int swServer_master_send(swServer *serv, swSendData *_send)
         }
         else
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "connection#%d output buffer overflow.", fd);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "connection#%d output buffer overflow", fd);
         }
         return SW_ERR;
     }
@@ -1110,7 +1110,7 @@ int swServer_master_send(swServer *serv, swSendData *_send)
         //connection is closed
         if (conn->removed)
         {
-            swWarn("connection#%d is closed by client.", fd);
+            swWarn("connection#%d is closed by client", fd);
             return SW_ERR;
         }
         //connection output buffer overflow
@@ -1122,7 +1122,7 @@ int swServer_master_send(swServer *serv, swSendData *_send)
             }
             else
             {
-                swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "connection#%d output buffer overflow.", fd);
+                swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "connection#%d output buffer overflow", fd);
             }
             conn->overflow = 1;
             if (serv->onBufferEmpty && serv->onBufferFull == NULL)
@@ -1184,13 +1184,13 @@ static int swServer_tcp_sendfile(swServer *serv, int session_id, char *filename,
 {
     if (unlikely(session_id <= 0 || session_id > SW_MAX_SESSION_ID))
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SESSION_INVALID_ID, "invalid fd[%d].", session_id);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SESSION_INVALID_ID, "invalid fd[%d]", session_id);
         return SW_ERR;
     }
 
     if (unlikely(swIsMaster()))
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER, "can't send data to the connections in master process.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER, "can't send data to the connections in master process");
         return SW_ERR;
     }
 
@@ -1201,7 +1201,7 @@ static int swServer_tcp_sendfile(swServer *serv, int session_id, char *filename,
     if (unlikely(filename_length > SW_IPC_BUFFER_SIZE - sizeof(swSendFile_request) - 1))
     {
         swoole_error_log(
-            SW_LOG_WARNING, SW_ERROR_NAME_TOO_LONG, "sendfile name[%.8s...] length %u is exceed the max name len %u.",
+            SW_LOG_WARNING, SW_ERROR_NAME_TOO_LONG, "sendfile name[%.8s...] length %u is exceed the max name len %u",
             filename, filename_length, (uint32_t) (SW_IPC_BUFFER_SIZE - sizeof(swSendFile_request) - 1)
         );
         return SW_ERR;
@@ -1213,12 +1213,12 @@ static int swServer_tcp_sendfile(swServer *serv, int session_id, char *filename,
     struct stat file_stat;
     if (stat(filename, &file_stat) < 0)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "stat(%s) failed.", filename);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "stat(%s) failed", filename);
         return SW_ERR;
     }
     if (file_stat.st_size <= offset)
     {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "file[offset=%ld] is empty.", (long) offset);
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SYSTEM_CALL_FAIL, "file[offset=%ld] is empty", (long) offset);
         return SW_ERR;
     }
     req->offset = offset;
@@ -1242,7 +1242,7 @@ static int swServer_tcp_sendwait(swServer *serv, int session_id, void *data, uin
     swConnection *conn = swServer_connection_verify(serv, session_id);
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "send %d byte failed, because session#%d is closed.", length, session_id);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "send %d byte failed, because session#%d is closed", length, session_id);
         return SW_ERR;
     }
     return swSocket_write_blocking(conn->fd, data, length);
@@ -1269,8 +1269,7 @@ static int swServer_tcp_close(swServer *serv, int session_id, int reset)
 {
     if (unlikely(swIsMaster()))
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER,
-                "can't close the connections in master process.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_SEND_IN_MASTER, "can't close the connections in master process");
         return SW_ERR;
     }
     swConnection *conn = swServer_connection_verify_no_ssl(serv, session_id);
@@ -1285,7 +1284,7 @@ static int swServer_tcp_close(swServer *serv, int session_id, int reset)
     }
     //server is initiative to close the connection
     conn->close_actively = 1;
-    swTraceLog(SW_TRACE_CLOSE, "session_id=%d, fd=%d.", session_id, conn->session_id);
+    swTraceLog(SW_TRACE_CLOSE, "session_id=%d, fd=%d", session_id, conn->session_id);
 
     int ret;
     if (!swIsWorker())
@@ -1332,7 +1331,7 @@ void swServer_master_onTimer(swTimer *timer, swTimer_node *tnode)
     {
         serv->scheduler_warning = 0;
         serv->warning_time = serv->gs->now;
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_NO_IDLE_WORKER, "No idle worker is available.");
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_NO_IDLE_WORKER, "No idle worker is available");
     }
 
     if (serv->hooks[SW_SERVER_HOOK_MASTER_TIMER])
@@ -1408,7 +1407,7 @@ int swServer_add_systemd_socket(swServer *serv)
     int pid = atoi(e);
     if (getpid() != pid)
     {
-        swWarn("invalid LISTEN_PID.");
+        swWarn("invalid LISTEN_PID");
         return 0;
     }
 
@@ -1420,12 +1419,12 @@ int swServer_add_systemd_socket(swServer *serv)
     int n = atoi(e);
     if (n < 1)
     {
-        swWarn("invalid LISTEN_FDS.");
+        swWarn("invalid LISTEN_FDS");
         return 0;
     }
     else if (n >= SW_MAX_LISTEN_PORT)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_TOO_MANY_LISTEN_PORT, "LISTEN_FDS is too big.");
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_SERVER_TOO_MANY_LISTEN_PORT, "LISTEN_FDS is too big");
         return 0;
     }
 
@@ -1441,26 +1440,26 @@ int swServer_add_systemd_socket(swServer *serv)
         swListenPort *ls = (swListenPort *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swListenPort));
         if (ls == NULL)
         {
-            swWarn("alloc failed.");
+            swWarn("alloc failed");
             return count;
         }
         //get socket type
         optlen = sizeof(val);
         if (getsockopt(sock, SOL_SOCKET, SO_TYPE, &val, &optlen) < 0)
         {
-            swWarn("getsockopt(%d, SOL_SOCKET, SO_TYPE) failed.", sock);
+            swWarn("getsockopt(%d, SOL_SOCKET, SO_TYPE) failed", sock);
             return count;
         }
         sock_type = val;
         //get socket family
 #ifndef SO_DOMAIN
-        swWarn("no getsockopt(SO_DOMAIN) supports.");
+        swWarn("no getsockopt(SO_DOMAIN) supports");
         return count;
 #else
         optlen = sizeof(val);
         if (getsockopt(sock, SOL_SOCKET, SO_DOMAIN, &val, &optlen) < 0)
         {
-            swWarn("getsockopt(%d, SOL_SOCKET, SO_DOMAIN) failed.", sock);
+            swWarn("getsockopt(%d, SOL_SOCKET, SO_DOMAIN) failed", sock);
             return count;
         }
 #endif
@@ -1469,7 +1468,7 @@ int swServer_add_systemd_socket(swServer *serv)
         address.len = sizeof(address.addr);
         if (getsockname(sock, (struct sockaddr*) &address.addr, &address.len) < 0)
         {
-            swWarn("getsockname(%d) failed.", sock);
+            swWarn("getsockname(%d) failed", sock);
             return count;
         }
 
@@ -1513,7 +1512,7 @@ int swServer_add_systemd_socket(swServer *serv)
             strncpy(ls->host, address.addr.un.sun_path, SW_HOST_MAXSIZE);
             break;
         default:
-            swWarn("Unknown socket type[%d].", sock_type);
+            swWarn("Unknown socket type[%d]", sock_type);
             break;
         }
 
@@ -1606,7 +1605,7 @@ swListenPort* swServer_add_port(swServer *serv, int type, const char *host, int 
     int sock = swSocket_create(ls->type);
     if (sock < 0)
     {
-        swSysWarn("create socket failed.");
+        swSysWarn("create socket failed");
         return NULL;
     }
     //bind address and port
@@ -1662,7 +1661,7 @@ int swServer_get_socket(swServer *serv, int port)
 
 static void swServer_signal_handler(int sig)
 {
-    swTraceLog(SW_TRACE_SERVER, "signal[%d] triggered.", sig);
+    swTraceLog(SW_TRACE_SERVER, "signal[%d] triggered", sig);
 
     swServer *serv = SwooleG.serv;
     int status;
@@ -1678,7 +1677,7 @@ static void swServer_signal_handler(int sig)
         {
             SwooleG.running = 0;
         }
-        swInfo("Server is shutdown now.");
+        swInfo("Server is shutdown now");
         break;
     case SIGALRM:
         swSystemTimer_signal_handler(SIGALRM);
@@ -1695,7 +1694,7 @@ static void swServer_signal_handler(int sig)
         pid = waitpid(-1, &status, WNOHANG);
         if (pid > 0 && pid == serv->gs->manager_pid)
         {
-            swWarn("Fatal Error: manager process exit. status=%d, signal=[%s].", WEXITSTATUS(status), swSignal_str(WTERMSIG(status)));
+            swWarn("Fatal Error: manager process exit. status=%d, signal=[%s]", WEXITSTATUS(status), swSignal_str(WTERMSIG(status)));
         }
         break;
         /**
@@ -1770,7 +1769,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
         int sockopt = 1;
         if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &sockopt, sizeof(sockopt)) != 0)
         {
-            swSysWarn("setsockopt(TCP_NODELAY) failed.");
+            swSysWarn("setsockopt(TCP_NODELAY) failed");
         }
         connection->tcp_nodelay = 1;
     }
@@ -1780,7 +1779,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     {
         if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &ls->kernel_socket_recv_buffer_size, sizeof(int)) != 0)
         {
-            swSysWarn("setsockopt(SO_RCVBUF, %d) failed.", ls->kernel_socket_recv_buffer_size);
+            swSysWarn("setsockopt(SO_RCVBUF, %d) failed", ls->kernel_socket_recv_buffer_size);
         }
     }
 
@@ -1789,7 +1788,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     {
         if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &ls->kernel_socket_send_buffer_size, sizeof(int)) != 0)
         {
-            swSysWarn("setsockopt(SO_SNDBUF, %d) failed.", ls->kernel_socket_send_buffer_size);
+            swSysWarn("setsockopt(SO_SNDBUF, %d) failed", ls->kernel_socket_send_buffer_size);
         }
     }
 

--- a/src/server/port.c
+++ b/src/server/port.c
@@ -58,20 +58,20 @@ int swPort_enable_ssl_encrypt(swListenPort *ls)
 {
     if (ls->ssl_option.cert_file == NULL || ls->ssl_option.key_file == NULL)
     {
-        swWarn("SSL error, require ssl_cert_file and ssl_key_file.");
+        swWarn("SSL error, require ssl_cert_file and ssl_key_file");
         return SW_ERR;
     }
     ls->ssl_context = swSSL_get_context(&ls->ssl_option);
     if (ls->ssl_context == NULL)
     {
-        swWarn("swSSL_get_context() error.");
+        swWarn("swSSL_get_context() error");
         return SW_ERR;
     }
     if (ls->ssl_option.client_cert_file
             && swSSL_set_client_certificate(ls->ssl_context, ls->ssl_option.client_cert_file,
                     ls->ssl_option.verify_depth) == SW_ERR)
     {
-        swWarn("swSSL_set_client_certificate() error.");
+        swWarn("swSSL_set_client_certificate() error");
         return SW_ERR;
     }
     if (ls->open_http_protocol)
@@ -85,7 +85,7 @@ int swPort_enable_ssl_encrypt(swListenPort *ls)
     }
     if (swSSL_server_set_cipher(ls->ssl_context, &ls->ssl_config) < 0)
     {
-        swWarn("swSSL_server_set_cipher() error.");
+        swWarn("swSSL_server_set_cipher() error");
         return SW_ERR;
     }
     return SW_OK;
@@ -109,7 +109,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, (const void*) &ls->tcp_defer_accept, sizeof(int)) != 0)
         {
-            swSysWarn("setsockopt(TCP_DEFER_ACCEPT) failed.");
+            swSysWarn("setsockopt(TCP_DEFER_ACCEPT) failed");
         }
     }
 #endif
@@ -119,7 +119,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, IPPROTO_TCP, TCP_FASTOPEN, (const void*) &ls->tcp_fastopen, sizeof(int)) != 0)
         {
-            swSysWarn("setsockopt(TCP_FASTOPEN) failed.");
+            swSysWarn("setsockopt(TCP_FASTOPEN) failed");
         }
     }
 #endif
@@ -129,7 +129,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, (void *) &option, sizeof(option)) != 0)
         {
-            swSysWarn("setsockopt(SO_KEEPALIVE) failed.");
+            swSysWarn("setsockopt(SO_KEEPALIVE) failed");
         }
 #ifdef TCP_KEEPIDLE
         setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, (void*) &ls->tcp_keepidle, sizeof(int));
@@ -235,7 +235,7 @@ static int swPort_onRead_raw(swReactor *reactor, swListenPort *port, swEvent *ev
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("recv from connection#%d failed.", event->fd);
+            swSysWarn("recv from connection#%d failed", event->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -345,7 +345,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("recv from connection#%d failed.", event->fd);
+            swSysWarn("recv from connection#%d failed", event->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -372,7 +372,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
             {
                 return SW_OK;
             }
-            swoole_error_log(SW_LOG_TRACE, SW_ERROR_HTTP_INVALID_PROTOCOL, "get protocol failed.");
+            swoole_error_log(SW_LOG_TRACE, SW_ERROR_HTTP_INVALID_PROTOCOL, "get protocol failed");
 #ifdef SW_USE_HTTP2
             _bad_request:
 #endif
@@ -420,7 +420,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
             {
                 if (buffer->size == buffer->length)
                 {
-                    swWarn("[2]http header is too long.");
+                    swWarn("[2]http header is too long");
                     goto close_fd;
                 }
                 else
@@ -464,7 +464,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
                 }
                 else if (buffer->size == buffer->length)
                 {
-                    swWarn("[0]http header is too long.");
+                    swWarn("[0]http header is too long");
                     goto close_fd;
                 }
                 /* wait more data */
@@ -475,7 +475,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
             }
             else if (request->content_length > (protocol->package_max_length - request->header_length))
             {
-                swWarn("Content-Length is too big, MaxSize=[%d].", protocol->package_max_length - request->header_length);
+                swWarn("Content-Length is too big, MaxSize=[%d]", protocol->package_max_length - request->header_length);
                 goto close_fd;
             }
         }

--- a/src/server/port.c
+++ b/src/server/port.c
@@ -100,7 +100,7 @@ int swPort_listen(swListenPort *ls)
     //listen stream socket
     if (listen(sock, ls->backlog) < 0)
     {
-        swSysError("listen(%s:%d, %d) failed", ls->host, ls->port, ls->backlog);
+        swSysWarn("listen(%s:%d, %d) failed", ls->host, ls->port, ls->backlog);
         return SW_ERR;
     }
 
@@ -109,7 +109,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, IPPROTO_TCP, TCP_DEFER_ACCEPT, (const void*) &ls->tcp_defer_accept, sizeof(int)) != 0)
         {
-            swSysError("setsockopt(TCP_DEFER_ACCEPT) failed.");
+            swSysWarn("setsockopt(TCP_DEFER_ACCEPT) failed.");
         }
     }
 #endif
@@ -119,7 +119,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, IPPROTO_TCP, TCP_FASTOPEN, (const void*) &ls->tcp_fastopen, sizeof(int)) != 0)
         {
-            swSysError("setsockopt(TCP_FASTOPEN) failed.");
+            swSysWarn("setsockopt(TCP_FASTOPEN) failed.");
         }
     }
 #endif
@@ -129,7 +129,7 @@ int swPort_listen(swListenPort *ls)
     {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, (void *) &option, sizeof(option)) != 0)
         {
-            swSysError("setsockopt(SO_KEEPALIVE) failed.");
+            swSysWarn("setsockopt(SO_KEEPALIVE) failed.");
         }
 #ifdef TCP_KEEPIDLE
         setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, (void*) &ls->tcp_keepidle, sizeof(int));
@@ -235,7 +235,7 @@ static int swPort_onRead_raw(swReactor *reactor, swListenPort *port, swEvent *ev
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("recv from connection#%d failed.", event->fd);
+            swSysWarn("recv from connection#%d failed.", event->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -345,7 +345,7 @@ static int swPort_onRead_http(swReactor *reactor, swListenPort *port, swEvent *e
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("recv from connection#%d failed.", event->fd);
+            swSysWarn("recv from connection#%d failed.", event->fd);
             return SW_OK;
         case SW_CLOSE:
             conn->close_errno = errno;
@@ -791,7 +791,7 @@ static int swPort_http_static_handler(swServer *serv, swHttpRequest *request, sw
     {
         if (swSocket_tcp_nopush(conn->fd, 1) == -1)
         {
-            swSysError("swSocket_tcp_nopush() failed");
+            swSysWarn("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 1;
     }

--- a/src/server/port.c
+++ b/src/server/port.c
@@ -100,7 +100,7 @@ int swPort_listen(swListenPort *ls)
     //listen stream socket
     if (listen(sock, ls->backlog) < 0)
     {
-        swWarn("listen(%s:%d, %d) failed. Error: %s[%d]", ls->host, ls->port, ls->backlog, strerror(errno), errno);
+        swSysError("listen(%s:%d, %d) failed", ls->host, ls->port, ls->backlog);
         return SW_ERR;
     }
 
@@ -791,7 +791,7 @@ static int swPort_http_static_handler(swServer *serv, swHttpRequest *request, sw
     {
         if (swSocket_tcp_nopush(conn->fd, 1) == -1)
         {
-            swWarn("swSocket_tcp_nopush() failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("swSocket_tcp_nopush() failed");
         }
         conn->tcp_nopush = 1;
     }

--- a/src/server/process.c
+++ b/src/server/process.c
@@ -137,7 +137,7 @@ static int swFactoryProcess_start(swFactory *factory)
     object->pipes = (swPipe *) sw_calloc(serv->worker_num, sizeof(swPipe));
     if (object->pipes == NULL)
     {
-        swError("malloc[pipes] failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("malloc[pipes] failed");
         return SW_ERR;
     }
 
@@ -172,7 +172,7 @@ static int swFactoryProcess_start(swFactory *factory)
     object->buffers = sw_calloc(serv->reactor_num, sizeof(swSendBuffer *));
     if (object->buffers == NULL)
     {
-        swError("malloc[buffers] failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("malloc[buffers] failed");
         return SW_ERR;
     }
     for (i = 0; i < serv->reactor_num; i++)
@@ -180,7 +180,7 @@ static int swFactoryProcess_start(swFactory *factory)
         object->buffers[i] = sw_malloc(serv->ipc_max_size);
         if (object->buffers[i] == NULL)
         {
-            swError("malloc[sndbuf][%d] failed. Error: %s [%d]", i, strerror(errno), errno);
+            swSysError("malloc[sndbuf][%d] failed", i);
             return SW_ERR;
         }
     }

--- a/src/server/process.c
+++ b/src/server/process.c
@@ -62,12 +62,12 @@ static int swFactoryProcess_shutdown(swFactory *factory)
 
     if (swKill(serv->gs->manager_pid, SIGTERM) < 0)
     {
-        swSysWarn("swKill(%d) failed.", serv->gs->manager_pid);
+        swSysWarn("swKill(%d) failed", serv->gs->manager_pid);
     }
 
     if (swWaitpid(serv->gs->manager_pid, &status, 0) < 0)
     {
-        swSysWarn("waitpid(%d) failed.", serv->gs->manager_pid);
+        swSysWarn("waitpid(%d) failed", serv->gs->manager_pid);
     }
 
     return SW_OK;
@@ -189,7 +189,7 @@ static int swFactoryProcess_start(swFactory *factory)
      */
     if (swManager_start(serv) < 0)
     {
-        swWarn("swFactoryProcess_manager_start failed.");
+        swWarn("swFactoryProcess_manager_start failed");
         return SW_ERR;
     }
     factory->finish = swFactory_finish;
@@ -233,7 +233,7 @@ static int swFactoryProcess_dispatch(swFactory *factory, swSendData *task)
         swConnection *conn = swServer_connection_get(serv, fd);
         if (conn == NULL || conn->active == 0)
         {
-            swWarn("dispatch[type=%d] failed, connection#%d is not active.", task->info.type, fd);
+            swWarn("dispatch[type=%d] failed, connection#%d is not active", task->info.type, fd);
             return SW_ERR;
         }
         //server active close, discard data.
@@ -336,7 +336,7 @@ static int swFactoryProcess_finish(swFactory *factory, swSendData *resp)
         swoole_error_log(
             SW_LOG_WARNING, SW_ERROR_DATA_LENGTH_TOO_LARGE,
             "The length of data [%u] exceeds the output buffer size[%u], "
-            "please use the sendfile, chunked transfer mode or adjust the buffer_output_size.",
+            "please use the sendfile, chunked transfer mode or adjust the buffer_output_size",
             resp->info.len, serv->buffer_output_size
         );
         return SW_ERR;
@@ -354,13 +354,13 @@ static int swFactoryProcess_finish(swFactory *factory, swSendData *resp)
     }
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[fd=%d] does not exists.", session_id);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[fd=%d] does not exists", session_id);
         return SW_ERR;
     }
     else if ((conn->closed || conn->removed) && resp->info.type != SW_EVENT_CLOSE)
     {
         swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED,
-                "send %d byte failed, because connection[fd=%d] is closed.", resp->info.len, session_id);
+                "send %d byte failed, because connection[fd=%d] is closed", resp->info.len, session_id);
         return SW_ERR;
     }
     else if (conn->overflow)
@@ -371,7 +371,7 @@ static int swFactoryProcess_finish(swFactory *factory, swSendData *resp)
         }
         else
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "send failed, connection[fd=%d] output buffer has been overflowed.", session_id);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "send failed, connection[fd=%d] output buffer has been overflowed", session_id);
         }
         return SW_ERR;
     }
@@ -487,7 +487,7 @@ static int swFactoryProcess_end(swFactory *factory, int fd)
     }
     else if (conn->closing)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSING, "The connection[%d] is closing.", fd);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSING, "The connection[%d] is closing", fd);
         return SW_ERR;
     }
     else if (conn->closed)

--- a/src/server/process.c
+++ b/src/server/process.c
@@ -62,12 +62,12 @@ static int swFactoryProcess_shutdown(swFactory *factory)
 
     if (swKill(serv->gs->manager_pid, SIGTERM) < 0)
     {
-        swSysError("swKill(%d) failed.", serv->gs->manager_pid);
+        swSysWarn("swKill(%d) failed.", serv->gs->manager_pid);
     }
 
     if (swWaitpid(serv->gs->manager_pid, &status, 0) < 0)
     {
-        swSysError("waitpid(%d) failed.", serv->gs->manager_pid);
+        swSysWarn("waitpid(%d) failed.", serv->gs->manager_pid);
     }
 
     return SW_OK;
@@ -459,7 +459,7 @@ static int swFactoryProcess_finish(swFactory *factory, swSendData *resp)
     ret = swWorker_send2reactor(serv, &ev_data, sendn, session_id);
     if (ret < 0)
     {
-        swSysError("sendto to reactor failed");
+        swSysWarn("sendto to reactor failed");
     }
     return ret;
 }

--- a/src/server/process.c
+++ b/src/server/process.c
@@ -459,7 +459,7 @@ static int swFactoryProcess_finish(swFactory *factory, swSendData *resp)
     ret = swWorker_send2reactor(serv, &ev_data, sendn, session_id);
     if (ret < 0)
     {
-        swWarn("sendto to reactor failed. Error: %s [%d]", strerror(errno), errno);
+        swSysError("sendto to reactor failed");
     }
     return ret;
 }

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -40,13 +40,13 @@ int swReactorProcess_create(swServer *serv)
     serv->connection_list = (swConnection *) sw_calloc(serv->max_connection, sizeof(swConnection));
     if (serv->connection_list == NULL)
     {
-        swSysWarn("calloc[2](%d) failed.", (int )(serv->max_connection * sizeof(swConnection)));
+        swSysWarn("calloc[2](%d) failed", (int )(serv->max_connection * sizeof(swConnection)));
         return SW_ERR;
     }
     //create factry object
     if (swFactory_create(&(serv->factory)) < 0)
     {
-        swError("create factory failed.");
+        swError("create factory failed");
         return SW_ERR;
     }
     serv->factory.finish = swReactorProcess_send2client;
@@ -71,7 +71,7 @@ int swReactorProcess_start(swServer *serv)
             {
                 if (close(ls->sock) < 0)
                 {
-                    swSysWarn("close(%d) failed.", ls->sock);
+                    swSysWarn("close(%d) failed", ls->sock);
                 }
                 continue;
             }
@@ -178,7 +178,7 @@ int swReactorProcess_start(swServer *serv)
 
     if (serv->onStart)
     {
-        swWarn("The onStart event with SWOOLE_BASE is deprecated.");
+        swWarn("The onStart event with SWOOLE_BASE is deprecated");
         serv->onStart(serv);
     }
 
@@ -251,7 +251,7 @@ static int swReactorProcess_alloc_output_buffer(int n_buffer)
     SwooleWG.buffer_output = (swString **) sw_malloc(sizeof(swString*) * n_buffer);
     if (SwooleWG.buffer_output == NULL)
     {
-        swError("malloc for SwooleWG.buffer_output failed.");
+        swError("malloc for SwooleWG.buffer_output failed");
         return SW_ERR;
     }
 
@@ -261,7 +261,7 @@ static int swReactorProcess_alloc_output_buffer(int n_buffer)
         SwooleWG.buffer_output[i] = swString_new(SW_BUFFER_SIZE_BIG);
         if (SwooleWG.buffer_output[i] == NULL)
         {
-            swError("buffer_output init failed.");
+            swError("buffer_output init failed");
             return SW_ERR;
         }
     }
@@ -516,7 +516,7 @@ static int swReactorProcess_send2client(swFactory *factory, swSendData *_send)
     swSession *session = swServer_get_session(serv, session_id);
     if (session->fd == 0)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send %d byte failed, session#%d does not exist.",
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "send %d byte failed, session#%d does not exist",
                 _send->info.len, session_id);
         return SW_ERR;
     }
@@ -562,7 +562,7 @@ static int swReactorProcess_send2client(swFactory *factory, swSendData *_send)
         }
         else
         {
-            swWarn("unkown event type[%d].", _send->info.type);
+            swWarn("unkown event type[%d]", _send->info.type);
             return SW_ERR;
         }
         return SW_OK;
@@ -629,7 +629,7 @@ static int swReactorProcess_reuse_port(swListenPort *ls)
     int sock = swSocket_create(ls->type);
     if (sock < 0)
     {
-        swSysWarn("create socket failed.");
+        swSysWarn("create socket failed");
         return SW_ERR;
     }
     //bind address and port

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -145,7 +145,7 @@ int swReactorProcess_start(swServer *serv)
         serv->user_workers = (swWorker *) sw_malloc(serv->user_worker_num * sizeof(swWorker));
         if (serv->user_workers == NULL)
         {
-            swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "gmalloc[server->user_workers] failed.");
+            swSysWarn("gmalloc[server->user_workers] failed");
             return SW_ERR;
         }
         swUserWorker_node *user_worker;

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -40,7 +40,7 @@ int swReactorProcess_create(swServer *serv)
     serv->connection_list = (swConnection *) sw_calloc(serv->max_connection, sizeof(swConnection));
     if (serv->connection_list == NULL)
     {
-        swSysError("calloc[2](%d) failed.", (int )(serv->max_connection * sizeof(swConnection)));
+        swSysWarn("calloc[2](%d) failed.", (int )(serv->max_connection * sizeof(swConnection)));
         return SW_ERR;
     }
     //create factry object
@@ -71,7 +71,7 @@ int swReactorProcess_start(swServer *serv)
             {
                 if (close(ls->sock) < 0)
                 {
-                    swSysError("close(%d) failed.", ls->sock);
+                    swSysWarn("close(%d) failed.", ls->sock);
                 }
                 continue;
             }
@@ -629,7 +629,7 @@ static int swReactorProcess_reuse_port(swListenPort *ls)
     int sock = swSocket_create(ls->type);
     if (sock < 0)
     {
-        swSysError("create socket failed.");
+        swSysWarn("create socket failed.");
         return SW_ERR;
     }
     //bind address and port

--- a/src/server/reactor_thread.c
+++ b/src/server/reactor_thread.c
@@ -165,7 +165,7 @@ static int swReactorThread_onPackage(swReactor *reactor, swEvent *event)
         }
         else
         {
-            swSysError("recvfrom(%d) failed.", fd);
+            swSysWarn("recvfrom(%d) failed.", fd);
             return ret;
         }
     }
@@ -261,7 +261,7 @@ int swReactorThread_close(swReactor *reactor, int fd)
         linger.l_linger = 0;
         if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof(struct linger)) != 0)
         {
-            swSysError("setsockopt(SO_LINGER) failed");
+            swSysWarn("setsockopt(SO_LINGER) failed");
         }
     }
 #endif
@@ -418,7 +418,7 @@ static int swReactorThread_onPipeReceive(swReactor *reactor, swEvent *ev)
         }
         else
         {
-            swSysError("read(worker_pipe) failed");
+            swSysWarn("read(worker_pipe) failed");
             return SW_ERR;
         }
     }
@@ -449,7 +449,7 @@ int swReactorThread_send2worker(swServer *serv, swWorker *worker, void *data, in
             {
                 if (thread->reactor.set(&thread->reactor, pipe_fd, SW_FD_PIPE | SW_EVENT_READ | SW_EVENT_WRITE) < 0)
                 {
-                    swSysError("reactor->set(%d, PIPE | READ | WRITE) failed.", pipe_fd);
+                    swSysWarn("reactor->set(%d, PIPE | READ | WRITE) failed.", pipe_fd);
                 }
                 goto append_pipe_buffer;
             }
@@ -550,7 +550,7 @@ static int swReactorThread_onPipeWrite(swReactor *reactor, swEvent *ev)
         }
         if (ret < 0)
         {
-            swSysError("reactor->set(%d) failed.", ev->fd);
+            swSysWarn("reactor->set(%d) failed.", ev->fd);
         }
     }
 
@@ -1088,7 +1088,7 @@ static int swReactorThread_loop(swThreadParam *param)
 
         if (0 != pthread_setaffinity_np(pthread_self(), sizeof(cpu_set), &cpu_set))
         {
-            swSysError("pthread_setaffinity_np() failed.");
+            swSysWarn("pthread_setaffinity_np() failed.");
         }
     }
 #endif
@@ -1203,13 +1203,13 @@ void swReactorThread_free(swServer *serv)
         {
             cancel: if (pthread_cancel(thread->thread_id) < 0)
             {
-                swSysError("pthread_cancel(%ld) failed.", (long ) thread->thread_id);
+                swSysWarn("pthread_cancel(%ld) failed.", (long ) thread->thread_id);
             }
         }
         //wait thread
         if (pthread_join(thread->thread_id, NULL) != 0)
         {
-            swSysError("pthread_join(%ld) failed.", (long ) thread->thread_id);
+            swSysWarn("pthread_join(%ld) failed.", (long ) thread->thread_id);
         }
     }
 }

--- a/src/server/reactor_thread.c
+++ b/src/server/reactor_thread.c
@@ -883,7 +883,7 @@ int swReactorThread_start(swServer *serv)
 
         if (pthread_create(&pidt, NULL, (void * (*)(void *)) swReactorThread_loop, (void *) param) < 0)
         {
-            swError("pthread_create[tcp_reactor] failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("pthread_create[tcp_reactor] failed");
         }
         thread->thread_id = pidt;
     }

--- a/src/server/reactor_thread.c
+++ b/src/server/reactor_thread.c
@@ -106,7 +106,7 @@ static void swReactorThread_onStreamResponse(swStream *stream, char *data, uint3
     swConnection *conn = swServer_connection_verify(SwooleG.serv, pkg_info->fd);
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[fd=%d] does not exists.", pkg_info->fd);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[fd=%d] does not exists", pkg_info->fd);
         return;
     }
     response.info.fd = conn->session_id;
@@ -165,7 +165,7 @@ static int swReactorThread_onPackage(swReactor *reactor, swEvent *event)
         }
         else
         {
-            swSysWarn("recvfrom(%d) failed.", fd);
+            swSysWarn("recvfrom(%d) failed", fd);
             return ret;
         }
     }
@@ -306,7 +306,7 @@ static int swReactorThread_onClose(swReactor *reactor, swEvent *event)
     notify_ev.fd = fd;
     notify_ev.type = SW_EVENT_CLOSE;
 
-    swTraceLog(SW_TRACE_CLOSE, "client[fd=%d] close the connection.", fd);
+    swTraceLog(SW_TRACE_CLOSE, "client[fd=%d] close the connection", fd);
 
     swConnection *conn = swServer_connection_get(serv, fd);
     if (conn == NULL || conn->active == 0)
@@ -449,7 +449,7 @@ int swReactorThread_send2worker(swServer *serv, swWorker *worker, void *data, in
             {
                 if (thread->reactor.set(&thread->reactor, pipe_fd, SW_FD_PIPE | SW_EVENT_READ | SW_EVENT_WRITE) < 0)
                 {
-                    swSysWarn("reactor->set(%d, PIPE | READ | WRITE) failed.", pipe_fd);
+                    swSysWarn("reactor->set(%d, PIPE | READ | WRITE) failed", pipe_fd);
                 }
                 goto append_pipe_buffer;
             }
@@ -459,7 +459,7 @@ int swReactorThread_send2worker(swServer *serv, swWorker *worker, void *data, in
             append_pipe_buffer:
             if (swBuffer_append(buffer, data, len) < 0)
             {
-                swWarn("append to pipe_buffer failed.");
+                swWarn("append to pipe_buffer failed");
                 ret = SW_ERR;
             }
             else
@@ -511,7 +511,7 @@ static int swReactorThread_onPipeWrite(swReactor *reactor, swEvent *ev)
             {
                 if (conn->closed)
                 {
-                    swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED_BY_SERVER, "Session#%d is closed by server.", send_data->info.fd);
+                    swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED_BY_SERVER, "Session#%d is closed by server", send_data->info.fd);
                     _discard: swBuffer_pop_chunk(buffer, chunk);
                     continue;
                 }
@@ -550,7 +550,7 @@ static int swReactorThread_onPipeWrite(swReactor *reactor, swEvent *ev)
         }
         if (ret < 0)
         {
-            swSysWarn("reactor->set(%d) failed.", ev->fd);
+            swSysWarn("reactor->set(%d) failed", ev->fd);
         }
     }
 
@@ -1009,7 +1009,7 @@ int swReactorThread_init_reactor(swServer *serv, swReactor *reactor, uint16_t re
         swBuffer *buffer = swBuffer_new(sizeof(swEventData));
         if (!buffer)
         {
-            swWarn("create buffer failed.");
+            swWarn("create buffer failed");
             return SW_ERR;
         }
         serv->connection_list[pipe_fd].in_buffer = buffer;
@@ -1038,7 +1038,7 @@ int swReactorThread_init_reactor(swServer *serv, swReactor *reactor, uint16_t re
          */
         if (serv->connection_list[pipe_fd].object == NULL)
         {
-            swWarn("create pipe mutex lock failed.");
+            swWarn("create pipe mutex lock failed");
             return SW_ERR;
         }
         swMutex_create(serv->connection_list[pipe_fd].object, 0);
@@ -1088,7 +1088,7 @@ static int swReactorThread_loop(swThreadParam *param)
 
         if (0 != pthread_setaffinity_np(pthread_self(), sizeof(cpu_set), &cpu_set))
         {
-            swSysWarn("pthread_setaffinity_np() failed.");
+            swSysWarn("pthread_setaffinity_np() failed");
         }
     }
 #endif
@@ -1141,7 +1141,7 @@ int swReactorThread_dispatch(swConnection *conn, char *data, uint32_t length)
     task.info.info.time = conn->last_time_usec;
 #endif
 
-    swTrace("send string package, size=%ld bytes.", (long)length);
+    swTrace("send string package, size=%ld bytes", (long)length);
 
     if (serv->stream_socket)
     {
@@ -1203,13 +1203,13 @@ void swReactorThread_free(swServer *serv)
         {
             cancel: if (pthread_cancel(thread->thread_id) < 0)
             {
-                swSysWarn("pthread_cancel(%ld) failed.", (long ) thread->thread_id);
+                swSysWarn("pthread_cancel(%ld) failed", (long ) thread->thread_id);
             }
         }
         //wait thread
         if (pthread_join(thread->thread_id, NULL) != 0)
         {
-            swSysWarn("pthread_join(%ld) failed.", (long ) thread->thread_id);
+            swSysWarn("pthread_join(%ld) failed", (long ) thread->thread_id);
         }
     }
 }

--- a/src/server/reactor_thread.c
+++ b/src/server/reactor_thread.c
@@ -261,7 +261,7 @@ int swReactorThread_close(swReactor *reactor, int fd)
         linger.l_linger = 0;
         if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger, sizeof(struct linger)) != 0)
         {
-            swWarn("setsockopt(SO_LINGER) failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("setsockopt(SO_LINGER) failed");
         }
     }
 #endif
@@ -418,7 +418,7 @@ static int swReactorThread_onPipeReceive(swReactor *reactor, swEvent *ev)
         }
         else
         {
-            swWarn("read(worker_pipe) failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("read(worker_pipe) failed");
             return SW_ERR;
         }
     }

--- a/src/server/task_worker.c
+++ b/src/server/task_worker.c
@@ -426,7 +426,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
     }
     if (ret < 0)
     {
-        swWarn("TaskWorker: send result to worker failed. Error: %s[%d]", strerror(errno), errno);
+        swSysError("TaskWorker: send result to worker failed");
     }
     return ret;
 }

--- a/src/server/task_worker.c
+++ b/src/server/task_worker.c
@@ -98,7 +98,7 @@ int swTaskWorker_large_pack(swEventData *task, void *data, int data_len)
     //write to file
     if (swoole_sync_writefile(tmp_fd, data, data_len) != data_len)
     {
-        swWarn("write to tmpfile failed.");
+        swWarn("write to tmpfile failed");
         return SW_ERR;
     }
 
@@ -148,11 +148,11 @@ void swTaskWorker_onStart(swProcessPool *pool, int worker_id)
         SwooleG.main_reactor = sw_malloc(sizeof(swReactor));
         if (SwooleG.main_reactor == NULL)
         {
-            swError("[TaskWorker] malloc for reactor failed.");
+            swError("[TaskWorker] malloc for reactor failed");
         }
         if (swReactor_create(SwooleG.main_reactor, SW_REACTOR_MAXEVENTS) < 0)
         {
-            swError("[TaskWorker] create reactor failed.");
+            swError("[TaskWorker] create reactor failed");
         }
         SwooleG.enable_signalfd = 1;
     }
@@ -218,7 +218,7 @@ static int swTaskWorker_onPipeReceive(swReactor *reactor, swEvent *event)
     }
     else
     {
-        swSysWarn("read(%d, %ld) failed.", event->fd, sizeof(task));
+        swSysWarn("read(%d, %ld) failed", event->fd, sizeof(task));
         return SW_ERR;
     }
 }
@@ -266,7 +266,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
     bzero(&buf.info, sizeof(buf.info));
     if (serv->task_worker_num < 1)
     {
-        swWarn("cannot use task/finish, because no set serv->task_worker_num.");
+        swWarn("cannot use task/finish, because no set serv->task_worker_num");
         return SW_ERR;
     }
     if (current_task == NULL)
@@ -275,12 +275,12 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
     }
     if (current_task->info.type == SW_EVENT_PIPE_MESSAGE)
     {
-        swWarn("task/finish is not supported in onPipeMessage callback.");
+        swWarn("task/finish is not supported in onPipeMessage callback");
         return SW_ERR;
     }
     if (swTask_type(current_task) & SW_TASK_NOREPLY)
     {
-        swWarn("task->finish() can only be used in the worker process.");
+        swWarn("task->finish() can only be used in the worker process");
         return SW_ERR;
     }
 
@@ -289,7 +289,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
 
     if (worker == NULL)
     {
-        swWarn("invalid worker_id[%d].", source_worker_id);
+        swWarn("invalid worker_id[%d]", source_worker_id);
         return SW_ERR;
     }
 
@@ -379,7 +379,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
                 //write to tmpfile
                 if (swoole_sync_writefile(fd, &buf, sizeof(buf.info) + buf.info.len) != sizeof(buf.info) + buf.info.len)
                 {
-                    swSysWarn("write(%s, %ld) failed.", _tmpfile, sizeof(buf.info) + buf.info.len);
+                    swSysWarn("write(%s, %ld) failed", _tmpfile, sizeof(buf.info) + buf.info.len);
                 }
                 sw_atomic_fetch_add(finish_count, 1);
                 close(fd);

--- a/src/server/task_worker.c
+++ b/src/server/task_worker.c
@@ -218,7 +218,7 @@ static int swTaskWorker_onPipeReceive(swReactor *reactor, swEvent *event)
     }
     else
     {
-        swSysError("read(%d, %ld) failed.", event->fd, sizeof(task));
+        swSysWarn("read(%d, %ld) failed.", event->fd, sizeof(task));
         return SW_ERR;
     }
 }
@@ -379,7 +379,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
                 //write to tmpfile
                 if (swoole_sync_writefile(fd, &buf, sizeof(buf.info) + buf.info.len) != sizeof(buf.info) + buf.info.len)
                 {
-                    swSysError("write(%s, %ld) failed.", _tmpfile, sizeof(buf.info) + buf.info.len);
+                    swSysWarn("write(%s, %ld) failed.", _tmpfile, sizeof(buf.info) + buf.info.len);
                 }
                 sw_atomic_fetch_add(finish_count, 1);
                 close(fd);
@@ -426,7 +426,7 @@ int swTaskWorker_finish(swServer *serv, char *data, int data_len, int flags, swE
     }
     if (ret < 0)
     {
-        swSysError("TaskWorker: send result to worker failed");
+        swSysWarn("TaskWorker: send result to worker failed");
     }
     return ret;
 }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -148,8 +148,7 @@ static int swWorker_onStreamAccept(swReactor *reactor, swEvent *event)
         case EAGAIN:
             return SW_OK;
         default:
-            swoole_error_log(SW_LOG_ERROR, SW_ERROR_SYSTEM_CALL_FAIL, "accept() failed. Error: %s[%d]", strerror(errno),
-                    errno);
+            swSysWarn("accept() failed");
             return SW_OK;
         }
     }

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -411,7 +411,7 @@ void swWorker_onStart(swServer *serv)
             group = getgrnam(SwooleG.group);
             if (!group)
             {
-                swWarn("get group [%s] info failed.", SwooleG.group);
+                swWarn("get group [%s] info failed", SwooleG.group);
             }
         }
         //get user info
@@ -420,7 +420,7 @@ void swWorker_onStart(swServer *serv)
             passwd = getpwnam(SwooleG.user);
             if (!passwd)
             {
-                swWarn("get user [%s] info failed.", SwooleG.user);
+                swWarn("get user [%s] info failed", SwooleG.user);
             }
         }
         //chroot
@@ -428,7 +428,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (0 > chroot(SwooleG.chroot))
             {
-                swSysWarn("chroot to [%s] failed.", SwooleG.chroot);
+                swSysWarn("chroot to [%s] failed", SwooleG.chroot);
             }
         }
         //set process group
@@ -436,7 +436,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (setgid(group->gr_gid) < 0)
             {
-                swSysWarn("setgid to [%s] failed.", SwooleG.group);
+                swSysWarn("setgid to [%s] failed", SwooleG.group);
             }
         }
         //set process user
@@ -444,7 +444,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (setuid(passwd->pw_uid) < 0)
             {
-                swSysWarn("setuid to [%s] failed.", SwooleG.user);
+                swSysWarn("setuid to [%s] failed", SwooleG.user);
             }
         }
     }
@@ -577,7 +577,7 @@ static void swWorker_onTimeout(swTimer *timer, swTimer_node *tnode)
     SwooleG.running = 0;
     SwooleG.main_reactor->running = 0;
     SwooleWG.exit_timer = nullptr;
-    swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_WORKER_EXIT_TIMEOUT, "worker exit timeout, forced to terminate.");
+    swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_WORKER_EXIT_TIMEOUT, "worker exit timeout, forced to terminate");
 }
 
 void swWorker_try_to_exit()
@@ -674,13 +674,13 @@ int swWorker_loop(swServer *serv, int worker_id)
     SwooleG.main_reactor = (swReactor *) sw_malloc(sizeof(swReactor));
     if (SwooleG.main_reactor == NULL)
     {
-        swError("[Worker] malloc for reactor failed.");
+        swError("[Worker] malloc for reactor failed");
         return SW_ERR;
     }
 
     if (swReactor_create(SwooleG.main_reactor, SW_REACTOR_MAXEVENTS) < 0)
     {
-        swError("[Worker] create worker_reactor failed.");
+        swError("[Worker] create worker_reactor failed");
         return SW_ERR;
     }
 

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -429,7 +429,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (0 > chroot(SwooleG.chroot))
             {
-                swSysError("chroot to [%s] failed.", SwooleG.chroot);
+                swSysWarn("chroot to [%s] failed.", SwooleG.chroot);
             }
         }
         //set process group
@@ -437,7 +437,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (setgid(group->gr_gid) < 0)
             {
-                swSysError("setgid to [%s] failed.", SwooleG.group);
+                swSysWarn("setgid to [%s] failed.", SwooleG.group);
             }
         }
         //set process user
@@ -445,7 +445,7 @@ void swWorker_onStart(swServer *serv)
         {
             if (setuid(passwd->pw_uid) < 0)
             {
-                swSysError("setuid to [%s] failed.", SwooleG.user);
+                swSysWarn("setuid to [%s] failed.", SwooleG.user);
             }
         }
     }

--- a/src/wrapper/client.cc
+++ b/src/wrapper/client.cc
@@ -55,7 +55,7 @@ void check_reactor(void)
 
     if (swIsTaskWorker())
     {
-        swWarn("cannot use async-io in task process.");
+        swWarn("cannot use async-io in task process");
     }
 
     if (SwooleG.main_reactor == NULL)
@@ -65,11 +65,11 @@ void check_reactor(void)
         SwooleG.main_reactor = (swReactor *) malloc(sizeof(swReactor));
         if (SwooleG.main_reactor == NULL)
         {
-            swWarn("malloc failed.");
+            swWarn("malloc failed");
         }
         if (swReactor_create(SwooleG.main_reactor, SW_REACTOR_MAXEVENTS) < 0)
         {
-            swWarn("create reactor failed.");
+            swWarn("create reactor failed");
         }
         //client, swoole_event_exit will set swoole_running = 0
         SwooleWG.in_client = 1;

--- a/src/wrapper/client.cc
+++ b/src/wrapper/client.cc
@@ -40,7 +40,7 @@ void event_wait(void)
         int ret = SwooleG.main_reactor->wait(SwooleG.main_reactor, NULL);
         if (ret < 0)
         {
-            swWarn("reactor wait failed. Error: %s [%d]", strerror(errno), errno);
+            swSysError("reactor wait failed");
         }
     }
 }

--- a/src/wrapper/client.cc
+++ b/src/wrapper/client.cc
@@ -40,7 +40,7 @@ void event_wait(void)
         int ret = SwooleG.main_reactor->wait(SwooleG.main_reactor, NULL);
         if (ret < 0)
         {
-            swSysError("reactor wait failed");
+            swSysWarn("reactor wait failed");
         }
     }
 }

--- a/src/wrapper/server.cc
+++ b/src/wrapper/server.cc
@@ -212,17 +212,17 @@ int Server::check_task_param(int dst_worker_id)
 {
     if (SwooleG.serv->task_worker_num < 1)
     {
-        swWarn("Task method cannot use, Please set task_worker_num.");
+        swWarn("Task method cannot use, Please set task_worker_num");
         return SW_ERR;
     }
     if (dst_worker_id >= SwooleG.serv->task_worker_num)
     {
-        swWarn("worker_id must be less than serv->task_worker_num.");
+        swWarn("worker_id must be less than serv->task_worker_num");
         return SW_ERR;
     }
     if (!swIsWorker())
     {
-        swWarn("The method can only be used in the worker process.");
+        swWarn("The method can only be used in the worker process");
         return SW_ERR;
     }
     return SW_OK;
@@ -232,7 +232,7 @@ int Server::task(DataBuffer &data, int dst_worker_id)
 {
     if (serv.gs->start == 0)
     {
-        swWarn("Server is not running.");
+        swWarn("Server is not running");
         return false;
     }
 
@@ -264,7 +264,7 @@ bool Server::finish(DataBuffer &data)
 {
     if (serv.gs->start == 0)
     {
-        swWarn("Server is not running.");
+        swWarn("Server is not running");
         return false;
     }
     return swTaskWorker_finish(&serv, (char *) data.buffer, (int) data.length, 0, nullptr) == 0;
@@ -292,7 +292,7 @@ bool Server::sendto(const string &ip, int port, const DataBuffer &data, int serv
     }
     else if (serv.udp_socket_ipv4 <= 0)
     {
-        swWarn("You must add an UDP listener to server before using sendto.");
+        swWarn("You must add an UDP listener to server before using sendto");
         return false;
     }
 
@@ -317,19 +317,19 @@ bool Server::sendfile(int fd, string &file, off_t offset, size_t length)
 {
     if (serv.gs->start == 0)
     {
-        swWarn("Server is not running.");
+        swWarn("Server is not running");
         return false;
     }
 
     struct stat file_stat;
     if (stat(file.c_str(), &file_stat) < 0)
     {
-        swWarn("stat(%s) failed.", file.c_str());
+        swWarn("stat(%s) failed", file.c_str());
         return false;
     }
     if (file_stat.st_size <= offset)
     {
-        swWarn("file[offset=%jd] is empty.", (intmax_t) offset);
+        swWarn("file[offset=%jd] is empty", (intmax_t) offset);
         return false;
     }
     return serv.sendfile(&serv, fd, (char *) file.c_str(), file.length(), offset, length) == SW_OK;
@@ -341,25 +341,25 @@ bool Server::sendMessage(int worker_id, DataBuffer &data)
 
     if (serv.gs->start == 0)
     {
-        swWarn("Server is not running.");
+        swWarn("Server is not running");
         return false;
     }
 
     if (worker_id == (int) SwooleWG.id)
     {
-        swWarn("cannot send message to self.");
+        swWarn("cannot send message to self");
         return false;
     }
 
     if (worker_id >= serv.worker_num + serv.task_worker_num)
     {
-        swWarn("worker_id[%d] is invalid.", worker_id);
+        swWarn("worker_id[%d] is invalid", worker_id);
         return false;
     }
 
     if (serv.onPipeMessage == NULL)
     {
-        swWarn("onPipeMessage is null, cannot use sendMessage.");
+        swWarn("onPipeMessage is null, cannot use sendMessage");
         return false;
     }
 
@@ -380,7 +380,7 @@ bool Server::sendwait(int fd, const DataBuffer &data)
 {
     if (serv.gs->start == 0)
     {
-        swWarn("Server is not running.");
+        swWarn("Server is not running");
         return false;
     }
     if (data.length <= 0)
@@ -389,7 +389,7 @@ bool Server::sendwait(int fd, const DataBuffer &data)
     }
     if (serv.factory_mode != SW_MODE_BASE || swIsTaskWorker())
     {
-        swWarn("cannot sendwait.");
+        swWarn("cannot sendwait");
         return false;
     }
     return serv.sendwait(&serv, fd, data.buffer, data.length) == 0;
@@ -572,7 +572,7 @@ DataBuffer Server::taskwait(const DataBuffer &data, double timeout, int dst_work
 
     if (serv.gs->start == 0)
     {
-        swWarn("server is not running.");
+        swWarn("server is not running");
         return retval;
     }
 
@@ -617,7 +617,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
 
     if (serv.gs->start == 0)
     {
-        swWarn("server is not running.");
+        swWarn("server is not running");
         return retval;
     }
 
@@ -638,7 +638,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
     int _tmpfile_fd = swoole_tmpfile(_tmpfile);
     if (_tmpfile_fd < 0)
     {
-        swSysWarn("mktemp(%s) failed.", SW_TASK_TMP_FILE);
+        swSysWarn("mktemp(%s) failed", SW_TASK_TMP_FILE);
         return retval;
     }
 
@@ -660,7 +660,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
         task_id = task_pack(&buf, *task);
         if (task_id < 0)
         {
-            swWarn("task pack failed.");
+            swWarn("task pack failed");
             goto fail;
         }
         swTask_type(&buf) |= SW_TASK_WAITALL;
@@ -692,7 +692,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
         }
         else
         {
-            swSysWarn("taskwait failed.");
+            swSysWarn("taskwait failed");
             unlink(_tmpfile);
             return retval;
         }

--- a/src/wrapper/server.cc
+++ b/src/wrapper/server.cc
@@ -604,7 +604,7 @@ DataBuffer Server::taskwait(const DataBuffer &data, double timeout, int dst_work
         }
         else
         {
-            swSysError("taskwait failed");
+            swSysWarn("taskwait failed");
         }
     }
     return retval;
@@ -638,7 +638,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
     int _tmpfile_fd = swoole_tmpfile(_tmpfile);
     if (_tmpfile_fd < 0)
     {
-        swSysError("mktemp(%s) failed.", SW_TASK_TMP_FILE);
+        swSysWarn("mktemp(%s) failed.", SW_TASK_TMP_FILE);
         return retval;
     }
 
@@ -672,7 +672,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
         }
         else
         {
-            swSysError("taskwait failed");
+            swSysWarn("taskwait failed");
             fail: retval[i] = DataBuffer();
             n_task--;
         }
@@ -692,7 +692,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
         }
         else
         {
-            swSysError("taskwait failed.");
+            swSysWarn("taskwait failed.");
             unlink(_tmpfile);
             return retval;
         }

--- a/src/wrapper/server.cc
+++ b/src/wrapper/server.cc
@@ -604,7 +604,7 @@ DataBuffer Server::taskwait(const DataBuffer &data, double timeout, int dst_work
         }
         else
         {
-            swWarn("taskwait failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("taskwait failed");
         }
     }
     return retval;
@@ -672,7 +672,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
         }
         else
         {
-            swWarn("taskwait failed. Error: %s[%d]", strerror(errno), errno);
+            swSysError("taskwait failed");
             fail: retval[i] = DataBuffer();
             n_task--;
         }

--- a/src/wrapper/timer.cc
+++ b/src/wrapper/timer.cc
@@ -32,7 +32,7 @@ long swoole_timer_add(long ms, uchar persistent, swTimerCallback callback, void 
     swTimer_node *tnode = swTimer_add(&SwooleG.timer, ms, persistent, private_data, callback);
     if (tnode == nullptr)
     {
-        swWarn("addtimer failed.");
+        swWarn("addtimer failed");
         return SW_ERR;
     }
     else

--- a/swoole.c
+++ b/swoole.c
@@ -1167,7 +1167,7 @@ PHP_FUNCTION(swoole_get_local_ip)
 
     if (getifaddrs(&ipaddrs) != 0)
     {
-        php_error_docref(NULL, E_WARNING, "getifaddrs() failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "getifaddrs() failed");
         RETURN_FALSE;
     }
     array_init(return_value);
@@ -1220,7 +1220,7 @@ PHP_FUNCTION(swoole_get_local_mac)
 
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
     {
-        php_error_docref(NULL, E_WARNING, "new socket failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "new socket failed");
         RETURN_FALSE;
     }
     array_init(return_value);

--- a/swoole.c
+++ b/swoole.c
@@ -306,7 +306,7 @@ ssize_t php_swoole_length_func(swProtocol *protocol, swConnection *conn, char *d
 
     if (sw_call_user_function_ex(EG(function_table), NULL, callback, &retval, 1, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "length function handler error.");
+        swoole_php_fatal_error(E_WARNING, "length function handler error");
         goto error;
     }
     zval_ptr_dtor(&args[0]);
@@ -347,14 +347,14 @@ int php_swoole_dispatch_func(swServer *serv, swConnection *conn, swSendData *dat
     }
     if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, zdata ? 4 : 3, args) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "dispatch function handler error.");
+        swoole_php_fatal_error(E_WARNING, "dispatch function handler error");
     }
     else if (!ZVAL_IS_NULL(retval))
     {
         worker_id = (int) zval_get_long(retval);
         if (worker_id >= serv->worker_num)
         {
-            swoole_php_fatal_error(E_WARNING, "invalid target worker-id[%d].", worker_id);
+            swoole_php_fatal_error(E_WARNING, "invalid target worker-id[%d]", worker_id);
             worker_id = -1;
         }
         zval_ptr_dtor(retval);
@@ -401,7 +401,7 @@ void swoole_set_object_by_handle(uint32_t handle, void *ptr)
         new_ptr = sw_realloc(old_ptr, sizeof(void*) * new_size);
         if (!new_ptr)
         {
-            swoole_php_fatal_error(E_ERROR, "malloc(%d) failed.", (int )(new_size * sizeof(void *)));
+            swoole_php_fatal_error(E_ERROR, "malloc(%d) failed", (int )(new_size * sizeof(void *)));
             return;
         }
         bzero(new_ptr + (old_size * sizeof(void*)), (new_size - old_size) * sizeof(void*));
@@ -442,7 +442,7 @@ void swoole_set_property_by_handle(uint32_t handle, int property_id, void *ptr)
         }
         if (new_ptr == NULL)
         {
-            swoole_php_fatal_error(E_ERROR, "malloc(%d) failed.", (int )(new_size * sizeof(void *)));
+            swoole_php_fatal_error(E_ERROR, "malloc(%d) failed", (int )(new_size * sizeof(void *)));
             return;
         }
         if (old_size > 0)
@@ -1007,8 +1007,10 @@ PHP_RSHUTDOWN_FUNCTION(swoole)
             case E_CORE_ERROR:
             case E_USER_ERROR:
             case E_COMPILE_ERROR:
-                swoole_error_log(SW_LOG_ERROR, SW_ERROR_PHP_FATAL_ERROR, "Fatal error: %s in %s on line %d.",
-                        PG(last_error_message), PG(last_error_file)?PG(last_error_file):"-", PG(last_error_lineno));
+                swoole_error_log(
+                    SW_LOG_ERROR, SW_ERROR_PHP_FATAL_ERROR, "Fatal error: %s in %s on line %d",
+                    PG(last_error_message), PG(last_error_file)?PG(last_error_file):"-", PG(last_error_lineno)
+                );
                 break;
             default:
                 break;
@@ -1016,7 +1018,7 @@ PHP_RSHUTDOWN_FUNCTION(swoole)
         }
         else
         {
-            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SERVER_WORKER_TERMINATED, "worker process is terminated by exit()/die().");
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SERVER_WORKER_TERMINATED, "worker process is terminated by exit()/die()");
         }
     }
 
@@ -1143,13 +1145,13 @@ PHP_FUNCTION(swoole_set_process_name)
 {
 #ifdef __MACH__
     // MacOS doesn't support 'cli_set_process_title'
-    swoole_php_fatal_error(E_WARNING, "swoole_set_process_name is not supported on MacOS.");
+    swoole_php_fatal_error(E_WARNING, "swoole_set_process_name is not supported on MacOS");
     RETURN_FALSE;
 #else
     zend_function *cli_set_process_title =  zend_hash_str_find_ptr(EG(function_table), ZEND_STRL("cli_set_process_title"));
     if (!cli_set_process_title)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_set_process_name only support in CLI mode.");
+        swoole_php_fatal_error(E_WARNING, "swoole_set_process_name only support in CLI mode");
         RETURN_FALSE;
     }
     cli_set_process_title->internal_function.handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -1191,7 +1193,7 @@ PHP_FUNCTION(swoole_get_local_ip)
         }
         if (!inet_ntop(ifa->ifa_addr->sa_family, in_addr, ip, sizeof(ip)))
         {
-            php_error_docref(NULL, E_WARNING, "%s: inet_ntop failed.", ifa->ifa_name);
+            php_error_docref(NULL, E_WARNING, "%s: inet_ntop failed", ifa->ifa_name);
         }
         else
         {
@@ -1246,7 +1248,7 @@ PHP_FUNCTION(swoole_get_local_mac)
     }
     close(sock);
 #else
-    php_error_docref(NULL, E_WARNING, "swoole_get_local_mac is not supported.");
+    php_error_docref(NULL, E_WARNING, "swoole_get_local_mac is not supported");
     RETURN_FALSE;
 #endif
 }
@@ -1261,7 +1263,7 @@ PHP_FUNCTION(swoole_internal_call_user_shutdown_begin)
     }
     else
     {
-        php_error_docref(NULL, E_WARNING, "can not call this function in user level.");
+        php_error_docref(NULL, E_WARNING, "can not call this function in user level");
         RETURN_FALSE;
     }
 }

--- a/swoole_async_coro.cc
+++ b/swoole_async_coro.cc
@@ -200,7 +200,7 @@ PHP_FUNCTION(swoole_async_set)
 {
     if (SwooleG.main_reactor != NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "eventLoop has already been created. unable to change settings.");
+        swoole_php_fatal_error(E_ERROR, "eventLoop has already been created. unable to change settings");
         RETURN_FALSE;
     }
 
@@ -293,13 +293,13 @@ PHP_FUNCTION(swoole_async_dns_lookup_coro)
 
     if (Z_TYPE_P(domain) != IS_STRING)
     {
-        swoole_php_fatal_error(E_WARNING, "invalid domain name.");
+        swoole_php_fatal_error(E_WARNING, "invalid domain name");
         RETURN_FALSE;
     }
 
     if (Z_STRLEN_P(domain) == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "domain name empty.");
+        swoole_php_fatal_error(E_WARNING, "domain name empty");
         RETURN_FALSE;
     }
 

--- a/swoole_atomic.c
+++ b/swoole_atomic.c
@@ -169,7 +169,7 @@ PHP_METHOD(swoole_atomic, __construct)
     sw_atomic_t *atomic = SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_t));
     if (atomic == NULL)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure.", SW_ERROR_MALLOC_FAIL);
+        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
     *atomic = (sw_atomic_t) value;
@@ -296,7 +296,7 @@ PHP_METHOD(swoole_atomic_long, __construct)
     sw_atomic_long_t *atomic = SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_long_t));
     if (atomic == NULL)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure.", SW_ERROR_MALLOC_FAIL);
+        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
     *atomic = (sw_atomic_long_t) value;

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -108,7 +108,7 @@ static PHP_METHOD(swoole_buffer, __construct)
 
     if (size < 1)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "buffer size can't be less than 0.", SW_ERROR_INVALID_PARAMS);
+        zend_throw_exception(swoole_exception_ce_ptr, "buffer size can't be less than 0", SW_ERROR_INVALID_PARAMS);
         RETURN_FALSE;
     }
     else if (size > SW_STRING_BUFFER_MAXLEN)
@@ -120,7 +120,7 @@ static PHP_METHOD(swoole_buffer, __construct)
     swString *buffer = swString_new(size);
     if (buffer == NULL)
     {
-        zend_throw_exception_ex(swoole_exception_ce_ptr, errno, "malloc(" ZEND_LONG_FMT ") failed.", size);
+        zend_throw_exception_ex(swoole_exception_ce_ptr, errno, "malloc(" ZEND_LONG_FMT ") failed", size);
         RETURN_FALSE;
     }
 
@@ -152,7 +152,7 @@ static PHP_METHOD(swoole_buffer, append)
     }
     if (str.length < 1)
     {
-        php_error_docref(NULL, E_WARNING, "string empty.");
+        php_error_docref(NULL, E_WARNING, "string empty");
         RETURN_FALSE;
     }
     swString *buffer = swoole_get_object(getThis());
@@ -207,7 +207,7 @@ static PHP_METHOD(swoole_buffer, substr)
     }
     if (length + offset > buffer->length)
     {
-        swoole_php_error(E_WARNING, "offset(" ZEND_LONG_FMT ", " ZEND_LONG_FMT ") is out of bounds.", offset, length);
+        swoole_php_error(E_WARNING, "offset(" ZEND_LONG_FMT ", " ZEND_LONG_FMT ") is out of bounds", offset, length);
         RETURN_FALSE;
     }
     if (remove)
@@ -243,7 +243,7 @@ static PHP_METHOD(swoole_buffer, write)
 
     if (str.length < 1)
     {
-        php_error_docref(NULL, E_WARNING, "string to write is empty.");
+        php_error_docref(NULL, E_WARNING, "string to write is empty");
         RETURN_FALSE;
     }
 
@@ -255,7 +255,7 @@ static PHP_METHOD(swoole_buffer, write)
     }
     if (offset < 0)
     {
-        php_error_docref(NULL, E_WARNING, "offset(%ld) is out of bounds.", offset);
+        php_error_docref(NULL, E_WARNING, "offset(%ld) is out of bounds", offset);
         RETURN_FALSE;
     }
 
@@ -302,7 +302,7 @@ static PHP_METHOD(swoole_buffer, read)
     }
     if (offset < 0)
     {
-        php_error_docref(NULL, E_WARNING, "offset(%ld) is out of bounds.", offset);
+        php_error_docref(NULL, E_WARNING, "offset(%ld) is out of bounds", offset);
         RETURN_FALSE;
     }
 

--- a/swoole_channel_coro.cc
+++ b/swoole_channel_coro.cc
@@ -90,7 +90,7 @@ static sw_inline Channel * swoole_get_channel(zval *zobject)
     Channel *chan = swoole_channel_coro_fetch_object(Z_OBJ_P(zobject))->chan;
     if (UNEXPECTED(!chan))
     {
-        swoole_php_fatal_error(E_ERROR, "you must call Channel constructor first.");
+        swoole_php_fatal_error(E_ERROR, "you must call Channel constructor first");
     }
     return chan;
 }

--- a/swoole_client.cc
+++ b/swoole_client.cc
@@ -133,14 +133,14 @@ static sw_inline void client_execute_callback(zval *zobject, enum php_swoole_cli
 
     if (!fci_cache)
     {
-        swoole_php_fatal_error(E_WARNING, "object have not %s callback.", callback_name);
+        swoole_php_fatal_error(E_WARNING, "object have not %s callback", callback_name);
         return;
     }
 
     args[0] = *zobject;
     if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 1, args) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "%s handler error.", callback_name);
+        swoole_php_fatal_error(E_WARNING, "%s handler error", callback_name);
         return;
     }
     if (UNEXPECTED(EG(exception)))
@@ -164,7 +164,7 @@ static sw_inline swClient* client_get_ptr(zval *zobject)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
         zend_update_property_long(swoole_client_ce_ptr, zobject, ZEND_STRL("errCode"), SwooleG.error);
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         return NULL;
     }
 }
@@ -322,7 +322,7 @@ static void client_onReceive(swClient *cli, char *data, uint32_t length)
     fci_cache = &cb->cache_onReceive;
     if (!fci_cache)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_client object has no 'onReceive' callback function.");
+        swoole_php_fatal_error(E_WARNING, "swoole_client object has no 'onReceive' callback function");
         goto free_zdata;
     }
     if (sw_call_user_function_fast_ex(NULL, &cb->cache_onReceive, retval, 2, args) == FAILURE)
@@ -361,7 +361,7 @@ static void client_onConnect(swClient *cli)
         client_callback *cb = (client_callback *) swoole_get_property(zobject, 0);
         if (!cb || !cb->cache_onReceive.function_handler)
         {
-            swoole_php_fatal_error(E_ERROR, "has no 'onReceive' callback function.");
+            swoole_php_fatal_error(E_ERROR, "has no 'onReceive' callback function");
         }
     }
 }
@@ -414,7 +414,7 @@ void php_swoole_client_check_ssl_setting(swClient *cli, zval *zset)
         zend::string str_v(v);
         if (access(str_v.val(), R_OK) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "ssl cert file[%s] not found.", str_v.val());
+            swoole_php_fatal_error(E_ERROR, "ssl cert file[%s] not found", str_v.val());
             return;
         }
         cli->ssl_option.cert_file = sw_strdup(str_v.val());
@@ -424,7 +424,7 @@ void php_swoole_client_check_ssl_setting(swClient *cli, zval *zset)
         zend::string str_v(v);
         if (access(str_v.val(), R_OK) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "ssl key file[%s] not found.", str_v.val());
+            swoole_php_fatal_error(E_ERROR, "ssl key file[%s] not found", str_v.val());
             return;
         }
         cli->ssl_option.key_file = sw_strdup(str_v.val());
@@ -465,7 +465,7 @@ void php_swoole_client_check_ssl_setting(swClient *cli, zval *zset)
     }
     if (cli->ssl_option.cert_file && !cli->ssl_option.key_file)
     {
-        swoole_php_fatal_error(E_ERROR, "ssl require key file.");
+        swoole_php_fatal_error(E_ERROR, "ssl require key file");
         return;
     }
 }
@@ -651,7 +651,7 @@ void php_swoole_client_check_setting(swClient *cli, zval *zset)
             value = 1;
             if (setsockopt(cli->socket->fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value)) != 0)
             {
-                swSysWarn("setsockopt(%d, TCP_NODELAY) failed.", cli->socket->fd);
+                swSysWarn("setsockopt(%d, TCP_NODELAY) failed", cli->socket->fd);
             }
         }
     }
@@ -681,13 +681,13 @@ void php_swoole_client_check_setting(swClient *cli, zval *zset)
                 }
                 else
                 {
-                    swoole_php_fatal_error(E_WARNING, "socks5_password should not be null.");
+                    swoole_php_fatal_error(E_WARNING, "socks5_password should not be null");
                 }
             }
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "socks5_port should not be null.");
+            swoole_php_fatal_error(E_WARNING, "socks5_port should not be null");
         }
     }
     /**
@@ -714,13 +714,13 @@ void php_swoole_client_check_setting(swClient *cli, zval *zset)
                 }
                 else
                 {
-                    swoole_php_fatal_error(E_WARNING, "http_proxy_password should not be null.");
+                    swoole_php_fatal_error(E_WARNING, "http_proxy_password should not be null");
                 }
             }
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "http_proxy_port should not be null.");
+            swoole_php_fatal_error(E_WARNING, "http_proxy_port should not be null");
         }
     }
     /**
@@ -822,7 +822,7 @@ swClient* php_swoole_client_new(zval *zobject, char *host, int host_len, int por
 
     if (ztype == NULL || ZVAL_IS_NULL(ztype))
     {
-        swoole_php_fatal_error(E_ERROR, "failed to get swoole_client->type.");
+        swoole_php_fatal_error(E_ERROR, "failed to get swoole_client->type");
         return NULL;
     }
 
@@ -836,7 +836,7 @@ swClient* php_swoole_client_new(zval *zobject, char *host, int host_len, int por
     int client_type = php_swoole_socktype(type);
     if ((client_type == SW_SOCK_TCP || client_type == SW_SOCK_TCP6) && (port <= 0 || port > SW_CLIENT_MAX_PORT))
     {
-        swoole_php_fatal_error(E_WARNING, "The port is invalid.");
+        swoole_php_fatal_error(E_WARNING, "The port is invalid");
         SwooleG.error = SW_ERROR_INVALID_PARAMS;
         return NULL;
     }
@@ -924,7 +924,7 @@ static PHP_METHOD(swoole_client, __construct)
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|bs", &type, &async, &id, &len) == FAILURE)
     {
-        swoole_php_fatal_error(E_ERROR, "socket type param is required.");
+        swoole_php_fatal_error(E_ERROR, "socket type param is required");
         RETURN_FALSE;
     }
 
@@ -937,7 +937,7 @@ static PHP_METHOD(swoole_client, __construct)
     {
         if ((type & SW_FLAG_KEEP) && SWOOLE_G(cli))
         {
-            swoole_php_fatal_error(E_ERROR, "The 'SWOOLE_KEEP' flag can only be used in the php-fpm or apache environment.");
+            swoole_php_fatal_error(E_ERROR, "The 'SWOOLE_KEEP' flag can only be used in the php-fpm or apache environment");
         }
         php_swoole_check_reactor();
     }
@@ -1022,14 +1022,14 @@ static PHP_METHOD(swoole_client, connect)
 
     if (host_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "The host is empty.");
+        swoole_php_fatal_error(E_WARNING, "The host is empty");
         RETURN_FALSE;
     }
 
     swClient *cli = (swClient *) swoole_get_object(getThis());
     if (cli)
     {
-        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established.");
+        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established");
         RETURN_FALSE;
     }
 
@@ -1057,7 +1057,7 @@ static PHP_METHOD(swoole_client, connect)
     }
     else if (cli->socket->active == 1)
     {
-        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established.");
+        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established");
         RETURN_FALSE;
     }
 
@@ -1073,7 +1073,7 @@ static PHP_METHOD(swoole_client, connect)
         client_callback *cb = (client_callback *) swoole_get_property(getThis(), 0);
         if (!cb)
         {
-            swoole_php_fatal_error(E_ERROR, "no event callback function.");
+            swoole_php_fatal_error(E_ERROR, "no event callback function");
             RETURN_FALSE;
         }
 
@@ -1081,17 +1081,17 @@ static PHP_METHOD(swoole_client, connect)
         {
             if (!cb->cache_onConnect.function_handler)
             {
-                swoole_php_fatal_error(E_ERROR, "no 'onConnect' callback function.");
+                swoole_php_fatal_error(E_ERROR, "no 'onConnect' callback function");
                 RETURN_FALSE;
             }
             if (!cb->cache_onError.function_handler)
             {
-                swoole_php_fatal_error(E_ERROR, "no 'onError' callback function.");
+                swoole_php_fatal_error(E_ERROR, "no 'onError' callback function");
                 RETURN_FALSE;
             }
             if (!cb->cache_onClose.function_handler)
             {
-                swoole_php_fatal_error(E_ERROR, "no 'onClose' callback function.");
+                swoole_php_fatal_error(E_ERROR, "no 'onClose' callback function");
                 RETURN_FALSE;
             }
             cli->onConnect = client_onConnect;
@@ -1112,7 +1112,7 @@ static PHP_METHOD(swoole_client, connect)
         {
             if (!cb || !cb->cache_onReceive.function_handler)
             {
-                swoole_php_fatal_error(E_ERROR, "no 'onReceive' callback function.");
+                swoole_php_fatal_error(E_ERROR, "no 'onReceive' callback function");
                 RETURN_FALSE;
             }
             if (cb->cache_onConnect.function_handler)
@@ -1151,7 +1151,7 @@ static PHP_METHOD(swoole_client, connect)
         }
         else
         {
-            swoole_php_sys_error(E_WARNING, "connect to server[%s:%d] failed.", host, (int )port);
+            swoole_php_sys_error(E_WARNING, "connect to server[%s:%d] failed", host, (int )port);
             zend_update_property_long(swoole_client_ce_ptr, getThis(), ZEND_STRL("errCode"), errno);
         }
         if (cli->async && cli->onError == NULL)
@@ -1182,7 +1182,7 @@ static PHP_METHOD(swoole_client, send)
 
     if (data_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data to send is empty.");
+        swoole_php_fatal_error(E_WARNING, "data to send is empty");
         RETURN_FALSE;
     }
 
@@ -1197,7 +1197,7 @@ static PHP_METHOD(swoole_client, send)
     int ret = cli->send(cli, data, data_len, flags);
     if (ret < 0)
     {
-        swoole_php_sys_error(E_WARNING, "failed to send(%d) %zu bytes.", cli->socket->fd, data_len);
+        swoole_php_sys_error(E_WARNING, "failed to send(%d) %zu bytes", cli->socket->fd, data_len);
         zend_update_property_long(swoole_client_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
         RETVAL_FALSE;
     }
@@ -1222,7 +1222,7 @@ static PHP_METHOD(swoole_client, sendto)
 
     if (len == 0)
     {
-        swoole_php_error(E_WARNING, "data to send is empty.");
+        swoole_php_error(E_WARNING, "data to send is empty");
         RETURN_FALSE;
     }
 
@@ -1249,7 +1249,7 @@ static PHP_METHOD(swoole_client, sendto)
     }
     else
     {
-        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6.");
+        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6");
         RETURN_FALSE;
     }
     SW_CHECK_RETURN(ret);
@@ -1268,7 +1268,7 @@ static PHP_METHOD(swoole_client, sendfile)
     }
     if (file_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "file to send is empty.");
+        swoole_php_fatal_error(E_WARNING, "file to send is empty");
         RETURN_FALSE;
     }
 
@@ -1280,7 +1280,7 @@ static PHP_METHOD(swoole_client, sendfile)
     //only stream socket can sendfile
     if (!(cli->type == SW_SOCK_TCP || cli->type == SW_SOCK_TCP6 || cli->type == SW_SOCK_UNIX_STREAM))
     {
-        swoole_php_error(E_WARNING, "dgram socket cannot use sendfile.");
+        swoole_php_error(E_WARNING, "dgram socket cannot use sendfile");
         RETURN_FALSE;
     }
     //clear errno
@@ -1550,14 +1550,14 @@ static PHP_METHOD(swoole_client, getsockname)
 
     if (cli->type == SW_SOCK_UNIX_STREAM || cli->type == SW_SOCK_UNIX_DGRAM)
     {
-        swoole_php_fatal_error(E_WARNING, "getsockname() only support AF_INET family socket.");
+        swoole_php_fatal_error(E_WARNING, "getsockname() only support AF_INET family socket");
         RETURN_FALSE;
     }
 
     cli->socket->info.len = sizeof(cli->socket->info.addr);
     if (getsockname(cli->socket->fd, (struct sockaddr*) &cli->socket->info.addr, &cli->socket->info.len) < 0)
     {
-        swoole_php_sys_error(E_WARNING, "getsockname() failed.");
+        swoole_php_sys_error(E_WARNING, "getsockname() failed");
         RETURN_FALSE;
     }
 
@@ -1572,7 +1572,7 @@ static PHP_METHOD(swoole_client, getsockname)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed.");
+            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed");
         }
     }
     else
@@ -1597,7 +1597,7 @@ static PHP_METHOD(swoole_client, getSocket)
     }
     if (cli->keep)
     {
-        swoole_php_fatal_error(E_WARNING, "the 'getSocket' method can't be used on persistent connection.");
+        swoole_php_fatal_error(E_WARNING, "the 'getSocket' method can't be used on persistent connection");
         RETURN_FALSE;
     }
     php_socket *socket_object = swoole_convert_to_socket(cli->socket->fd);
@@ -1638,12 +1638,12 @@ static PHP_METHOD(swoole_client, getpeername)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed.");
+            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed");
         }
     }
     else
     {
-        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6.");
+        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6");
         RETURN_FALSE;
     }
 }
@@ -1661,12 +1661,12 @@ static PHP_METHOD(swoole_client, close)
     swClient *cli = (swClient *) swoole_get_object(getThis());
     if (!cli || !cli->socket)
     {
-        swoole_php_fatal_error(E_WARNING, "client is not connected to the server.");
+        swoole_php_fatal_error(E_WARNING, "client is not connected to the server");
         RETURN_FALSE;
     }
     if (cli->socket->closed)
     {
-        swoole_php_error(E_WARNING, "client socket is closed.");
+        swoole_php_error(E_WARNING, "client socket is closed");
         RETURN_FALSE;
     }
     if (cli->async && cli->socket->active == 0)
@@ -1723,13 +1723,13 @@ static PHP_METHOD(swoole_client, on)
     zval *ztype = sw_zend_read_property(swoole_client_ce_ptr, getThis(), ZEND_STRL("type"), 0);
     if (ztype == NULL || ZVAL_IS_NULL(ztype))
     {
-        swoole_php_fatal_error(E_ERROR, "get swoole_client->type failed.");
+        swoole_php_fatal_error(E_ERROR, "get swoole_client->type failed");
         return;
     }
 
     if (!(Z_LVAL_P(ztype) & SW_FLAG_ASYNC))
     {
-        swoole_php_fatal_error(E_ERROR, "can't register event callback functions in SYNC mode.");
+        swoole_php_fatal_error(E_ERROR, "can't register event callback functions in SYNC mode");
         return;
     }
 
@@ -1782,7 +1782,7 @@ static PHP_METHOD(swoole_client, on)
     }
     else
     {
-        swoole_php_fatal_error(E_WARNING, "Unknown event callback type name '%s'.", cb_name);
+        swoole_php_fatal_error(E_WARNING, "Unknown event callback type name '%s'", cb_name);
         RETURN_FALSE;
     }
     RETURN_TRUE;
@@ -1818,12 +1818,12 @@ static PHP_METHOD(swoole_client, enableSSL)
     }
     if (cli->type != SW_SOCK_TCP && cli->type != SW_SOCK_TCP6)
     {
-        swoole_php_fatal_error(E_WARNING, "cannot use enableSSL.");
+        swoole_php_fatal_error(E_WARNING, "cannot use enableSSL");
         RETURN_FALSE;
     }
     if (cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL has been enabled.");
+        swoole_php_fatal_error(E_WARNING, "SSL has been enabled");
         RETURN_FALSE;
     }
     cli->open_ssl = 1;
@@ -1855,7 +1855,7 @@ static PHP_METHOD(swoole_client, enableSSL)
         client_callback *cb = (client_callback *) swoole_get_property(getThis(), client_property_callback);
         if (!cb)
         {
-            swoole_php_fatal_error(E_WARNING, "the object is not an instance of swoole_client.");
+            swoole_php_fatal_error(E_WARNING, "the object is not an instance of swoole_client");
             RETURN_FALSE;
         }
         zend_update_property(swoole_client_ce_ptr, getThis(), ZEND_STRL("onSSLReady"), zcallback);
@@ -1885,7 +1885,7 @@ static PHP_METHOD(swoole_client, getPeerCert)
     }
     if (!cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL is not ready.");
+        swoole_php_fatal_error(E_WARNING, "SSL is not ready");
         RETURN_FALSE;
     }
     char buf[8192];
@@ -1906,7 +1906,7 @@ static PHP_METHOD(swoole_client, verifyPeerCert)
     }
     if (!cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL is not ready.");
+        swoole_php_fatal_error(E_WARNING, "SSL is not ready");
         RETURN_FALSE;
     }
     zend_bool allow_self_signed = 0;
@@ -2263,7 +2263,7 @@ static int client_select_add(zval *sock_array, fd_set *fds, int *max_fd)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "socket[%d] > FD_SETSIZE[%d].", sock, FD_SETSIZE);
+            swoole_php_fatal_error(E_WARNING, "socket[%d] > FD_SETSIZE[%d]", sock, FD_SETSIZE);
             continue;
         }
         if (sock > *max_fd)

--- a/swoole_client.cc
+++ b/swoole_client.cc
@@ -888,7 +888,7 @@ swClient* php_swoole_client_new(zval *zobject, char *host, int host_len, int por
 
         create_socket: if (swClient_create(cli, php_swoole_socktype(type), async) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "swClient_create() failed. Error: %s [%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "swClient_create() failed");
             zend_update_property_long(Z_OBJCE_P(zobject), zobject, ZEND_STRL("errCode"), errno);
             return NULL;
         }
@@ -1354,7 +1354,7 @@ static PHP_METHOD(swoole_client, recv)
             ret = cli->recv(cli, buf, buf_len, 0);
             if (ret < 0)
             {
-                swoole_php_error(E_WARNING, "recv() failed. Error: %s [%d]", strerror(errno), errno);
+                swoole_php_sys_error(E_WARNING, "recv() failed");
                 buffer->length = 0;
                 RETURN_FALSE;
             }
@@ -2010,7 +2010,7 @@ PHP_FUNCTION(swoole_client_select)
     if (retval == -1)
     {
         efree(fds);
-        swoole_php_fatal_error(E_WARNING, "unable to poll(). Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "unable to poll()");
         RETURN_FALSE;
     }
 
@@ -2067,7 +2067,7 @@ PHP_FUNCTION(swoole_client_select)
     retval = select(max_fd + 1, &rfds, &wfds, &efds, &timeo);
     if (retval == -1)
     {
-        swoole_php_fatal_error(E_WARNING, "unable to select. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "unable to select");
         RETURN_FALSE;
     }
     if (r_array != NULL)

--- a/swoole_client.cc
+++ b/swoole_client.cc
@@ -651,7 +651,7 @@ void php_swoole_client_check_setting(swClient *cli, zval *zset)
             value = 1;
             if (setsockopt(cli->socket->fd, IPPROTO_TCP, TCP_NODELAY, &value, sizeof(value)) != 0)
             {
-                swSysError("setsockopt(%d, TCP_NODELAY) failed.", cli->socket->fd);
+                swSysWarn("setsockopt(%d, TCP_NODELAY) failed.", cli->socket->fd);
             }
         }
     }

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -188,7 +188,7 @@ static Socket* client_coro_new(zval *zobject, int port)
     Socket *cli = new Socket((enum swSocket_type) type);
     if (UNEXPECTED(cli->socket == nullptr))
     {
-        swoole_php_fatal_error(E_WARNING, "new Socket() failed. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "new Socket() failed");
         zend_update_property_long(Z_OBJCE_P(zobject), zobject, ZEND_STRL("errCode"), errno);
         zend_update_property_string(Z_OBJCE_P(zobject), zobject, ZEND_STRL("errMsg"), strerror(errno));
         delete cli;

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -180,7 +180,7 @@ static Socket* client_coro_new(zval *zobject, int port)
 
     if ((type == SW_SOCK_TCP || type == SW_SOCK_TCP6) && (port <= 0 || port > SW_CLIENT_MAX_PORT))
     {
-        swoole_php_fatal_error(E_WARNING, "The port is invalid.");
+        swoole_php_fatal_error(E_WARNING, "The port is invalid");
         return NULL;
     }
 
@@ -519,13 +519,13 @@ void php_swoole_client_set(Socket *cli, zval *zset)
                 }
                 else
                 {
-                    swoole_php_fatal_error(E_WARNING, "socks5_password should not be null.");
+                    swoole_php_fatal_error(E_WARNING, "socks5_password should not be null");
                 }
             }
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "socks5_port should not be null.");
+            swoole_php_fatal_error(E_WARNING, "socks5_port should not be null");
         }
     }
     /**
@@ -553,13 +553,13 @@ void php_swoole_client_set(Socket *cli, zval *zset)
                 }
                 else
                 {
-                    swoole_php_fatal_error(E_WARNING, "http_proxy_password should not be null.");
+                    swoole_php_fatal_error(E_WARNING, "http_proxy_password should not be null");
                 }
             }
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "http_proxy_port should not be null.");
+            swoole_php_fatal_error(E_WARNING, "http_proxy_port should not be null");
         }
     }
 }
@@ -591,7 +591,7 @@ static void php_swoole_socket_set_ssl(Socket *cli, zval *zset)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "ssl cert file[%s] not found.", cli->ssl_option.cert_file);
+            swoole_php_fatal_error(E_WARNING, "ssl cert file[%s] not found", cli->ssl_option.cert_file);
         }
     }
     if (php_swoole_array_get_value(vht, "ssl_key_file", v))
@@ -607,16 +607,16 @@ static void php_swoole_socket_set_ssl(Socket *cli, zval *zset)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "ssl key file[%s] not found.", cli->ssl_option.key_file);
+            swoole_php_fatal_error(E_WARNING, "ssl key file[%s] not found", cli->ssl_option.key_file);
         }
     }
     if (cli->ssl_option.cert_file && !cli->ssl_option.key_file)
     {
-        swoole_php_fatal_error(E_WARNING, "ssl require key file.");
+        swoole_php_fatal_error(E_WARNING, "ssl require key file");
     }
     else if (cli->ssl_option.key_file && !cli->ssl_option.cert_file)
     {
-        swoole_php_fatal_error(E_WARNING, "ssl require cert file.");
+        swoole_php_fatal_error(E_WARNING, "ssl require cert file");
     }
     if (php_swoole_array_get_value(vht, "ssl_passphrase", v))
     {
@@ -740,7 +740,7 @@ static PHP_METHOD(swoole_client_coro, connect)
 
     if (host_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "The host is empty.");
+        swoole_php_fatal_error(E_WARNING, "The host is empty");
         RETURN_FALSE;
     }
 
@@ -790,7 +790,7 @@ static PHP_METHOD(swoole_client_coro, send)
 
     if (data_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data to send is empty.");
+        swoole_php_fatal_error(E_WARNING, "data to send is empty");
         RETURN_FALSE;
     }
 
@@ -912,7 +912,7 @@ static PHP_METHOD(swoole_client_coro, sendfile)
     }
     if (file_len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "file to send is empty.");
+        swoole_php_fatal_error(E_WARNING, "file to send is empty");
         RETURN_FALSE;
     }
 
@@ -925,7 +925,7 @@ static PHP_METHOD(swoole_client_coro, sendfile)
     if (!(cli->type == SW_SOCK_TCP || cli->type == SW_SOCK_TCP6 || cli->type == SW_SOCK_UNIX_STREAM))
     {
         zend_update_property_long(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), EINVAL);
-        zend_update_property_string(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "dgram socket cannot use sendfile.");
+        zend_update_property_string(swoole_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "dgram socket cannot use sendfile");
         RETURN_FALSE;
     }
     PHPCoroutine::check_bind("client", cli->get_bound_cid(SW_EVENT_WRITE));
@@ -1051,14 +1051,14 @@ static PHP_METHOD(swoole_client_coro, getsockname)
 
     if (cli->type == SW_SOCK_UNIX_STREAM || cli->type == SW_SOCK_UNIX_DGRAM)
     {
-        swoole_php_fatal_error(E_WARNING, "getsockname() only support AF_INET family socket.");
+        swoole_php_fatal_error(E_WARNING, "getsockname() only support AF_INET family socket");
         RETURN_FALSE;
     }
 
     cli->socket->info.len = sizeof(cli->socket->info.addr);
     if (getsockname(cli->socket->fd, (struct sockaddr*) &cli->socket->info.addr, &cli->socket->info.len) < 0)
     {
-        swoole_php_sys_error(E_WARNING, "getsockname() failed.");
+        swoole_php_sys_error(E_WARNING, "getsockname() failed");
         RETURN_FALSE;
     }
 
@@ -1073,7 +1073,7 @@ static PHP_METHOD(swoole_client_coro, getsockname)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed.");
+            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed");
         }
     }
     else
@@ -1134,12 +1134,12 @@ static PHP_METHOD(swoole_client_coro, getpeername)
         }
         else
         {
-            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed.");
+            swoole_php_fatal_error(E_WARNING, "inet_ntop() failed");
         }
     }
     else
     {
-        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6.");
+        swoole_php_fatal_error(E_WARNING, "only supports SWOOLE_SOCK_UDP or SWOOLE_SOCK_UDP6");
         RETURN_FALSE;
     }
 }
@@ -1159,12 +1159,12 @@ static PHP_METHOD(swoole_client_coro, enableSSL)
     }
     if (cli->type != SW_SOCK_TCP && cli->type != SW_SOCK_TCP6)
     {
-        swoole_php_fatal_error(E_WARNING, "cannot use enableSSL.");
+        swoole_php_fatal_error(E_WARNING, "cannot use enableSSL");
         RETURN_FALSE;
     }
     if (cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL has been enabled.");
+        swoole_php_fatal_error(E_WARNING, "SSL has been enabled");
         RETURN_FALSE;
     }
     cli->open_ssl = true;
@@ -1190,7 +1190,7 @@ static PHP_METHOD(swoole_client_coro, getPeerCert)
     }
     if (!cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL is not ready.");
+        swoole_php_fatal_error(E_WARNING, "SSL is not ready");
         RETURN_FALSE;
     }
     char buf[8192];
@@ -1211,7 +1211,7 @@ static PHP_METHOD(swoole_client_coro, verifyPeerCert)
     }
     if (!cli->socket->ssl)
     {
-        swoole_php_fatal_error(E_WARNING, "SSL is not ready.");
+        swoole_php_fatal_error(E_WARNING, "SSL is not ready");
         RETURN_FALSE;
     }
     zend_bool allow_self_signed = 0;

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -19,7 +19,7 @@
 #ifndef __clang__
 // gcc version check
 #if defined(__GNUC__) && (__GNUC__ < 3 || (__GNUC__ == 4 && __GNUC_MINOR__ < 8))
-#error "GCC 4.8 or later required."
+#error "GCC 4.8 or later required"
 #endif
 #endif
 
@@ -181,7 +181,7 @@
 #define SW_STRING_BUFFER_GARBAGE_RATIO   4
 
 #define SW_SIGNO_MAX                     128
-#define SW_UNREGISTERED_SIGNAL_FMT       "Unable to find callback function for signal %s."
+#define SW_UNREGISTERED_SIGNAL_FMT       "Unable to find callback function for signal %s"
 
 #define SW_DNS_HOST_BUFFER_SIZE          16
 #define SW_DNS_SERVER_PORT               53

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -372,7 +372,7 @@ void PHPCoroutine::create_func(void *arg)
             defer_fci->fci.params = retval;
             if (UNEXPECTED(sw_call_function_anyway(&defer_fci->fci, &defer_fci->fci_cache) == FAILURE))
             {
-                swoole_php_fatal_error(E_WARNING, "defer callback handler error.");
+                swoole_php_fatal_error(E_WARNING, "defer callback handler error");
             }
             sw_fci_cache_discard(&defer_fci->fci_cache);
             efree(defer_fci);
@@ -412,18 +412,18 @@ long PHPCoroutine::create(zend_fcall_info_cache *fci_cache, uint32_t argc, zval 
     }
     if (unlikely(Coroutine::count() >= max_num))
     {
-        swoole_php_fatal_error(E_WARNING, "exceed max number of coroutine %zu.", (uintmax_t) Coroutine::count());
+        swoole_php_fatal_error(E_WARNING, "exceed max number of coroutine %zu", (uintmax_t) Coroutine::count());
         return SW_CORO_ERR_LIMIT;
     }
     if (unlikely(!fci_cache || !fci_cache->function_handler))
     {
-        swoole_php_fatal_error(E_ERROR, "invalid function call info cache.");
+        swoole_php_fatal_error(E_ERROR, "invalid function call info cache");
         return SW_CORO_ERR_INVALID;
     }
     zend_uchar type = fci_cache->function_handler->type;
     if (unlikely(type != ZEND_USER_FUNCTION && type != ZEND_INTERNAL_FUNCTION))
     {
-        swoole_php_fatal_error(E_ERROR, "invalid function type %u.", fci_cache->function_handler->type);
+        swoole_php_fatal_error(E_ERROR, "invalid function type %u", fci_cache->function_handler->type);
         return SW_CORO_ERR_INVALID;
     }
 

--- a/swoole_coroutine_util.cc
+++ b/swoole_coroutine_util.cc
@@ -266,7 +266,7 @@ static int coro_exit_handler(zend_execute_data *execute_data)
             exit_status = &_exit_status;
             ZVAL_NULL(exit_status);
         }
-        obj = zend_throw_error_exception(swoole_exit_exception_ce_ptr, "swoole exit.", 0, E_ERROR);
+        obj = zend_throw_error_exception(swoole_exit_exception_ce_ptr, "swoole exit", 0, E_ERROR);
         ZVAL_OBJ(&ex, obj);
         zend_update_property_long(swoole_exit_exception_ce_ptr, &ex, ZEND_STRL("flags"), flags);
         Z_TRY_ADDREF_P(exit_status);
@@ -458,7 +458,7 @@ static PHP_METHOD(swoole_coroutine_util, resume)
     auto coroutine_iterator = user_yield_coros.find(cid);
     if (coroutine_iterator == user_yield_coros.end())
     {
-        swoole_php_fatal_error(E_WARNING, "you can not resume the coroutine which is in IO operation.");
+        swoole_php_fatal_error(E_WARNING, "you can not resume the coroutine which is in IO operation");
         RETURN_FALSE;
     }
 
@@ -870,7 +870,7 @@ static PHP_METHOD(swoole_coroutine_util, fgets)
 
     if (async == 1)
     {
-        swoole_php_fatal_error(E_WARNING, "only support file resources.");
+        swoole_php_fatal_error(E_WARNING, "only support file resources");
         RETURN_FALSE;
     }
 
@@ -1139,13 +1139,13 @@ PHP_FUNCTION(swoole_coroutine_gethostbyname)
 
     if (l_domain_name == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "domain name is empty.");
+        swoole_php_fatal_error(E_WARNING, "domain name is empty");
         RETURN_FALSE;
     }
 
     if (family != AF_INET && family != AF_INET6)
     {
-        swoole_php_fatal_error(E_WARNING, "unknown protocol family, must be AF_INET or AF_INET6.");
+        swoole_php_fatal_error(E_WARNING, "unknown protocol family, must be AF_INET or AF_INET6");
         RETURN_FALSE;
     }
 
@@ -1178,13 +1178,13 @@ static PHP_METHOD(swoole_coroutine_util, getaddrinfo)
 
     if (l_hostname == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "hostname is empty.");
+        swoole_php_fatal_error(E_WARNING, "hostname is empty");
         RETURN_FALSE;
     }
 
     if (family != AF_INET && family != AF_INET6)
     {
-        swoole_php_fatal_error(E_WARNING, "unknown protocol family, must be AF_INET or AF_INET6.");
+        swoole_php_fatal_error(E_WARNING, "unknown protocol family, must be AF_INET or AF_INET6");
         RETURN_FALSE;
     }
 
@@ -1321,7 +1321,7 @@ PHP_FUNCTION(swoole_coroutine_exec)
 
     if (php_swoole_signal_isset_handler(SIGCHLD))
     {
-        swoole_php_error(E_WARNING, "The signal [SIGCHLD] is registered, cannot execute swoole_coroutine_exec.");
+        swoole_php_error(E_WARNING, "The signal [SIGCHLD] is registered, cannot execute swoole_coroutine_exec");
         RETURN_FALSE;
     }
 

--- a/swoole_event.c
+++ b/swoole_event.c
@@ -74,7 +74,7 @@ static int php_swoole_event_onRead(swReactor *reactor, swEvent *event)
 
     if (sw_call_user_function_ex(EG(function_table), NULL, fd->cb_read, &retval, 1, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event: onRead handler error.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event: onRead handler error");
         SwooleG.main_reactor->del(SwooleG.main_reactor, event->fd);
         return SW_ERR;
     }
@@ -172,7 +172,7 @@ static void php_swoole_event_onEndCallback(void *_cb)
 
     if (sw_call_user_function_ex(EG(function_table), NULL, defer->callback, &retval, 0, NULL, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event: cycle callback handler error.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event: cycle callback handler error");
         return;
     }
     if (UNEXPECTED(EG(exception)))
@@ -189,7 +189,7 @@ void php_swoole_reactor_init()
 {
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "async-io must be used in PHP CLI mode.");
+        swoole_php_fatal_error(E_ERROR, "async-io must be used in PHP CLI mode");
         return;
     }
 
@@ -197,12 +197,12 @@ void php_swoole_reactor_init()
     {
         if (swIsTaskWorker() && !SwooleG.serv->task_enable_coroutine)
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to use async-io in task processes, please set `task_enable_coroutine` to true.");
+            swoole_php_fatal_error(E_ERROR, "Unable to use async-io in task processes, please set `task_enable_coroutine` to true");
             return;
         }
         if (swIsManager())
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to use async-io in manager process.");
+            swoole_php_fatal_error(E_ERROR, "Unable to use async-io in manager process");
             return;
         }
     }
@@ -214,12 +214,12 @@ void php_swoole_reactor_init()
         SwooleG.main_reactor = (swReactor *) sw_malloc(sizeof(swReactor));
         if (SwooleG.main_reactor == NULL)
         {
-            swoole_php_fatal_error(E_ERROR, "malloc failed.");
+            swoole_php_fatal_error(E_ERROR, "malloc failed");
             return;
         }
         if (swReactor_create(SwooleG.main_reactor, SW_REACTOR_MAXEVENTS) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "failed to create reactor.");
+            swoole_php_fatal_error(E_ERROR, "failed to create reactor");
             return;
         }
 
@@ -468,19 +468,19 @@ PHP_FUNCTION(swoole_event_add)
 
     if ((cb_read == NULL && cb_write == NULL) || (ZVAL_IS_NULL(cb_read) && ZVAL_IS_NULL(cb_write)))
     {
-        swoole_php_fatal_error(E_WARNING, "no read or write event callback.");
+        swoole_php_fatal_error(E_WARNING, "no read or write event callback");
         RETURN_FALSE;
     }
 
     int socket_fd = swoole_convert_to_fd(zfd);
     if (socket_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "unknow type.");
+        swoole_php_fatal_error(E_WARNING, "unknow type");
         RETURN_FALSE;
     }
     if (socket_fd == 0 && (event_flag & SW_EVENT_WRITE))
     {
-        swoole_php_fatal_error(E_WARNING, "invalid socket fd [%d].", socket_fd);
+        swoole_php_fatal_error(E_WARNING, "invalid socket fd [%d]", socket_fd);
         RETURN_FALSE;
     }
 
@@ -528,7 +528,7 @@ PHP_FUNCTION(swoole_event_add)
 
     if (SwooleG.main_reactor->add(SwooleG.main_reactor, socket_fd, SW_FD_USER | event_flag) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event_add failed.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event_add failed");
         RETURN_FALSE;
     }
 
@@ -553,14 +553,14 @@ PHP_FUNCTION(swoole_event_write)
 
     if (len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data empty.");
+        swoole_php_fatal_error(E_WARNING, "data empty");
         RETURN_FALSE;
     }
 
     int socket_fd = swoole_convert_to_fd(zfd);
     if (socket_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "unknow type.");
+        swoole_php_fatal_error(E_WARNING, "unknow type");
         RETURN_FALSE;
     }
 
@@ -585,7 +585,7 @@ PHP_FUNCTION(swoole_event_set)
 
     if (!SwooleG.main_reactor)
     {
-        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_set.");
+        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_set");
         RETURN_FALSE;
     }
 
@@ -597,14 +597,14 @@ PHP_FUNCTION(swoole_event_set)
     int socket_fd = swoole_convert_to_fd(zfd);
     if (socket_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "unknow type.");
+        swoole_php_fatal_error(E_WARNING, "unknow type");
         RETURN_FALSE;
     }
 
     swConnection *socket = swReactor_get(SwooleG.main_reactor, socket_fd);
     if (!socket->active)
     {
-        swoole_php_fatal_error(E_WARNING, "socket[%d] is not found in the reactor.", socket_fd);
+        swoole_php_fatal_error(E_WARNING, "socket[%d] is not found in the reactor", socket_fd);
         efree(func_name);
         RETURN_FALSE;
     }
@@ -634,7 +634,7 @@ PHP_FUNCTION(swoole_event_set)
     {
         if (socket_fd == 0 && (event_flag & SW_EVENT_WRITE))
         {
-            swoole_php_fatal_error(E_WARNING, "invalid socket fd [%d].", socket_fd);
+            swoole_php_fatal_error(E_WARNING, "invalid socket fd [%d]", socket_fd);
             RETURN_FALSE;
         }
         if (!sw_zend_is_callable(cb_write, 0, &func_name))
@@ -657,19 +657,19 @@ PHP_FUNCTION(swoole_event_set)
 
     if ((event_flag & SW_EVENT_READ) && ev_set->cb_read == NULL)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event: no read callback.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event: no read callback");
         RETURN_FALSE;
     }
 
     if ((event_flag & SW_EVENT_WRITE) && ev_set->cb_write == NULL)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event: no write callback.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event: no write callback");
         RETURN_FALSE;
     }
 
     if (SwooleG.main_reactor->set(SwooleG.main_reactor, socket_fd, SW_FD_USER | event_flag) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event_set failed.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event_set failed");
         RETURN_FALSE;
     }
 
@@ -682,7 +682,7 @@ PHP_FUNCTION(swoole_event_del)
 
     if (!SwooleG.main_reactor)
     {
-        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_del.");
+        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_del");
         RETURN_FALSE;
     }
 
@@ -694,7 +694,7 @@ PHP_FUNCTION(swoole_event_del)
     int socket_fd = swoole_convert_to_fd(zfd);
     if (socket_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "unknow type.");
+        swoole_php_fatal_error(E_WARNING, "unknow type");
         RETURN_FALSE;
     }
 
@@ -740,7 +740,7 @@ PHP_FUNCTION(swoole_event_cycle)
 {
     if (!SwooleG.main_reactor)
     {
-        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_cycle.");
+        swoole_php_fatal_error(E_WARNING, "reactor is not ready, cannot call swoole_event_cycle");
         RETURN_FALSE;
     }
 
@@ -864,7 +864,7 @@ PHP_FUNCTION(swoole_event_isset)
     int socket_fd = swoole_convert_to_fd(zfd);
     if (socket_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "unknow type.");
+        swoole_php_fatal_error(E_WARNING, "unknow type");
         RETURN_FALSE;
     }
 

--- a/swoole_event.c
+++ b/swoole_event.c
@@ -127,7 +127,7 @@ static int php_swoole_event_onError(swReactor *reactor, swEvent *event)
 
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &error, &len) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event->onError[1]: getsockopt[sock=%d] failed. Error: %s[%d]", event->fd, strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "swoole_event->onError[1]: getsockopt[sock=%d] failed", event->fd);
     }
 
     if (error != 0)
@@ -279,7 +279,7 @@ void php_swoole_event_wait()
             int ret = SwooleG.main_reactor->wait(SwooleG.main_reactor, NULL);
             if (ret < 0)
             {
-                swoole_php_fatal_error(E_ERROR, "reactor wait failed. Error: %s [%d]", strerror(errno), errno);
+                swoole_php_sys_error(E_ERROR, "reactor wait failed");
             }
             SW_SET_EG_SCOPE(scope);
 #if defined(EG_FLAGS_IN_SHUTDOWN) && !defined(EG_FLAGS_OBJECT_STORE_NO_REUSE)
@@ -839,7 +839,7 @@ PHP_FUNCTION(swoole_event_dispatch)
     int ret = SwooleG.main_reactor->wait(SwooleG.main_reactor, NULL);
     if (ret < 0)
     {
-        swoole_php_fatal_error(E_ERROR, "reactor wait failed. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_ERROR, "reactor wait failed");
     }
 
     SwooleG.main_reactor->once = 0;

--- a/swoole_http.h
+++ b/swoole_http.h
@@ -216,12 +216,12 @@ static int http_parse_set_cookies(const char *at, size_t length, zval *cookies, 
     }
     if (key_len == 0 || key_len >= length - 1)
     {
-        swWarn("cookie key format is wrong.");
+        swWarn("cookie key format is wrong");
         return SW_ERR;
     }
     if (key_len > SW_HTTP_COOKIE_KEYLEN)
     {
-        swWarn("cookie[%.8s...] name length %d is exceed the max name len %d.", key, key_len, SW_HTTP_COOKIE_KEYLEN);
+        swWarn("cookie[%.8s...] name length %d is exceed the max name len %d", key, key_len, SW_HTTP_COOKIE_KEYLEN);
         return SW_ERR;
     }
     add_assoc_stringl_ex(set_cookie_headers, key, key_len, (char *) at, length);
@@ -235,7 +235,7 @@ static int http_parse_set_cookies(const char *at, size_t length, zval *cookies, 
     val_len = eof - p;
     if (val_len > SW_HTTP_COOKIE_VALLEN)
     {
-        swWarn("cookie[%.*s]'s value[v=%.8s...] length %d is exceed the max value len %d.", (int) key_len, key, p, val_len, SW_HTTP_COOKIE_VALLEN);
+        swWarn("cookie[%.*s]'s value[v=%.8s...] length %d is exceed the max value len %d", (int) key_len, key, p, val_len, SW_HTTP_COOKIE_VALLEN);
         return SW_ERR;
     }
     ZVAL_STRINGL(&val, p, val_len);

--- a/swoole_http_client.h
+++ b/swoole_http_client.h
@@ -84,16 +84,16 @@ static sw_inline int http_client_check_data(zval *data)
 {
     if (Z_TYPE_P(data) != IS_ARRAY && Z_TYPE_P(data) != IS_STRING)
     {
-        swoole_php_error(E_WARNING, "parameter $data must be an array or string.");
+        swoole_php_error(E_WARNING, "parameter $data must be an array or string");
         return SW_ERR;
     }
     else if (Z_TYPE_P(data) == IS_ARRAY && php_swoole_array_length(data) == 0)
     {
-        swoole_php_error(E_WARNING, "parameter $data is empty.");
+        swoole_php_error(E_WARNING, "parameter $data is empty");
     }
     else if (Z_TYPE_P(data) == IS_STRING && Z_STRLEN_P(data) == 0)
     {
-        swoole_php_error(E_WARNING, "parameter $data is empty.");
+        swoole_php_error(E_WARNING, "parameter $data is empty");
     }
     return SW_OK;
 }

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -454,7 +454,7 @@ bool http_client::init_compression(http_compress_method method)
         init_gzip();
         if (Z_OK != inflateInit(&gzip_stream))
         {
-            swWarn("inflateInit() failed.");
+            swWarn("inflateInit() failed");
             return false;
         }
         break;
@@ -462,7 +462,7 @@ bool http_client::init_compression(http_compress_method method)
         init_gzip();
         if (Z_OK != inflateInit2(&gzip_stream, MAX_WBITS + 16))
         {
-            swWarn("inflateInit2() failed.");
+            swWarn("inflateInit2() failed");
             return false;
         }
         break;
@@ -515,7 +515,7 @@ bool http_client::uncompress_response()
             break;
         }
     }
-    swWarn("http_response_uncompress failed.");
+    swWarn("http_response_uncompress failed");
     return false;
 }
 #endif
@@ -605,7 +605,7 @@ bool http_client::connect()
             body = swString_new(SW_HTTP_RESPONSE_INIT_SIZE);
             if (!body)
             {
-                swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
+                swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed", SW_HTTP_RESPONSE_INIT_SIZE);
                 return false;
             }
         }
@@ -647,7 +647,7 @@ bool http_client::send()
 
     if (uri.length() == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "path is empty.");
+        swoole_php_fatal_error(E_WARNING, "path is empty");
         return false;
     }
 
@@ -707,14 +707,14 @@ bool http_client::send()
         int fd = ::open(download_file_name, O_CREAT | O_WRONLY, 0664);
         if (fd < 0)
         {
-            swSysWarn("open(%s, O_CREAT | O_WRONLY) failed.", download_file_name);
+            swSysWarn("open(%s, O_CREAT | O_WRONLY) failed", download_file_name);
             return SW_ERR;
         }
         if (download_offset == 0)
         {
             if (ftruncate(fd, 0) < 0)
             {
-                swSysWarn("ftruncate(%s) failed.", download_file_name);
+                swSysWarn("ftruncate(%s) failed", download_file_name);
                 ::close(fd);
                 return SW_ERR;
             }
@@ -723,7 +723,7 @@ bool http_client::send()
         {
             if (lseek(fd, download_offset, SEEK_SET) < 0)
             {
-                swSysWarn("fseek(%s, %jd) failed.", download_file_name, (intmax_t) download_offset);
+                swSysWarn("fseek(%s, %jd) failed", download_file_name, (intmax_t) download_offset);
                 ::close(fd);
                 return SW_ERR;
             }
@@ -1090,7 +1090,7 @@ bool http_client::send()
                 char *formstr = sw_http_build_query(zbody, &len, &formstr_s);
                 if (formstr == NULL)
                 {
-                    swoole_php_error(E_WARNING, "http_build_query failed.");
+                    swoole_php_error(E_WARNING, "http_build_query failed");
                     return SW_ERR;
                 }
                 http_client_append_content_length(http_client_buffer, len);
@@ -1170,7 +1170,7 @@ bool http_client::recv(double timeout)
     if (!socket || !socket->is_connect())
     {
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION);
-        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available.");
+        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available");
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("statusCode"), HTTP_CLIENT_ESTATUS_SERVER_RESET);
         return false;
     }
@@ -1216,7 +1216,7 @@ void http_client::recv(zval *zframe, double timeout)
     if (!socket || !socket->is_connect())
     {
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION);
-        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available.");
+        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available");
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("statusCode"), HTTP_CLIENT_ESTATUS_SERVER_RESET);
         return;
     }
@@ -1274,7 +1274,7 @@ bool http_client::recv_http_response(double timeout)
         }
         total_bytes += retval;
         parsed_n = swoole_http_parser_execute(&parser, &http_parser_settings, buffer->str, retval);
-        swTraceLog(SW_TRACE_HTTP_CLIENT, "parsed_n=%ld, retval=%ld, total_bytes=%ld, completed=%d.", parsed_n, retval, total_bytes, parser.state == s_start_res);
+        swTraceLog(SW_TRACE_HTTP_CLIENT, "parsed_n=%ld, retval=%ld, total_bytes=%ld, completed=%d", parsed_n, retval, total_bytes, parser.state == s_start_res);
         if (parser.state == s_start_res)
         {
             // websocket stick package
@@ -1321,16 +1321,16 @@ bool http_client::push(zval *zdata, zend_long opcode, bool fin)
 
     if (!websocket)
     {
-        swoole_php_fatal_error(E_WARNING, "websocket handshake failed, cannot push data.");
+        swoole_php_fatal_error(E_WARNING, "websocket handshake failed, cannot push data");
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), SwooleG.error = SW_ERROR_WEBSOCKET_HANDSHAKE_FAILED);
-        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "websocket handshake failed, cannot push data.");
+        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "websocket handshake failed, cannot push data");
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("statusCode"), HTTP_CLIENT_ESTATUS_CONNECT_FAILED);
         return false;
     }
     if (!socket || !socket->is_connect())
     {
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION);
-        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available.");
+        zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "connection is not available");
         zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("statusCode"), HTTP_CLIENT_ESTATUS_SERVER_RESET);
         return false;
     }
@@ -1426,7 +1426,7 @@ static sw_inline http_client * swoole_get_phc(zval *zobject)
     http_client *phc = swoole_http_client_coro_fetch_object(Z_OBJ_P(zobject))->phc;
     if (UNEXPECTED(!phc))
     {
-        swoole_php_fatal_error(E_ERROR, "you must call Http Client constructor first.");
+        swoole_php_fatal_error(E_ERROR, "you must call Http Client constructor first");
     }
     return phc;
 }
@@ -1495,14 +1495,14 @@ void swoole_http_client_coro_init(int module_number)
     http_client_buffer = swString_new(SW_HTTP_RESPONSE_INIT_SIZE);
     if (!http_client_buffer)
     {
-        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
+        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed", SW_HTTP_RESPONSE_INIT_SIZE);
     }
 
 #ifdef SW_HAVE_ZLIB
     swoole_zlib_buffer = swString_new(SW_HTTP_RESPONSE_INIT_SIZE);
     if (!swoole_zlib_buffer)
     {
-        swoole_php_fatal_error(E_ERROR, "[2] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
+        swoole_php_fatal_error(E_ERROR, "[2] swString_new(%d) failed", SW_HTTP_RESPONSE_INIT_SIZE);
     }
 #endif
 }
@@ -1528,7 +1528,7 @@ static PHP_METHOD(swoole_http_client_coro, __construct)
     // check host
     if (host_len == 0)
     {
-        zend_throw_exception_ex(swoole_http_client_coro_exception_ce_ptr, EINVAL, "host is empty.");
+        zend_throw_exception_ex(swoole_http_client_coro_exception_ce_ptr, EINVAL, "host is empty");
         RETURN_FALSE;
     }
     // check ssl
@@ -1537,7 +1537,7 @@ static PHP_METHOD(swoole_http_client_coro, __construct)
     {
         zend_throw_exception_ex(
             swoole_http_client_coro_exception_ce_ptr,
-            EINVAL, "Need to use `--enable-openssl` to support ssl when compiling swoole."
+            EINVAL, "Need to use `--enable-openssl` to support ssl when compiling swoole"
         );
         RETURN_FALSE;
     }
@@ -1670,22 +1670,22 @@ static PHP_METHOD(swoole_http_client_coro, addFile)
     struct stat file_stat;
     if (stat(path, &file_stat) < 0)
     {
-        swoole_php_sys_error(E_WARNING, "stat(%s) failed.", path);
+        swoole_php_sys_error(E_WARNING, "stat(%s) failed", path);
         RETURN_FALSE;
     }
     if (file_stat.st_size == 0)
     {
-        swoole_php_sys_error(E_WARNING, "cannot send empty file[%s].", filename);
+        swoole_php_sys_error(E_WARNING, "cannot send empty file[%s]", filename);
         RETURN_FALSE;
     }
     if (file_stat.st_size <= offset)
     {
-        swoole_php_error(E_WARNING, "parameter $offset[" ZEND_LONG_FMT "] exceeds the file size.", offset);
+        swoole_php_error(E_WARNING, "parameter $offset[" ZEND_LONG_FMT "] exceeds the file size", offset);
         RETURN_FALSE;
     }
     if (length > file_stat.st_size - offset)
     {
-        swoole_php_sys_error(E_WARNING, "parameter $length[" ZEND_LONG_FMT "] exceeds the file size.", length);
+        swoole_php_sys_error(E_WARNING, "parameter $length[" ZEND_LONG_FMT "] exceeds the file size", length);
         RETURN_FALSE;
     }
     if (length == 0)

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -575,7 +575,7 @@ bool http_client::connect()
         socket = new Socket(socket_type);
         if (UNEXPECTED(socket->socket == nullptr))
         {
-            swoole_php_fatal_error(E_WARNING, "new Socket() failed. Error: %s [%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "new Socket() failed");
             zend_update_property_long(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errCode"), errno);
             zend_update_property_string(swoole_http_client_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), strerror(errno));
             delete socket;

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -707,14 +707,14 @@ bool http_client::send()
         int fd = ::open(download_file_name, O_CREAT | O_WRONLY, 0664);
         if (fd < 0)
         {
-            swSysError("open(%s, O_CREAT | O_WRONLY) failed.", download_file_name);
+            swSysWarn("open(%s, O_CREAT | O_WRONLY) failed.", download_file_name);
             return SW_ERR;
         }
         if (download_offset == 0)
         {
             if (ftruncate(fd, 0) < 0)
             {
-                swSysError("ftruncate(%s) failed.", download_file_name);
+                swSysWarn("ftruncate(%s) failed.", download_file_name);
                 ::close(fd);
                 return SW_ERR;
             }
@@ -723,7 +723,7 @@ bool http_client::send()
         {
             if (lseek(fd, download_offset, SEEK_SET) < 0)
             {
-                swSysError("fseek(%s, %jd) failed.", download_file_name, (intmax_t) download_offset);
+                swSysWarn("fseek(%s, %jd) failed.", download_file_name, (intmax_t) download_offset);
                 ::close(fd);
                 return SW_ERR;
             }

--- a/swoole_http_server.cc
+++ b/swoole_http_server.cc
@@ -705,7 +705,7 @@ static int multipart_body_on_data(multipart_parser* p, const char *at, size_t le
         fclose((FILE *) p->fp);
         p->fp = NULL;
 
-        swWarn("write upload file failed. Error %s[%d]", strerror(errno), errno);
+        swSysWarn("write upload file failed");
     }
     return 0;
 }
@@ -757,7 +757,7 @@ static int multipart_body_on_header_complete(multipart_parser* p)
     if (fp == NULL)
     {
         add_assoc_long(multipart_header, "error", HTTP_UPLOAD_ERR_NO_TMP_DIR);
-        swWarn("fopen(%s) failed. Error %s[%d]", file_path, strerror(errno), errno);
+        swSysWarn("fopen(%s) failed", file_path);
         return 0;
     }
 

--- a/swoole_http_server.cc
+++ b/swoole_http_server.cc
@@ -388,7 +388,7 @@ int swoole_http_parse_form_data(http_context *ctx, const char *boundary_str, int
     multipart_parser *mt_parser = multipart_parser_init(boundary_str, boundary_len, &mt_parser_settings);
     if (!mt_parser)
     {
-        swoole_php_fatal_error(E_WARNING, "multipart_parser_init() failed.");
+        swoole_php_fatal_error(E_WARNING, "multipart_parser_init() failed");
         return SW_ERR;
     }
 
@@ -417,7 +417,7 @@ void swoole_http_parse_cookie(zval *array, const char *at, size_t length)
             klen = i - j + 1;
             if (klen >= SW_HTTP_COOKIE_KEYLEN)
             {
-                swWarn("cookie[%.*s...] name length %d is exceed the max name len %d.", 8, (char *) at + j, klen, SW_HTTP_COOKIE_KEYLEN);
+                swWarn("cookie[%.*s...] name length %d is exceed the max name len %d", 8, (char *) at + j, klen, SW_HTTP_COOKIE_KEYLEN);
                 return;
             }
             memcpy(keybuf, (char *) at + j, klen - 1);
@@ -431,7 +431,7 @@ void swoole_http_parse_cookie(zval *array, const char *at, size_t length)
             vlen = i - j;
             if (vlen >= SW_HTTP_COOKIE_VALLEN)
             {
-                swWarn("cookie[%s]'s value[v=%.*s...] length %d is exceed the max value len %d.", keybuf, 8, (char *) at + j, vlen, SW_HTTP_COOKIE_VALLEN);
+                swWarn("cookie[%s]'s value[v=%.*s...] length %d is exceed the max value len %d", keybuf, 8, (char *) at + j, vlen, SW_HTTP_COOKIE_VALLEN);
                 return;
             }
             memcpy(valbuf, (char *) at + j, vlen);
@@ -465,13 +465,13 @@ void swoole_http_parse_cookie(zval *array, const char *at, size_t length)
         vlen = i - j;
         if (klen >= SW_HTTP_COOKIE_KEYLEN)
         {
-            swWarn("cookie[%.*s...] name length %d is exceed the max name len %d.", 8, keybuf, klen, SW_HTTP_COOKIE_KEYLEN);
+            swWarn("cookie[%.*s...] name length %d is exceed the max name len %d", 8, keybuf, klen, SW_HTTP_COOKIE_KEYLEN);
             return;
         }
         keybuf[klen - 1] = 0;
         if (vlen >= SW_HTTP_COOKIE_VALLEN)
         {
-            swWarn("cookie[%s]'s value[v=%.*s...] length %d is exceed the max value len %d.", keybuf, 8, (char *) at + j, vlen, SW_HTTP_COOKIE_VALLEN);
+            swWarn("cookie[%s]'s value[v=%.*s...] length %d is exceed the max value len %d", keybuf, 8, (char *) at + j, vlen, SW_HTTP_COOKIE_VALLEN);
             return;
         }
         memcpy(valbuf, (char *) at + j, vlen);
@@ -507,7 +507,7 @@ static int http_request_on_header_value(swoole_http_parser *parser, const char *
         swConnection *conn = swWorker_get_connection(SwooleG.serv, ctx->fd);
         if (!conn)
         {
-            swWarn("connection[%d] is closed.", ctx->fd);
+            swWarn("connection[%d] is closed", ctx->fd);
             return SW_ERR;
         }
         swListenPort *port = (swListenPort *) SwooleG.serv->connection_list[conn->from_fd].object;
@@ -545,7 +545,7 @@ static int http_request_on_header_value(swoole_http_parser *parser, const char *
                 }
                 if (boundary_len <= 0)
                 {
-                    swWarn("invalid multipart/form-data body fd:%d.", ctx->fd);
+                    swWarn("invalid multipart/form-data body fd:%d", ctx->fd);
                     return 0;
                 }
                 // trim '"'
@@ -598,7 +598,7 @@ static int multipart_body_on_header_value(multipart_parser* p, const char *at, s
     if (ctx->input_var_num > PG(max_input_vars))
     {
         swoole_php_error(E_WARNING, "Input variables exceeded " ZEND_LONG_FMT ". "
-                "To increase the limit change max_input_vars in php.ini.", PG(max_input_vars));
+                "To increase the limit change max_input_vars in php.ini", PG(max_input_vars));
         return SW_OK;
     }
     else
@@ -629,7 +629,7 @@ static int multipart_body_on_header_value(multipart_parser* p, const char *at, s
 
         if (Z_STRLEN_P(form_name) >= SW_HTTP_COOKIE_KEYLEN)
         {
-            swWarn("form_name[%s] is too large.", Z_STRVAL_P(form_name));
+            swWarn("form_name[%s] is too large", Z_STRVAL_P(form_name));
             return SW_OK;
         }
 
@@ -649,7 +649,7 @@ static int multipart_body_on_header_value(multipart_parser* p, const char *at, s
         {
             if (Z_STRLEN_P(filename) >= SW_HTTP_COOKIE_KEYLEN)
             {
-                swWarn("filename[%s] is too large.", Z_STRVAL_P(filename));
+                swWarn("filename[%s] is too large", Z_STRVAL_P(filename));
                 return SW_OK;
             }
             ctx->current_input_name = estrndup(tmp, value_len);
@@ -863,7 +863,7 @@ static int http_request_on_body(swoole_http_parser *parser, const char *at, size
         size_t n = multipart_parser_execute(multipart_parser, c, length);
         if (n != length)
         {
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_INVALID_REQUEST, "parse multipart body failed, n=%zu.", n);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_INVALID_REQUEST, "parse multipart body failed, n=%zu", n);
         }
     }
 
@@ -907,7 +907,7 @@ int php_swoole_http_onReceive(swServer *serv, swEventData *req)
     swConnection *conn = swServer_connection_verify_no_ssl(serv, fd);
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[%d] is closed.", fd);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_NOT_EXIST, "connection[%d] is closed", fd);
         return SW_ERR;
     }
 
@@ -950,7 +950,7 @@ int php_swoole_http_onReceive(swServer *serv, swEventData *req)
     if (n < 0)
     {
         sw_zval_free(zdata);
-        swWarn("swoole_http_parser_execute failed.");
+        swWarn("swoole_http_parser_execute failed");
         if (conn->websocket_status == WEBSOCKET_STATUS_CONNECTION)
         {
             return serv->close(serv, fd, 1);
@@ -978,7 +978,7 @@ int php_swoole_http_onReceive(swServer *serv, swEventData *req)
         if (!conn)
         {
             sw_zval_free(zdata);
-            swWarn("connection[%d] is closed.", fd);
+            swWarn("connection[%d] is closed", fd);
             return SW_ERR;
         }
 
@@ -1021,7 +1021,7 @@ int php_swoole_http_onReceive(swServer *serv, swEventData *req)
         {
             if (PHPCoroutine::create(fci_cache, 2, args) < 0)
             {
-                swoole_php_error(E_WARNING, "create Http onRequest coroutine error.");
+                swoole_php_error(E_WARNING, "create Http onRequest coroutine error");
 #ifdef SW_HTTP_SERVICE_UNAVAILABLE_PACKET
                 serv->send(serv, fd, (char *) SW_STRL(SW_HTTP_SERVICE_UNAVAILABLE_PACKET));
 #endif
@@ -1033,7 +1033,7 @@ int php_swoole_http_onReceive(swServer *serv, swEventData *req)
             zval _retval, *retval = &_retval;
             if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
             {
-                swoole_php_error(E_WARNING, "Http onRequest handler error.");
+                swoole_php_error(E_WARNING, "Http onRequest handler error");
             }
             zval_ptr_dtor(retval);
         }
@@ -1105,7 +1105,7 @@ http_context* swoole_http_context_new(int fd)
     http_context *ctx = (http_context *) emalloc(sizeof(http_context));
     if (!ctx)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "emalloc(%ld) failed.", sizeof(http_context));
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "emalloc(%ld) failed", sizeof(http_context));
         return NULL;
     }
     bzero(ctx, sizeof(http_context));
@@ -1290,14 +1290,14 @@ void php_swoole_http_server_before_start(swServer *serv, zval *zobject)
     swoole_http_buffer = swString_new(SW_HTTP_RESPONSE_INIT_SIZE);
     if (!swoole_http_buffer)
     {
-        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
+        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed", SW_HTTP_RESPONSE_INIT_SIZE);
         return;
     }
 
     swoole_http_form_data_buffer = swString_new(SW_HTTP_RESPONSE_INIT_SIZE);
     if (!swoole_http_form_data_buffer)
     {
-        swoole_php_fatal_error(E_ERROR, "[2] swString_new(%d) failed.", SW_HTTP_RESPONSE_INIT_SIZE);
+        swoole_php_fatal_error(E_ERROR, "[2] swString_new(%d) failed", SW_HTTP_RESPONSE_INIT_SIZE);
         return;
     }
 
@@ -1399,7 +1399,7 @@ static PHP_METHOD(swoole_http_response, write)
 #ifdef SW_USE_HTTP2
     if (ctx->stream)
     {
-        swoole_php_error(E_WARNING, "Http2 client does not support HTTP-CHUNK.");
+        swoole_php_error(E_WARNING, "Http2 client does not support HTTP-CHUNK");
         RETURN_FALSE;
     }
 #endif
@@ -1428,7 +1428,7 @@ static PHP_METHOD(swoole_http_response, write)
 
     if (length == 0)
     {
-        swoole_php_error(E_WARNING, "data to send is empty.");
+        swoole_php_error(E_WARNING, "data to send is empty");
         RETURN_FALSE;
     }
     else
@@ -1476,7 +1476,7 @@ static http_context* http_get_context(zval *zobject, int check_end)
     http_context *ctx = (http_context *) swoole_get_object(zobject);
     if (!ctx || (check_end && ctx->end))
     {
-        swoole_php_fatal_error(E_WARNING, "Http request is finished.");
+        swoole_php_fatal_error(E_WARNING, "Http request is finished");
         return NULL;
     }
     return ctx;
@@ -1741,7 +1741,7 @@ int swoole_http_response_compress(swString *body, int method, int level)
             input_size, input_buffer, &encoded_size, encoded_buffer
         ))
         {
-            swWarn("BrotliEncoderCompress() failed.");
+            swWarn("BrotliEncoderCompress() failed");
             return SW_ERR;
         }
         else
@@ -1803,7 +1803,7 @@ int swoole_http_response_compress(swString *body, int method, int level)
     }
     else
     {
-        swWarn("deflateInit2() failed, Error: [%d].", retval);
+        swWarn("deflateInit2() failed, Error: [%d]", retval);
     }
     return SW_ERR;
 }
@@ -1989,7 +1989,7 @@ static PHP_METHOD(swoole_http_response, sendfile)
     }
     if (filename_length <= 0)
     {
-        swoole_php_error(E_WARNING, "file name is empty.");
+        swoole_php_error(E_WARNING, "file name is empty");
         RETURN_FALSE;
     }
 
@@ -2005,29 +2005,29 @@ static PHP_METHOD(swoole_http_response, sendfile)
 
     if (ctx->chunk)
     {
-        swoole_php_fatal_error(E_ERROR, "can't use sendfile when Http-Chunk is enabled.");
+        swoole_php_fatal_error(E_ERROR, "can't use sendfile when Http-Chunk is enabled");
         RETURN_FALSE;
     }
 
     struct stat file_stat;
     if (stat(filename, &file_stat) < 0)
     {
-        swoole_php_sys_error(E_WARNING, "stat(%s) failed.", filename);
+        swoole_php_sys_error(E_WARNING, "stat(%s) failed", filename);
         RETURN_FALSE;
     }
     if (file_stat.st_size == 0)
     {
-        swoole_php_sys_error(E_WARNING, "can't send empty file[%s].", filename);
+        swoole_php_sys_error(E_WARNING, "can't send empty file[%s]", filename);
         RETURN_FALSE;
     }
     if (file_stat.st_size <= offset)
     {
-        swoole_php_error(E_WARNING, "parameter $offset[" ZEND_LONG_FMT "] exceeds the file size.", offset);
+        swoole_php_error(E_WARNING, "parameter $offset[" ZEND_LONG_FMT "] exceeds the file size", offset);
         RETURN_FALSE;
     }
     if (length > file_stat.st_size - offset)
     {
-        swoole_php_sys_error(E_WARNING, "parameter $length[" ZEND_LONG_FMT "] exceeds the file size.", length);
+        swoole_php_sys_error(E_WARNING, "parameter $length[" ZEND_LONG_FMT "] exceeds the file size", length);
         RETURN_FALSE;
     }
     if (length == 0)
@@ -2226,12 +2226,12 @@ static PHP_METHOD(swoole_http_response, header)
     }
     if (klen > SW_HTTP_HEADER_KEY_SIZE - 1)
     {
-        swoole_php_error(E_WARNING, "header key is too long.");
+        swoole_php_error(E_WARNING, "header key is too long");
         RETURN_FALSE;
     }
     if (vlen > SW_HTTP_HEADER_VALUE_SIZE)
     {
-        swoole_php_error(E_WARNING, "header value is too long.");
+        swoole_php_error(E_WARNING, "header value is too long");
         RETURN_FALSE;
     }
 
@@ -2285,12 +2285,12 @@ static PHP_METHOD(swoole_http_response, trailer)
     }
     if (klen > SW_HTTP_HEADER_KEY_SIZE - 1)
     {
-        swoole_php_error(E_WARNING, "trailer key is too long.");
+        swoole_php_error(E_WARNING, "trailer key is too long");
         RETURN_FALSE;
     }
     if (vlen > SW_HTTP_HEADER_VALUE_SIZE)
     {
-        swoole_php_error(E_WARNING, "trailer value is too long.");
+        swoole_php_error(E_WARNING, "trailer value is too long");
         RETURN_FALSE;
     }
 
@@ -2341,7 +2341,7 @@ static PHP_METHOD(swoole_http_response, create)
     http_context *ctx = (http_context *) emalloc(sizeof(http_context));
     if (!ctx)
     {
-        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "emalloc(%ld) failed.", sizeof(http_context));
+        swoole_error_log(SW_LOG_ERROR, SW_ERROR_MALLOC_FAIL, "emalloc(%ld) failed", sizeof(http_context));
         RETURN_FALSE;
     }
     bzero(ctx, sizeof(http_context));

--- a/swoole_http_v2_client_coro.cc
+++ b/swoole_http_v2_client_coro.cc
@@ -268,7 +268,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
 
     if (host_len == 0)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "host is empty.", SW_ERROR_INVALID_PARAMS);
+        zend_throw_exception(swoole_exception_ce_ptr, "host is empty", SW_ERROR_INVALID_PARAMS);
         RETURN_FALSE;
     }
 
@@ -281,7 +281,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
         type |= SW_SOCK_SSL;
         hcc->ssl = 1;
 #else
-        swoole_php_fatal_error(E_ERROR, "Need to use `--enable-openssl` to support ssl when compiling swoole.");
+        swoole_php_fatal_error(E_ERROR, "Need to use `--enable-openssl` to support ssl when compiling swoole");
 #endif
     }
     hcc->host = estrndup(host, host_len);
@@ -350,7 +350,7 @@ int http2_client_parse_header(http2_client_property *hcc, http2_client_stream *s
         rv = nghttp2_hd_inflate_hd(hcc->inflater, &nv, &inflate_flags, (uchar *) in, inlen, 1);
         if (rv < 0)
         {
-            swoole_php_error(E_WARNING, "inflate failed, Error: %s[%zd].", nghttp2_strerror(rv), rv);
+            swoole_php_error(E_WARNING, "inflate failed, Error: %s[%zd]", nghttp2_strerror(rv), rv);
             return SW_ERR;
         }
 
@@ -376,7 +376,7 @@ int http2_client_parse_header(http2_client_property *hcc, http2_client_stream *s
                 http2_client_init_gzip_stream(stream);
                 if (Z_OK != inflateInit2(&stream->gzip_stream, MAX_WBITS + 16))
                 {
-                    swWarn("inflateInit2() failed.");
+                    swWarn("inflateInit2() failed");
                     return SW_ERR;
                 }
             }
@@ -508,7 +508,7 @@ static ssize_t http2_client_build_header(zval *zobject, zval *zrequest, char *bu
     size_t buflen = nghttp2_hd_deflate_bound(hcc->deflater, headers.get(), headers.len());
     if (buflen > hcc->remote_settings.max_header_list_size)
     {
-        swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u.", hcc->remote_settings.max_header_list_size);
+        swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u", hcc->remote_settings.max_header_list_size);
         return -1;
     }
     ssize_t rv = nghttp2_hd_deflate_hd(hcc->deflater, (uchar *) buffer, buflen, headers.get(), headers.len());
@@ -570,19 +570,19 @@ static void http2_client_onReceive(swClient *cli, char *buf, uint32_t _length)
                         return;
                     }
                 }
-                swTraceLog(SW_TRACE_HTTP2, "setting: header_compression_table_max=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: header_compression_table_max=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS:
                 hcc->remote_settings.max_concurrent_streams = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_concurrent_streams=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_concurrent_streams=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_INIT_WINDOW_SIZE:
                 hcc->remote_settings.window_size = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: init_send_window=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: init_send_window=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_FRAME_SIZE:
                 hcc->remote_settings.max_frame_size = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_frame_size=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_frame_size=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE:
                 if (value != hcc->remote_settings.max_header_list_size)
@@ -596,11 +596,11 @@ static void http2_client_onReceive(swClient *cli, char *buf, uint32_t _length)
                         return;
                     }
                 }
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_header_list_size=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_header_list_size=%u", value);
                 break;
             default:
                 // disable warning and ignore it because some websites are not following http2 protocol totally
-                // swWarn("unknown option[%d]: %d.", id, value);
+                // swWarn("unknown option[%d]: %d", id, value);
                 break;
             }
             buf += sizeof(id) + sizeof(value);
@@ -853,7 +853,7 @@ static uint32_t http2_client_send_request(zval *zobject, zval *req)
     length = http2_client_build_header(zobject, req, buffer + SW_HTTP2_FRAME_HEADER_SIZE);
     if (length <= 0)
     {
-        swWarn("http2_client_build_header() failed.");
+        swWarn("http2_client_build_header() failed");
         return 0;
     }
 
@@ -910,7 +910,7 @@ static uint32_t http2_client_send_request(zval *zobject, zval *req)
             p = sw_http_build_query(zdata, &len, &formstr_s);
             if (p == NULL)
             {
-                swoole_php_error(E_WARNING, "http_build_query failed.");
+                swoole_php_error(E_WARNING, "http_build_query failed");
                 return 0;
             }
         }
@@ -979,7 +979,7 @@ static int http2_client_send_data(http2_client_property *hcc, uint32_t stream_id
         char *formstr = sw_http_build_query(data, &len, &formstr_s);
         if (formstr == NULL)
         {
-            swoole_php_error(E_WARNING, "http_build_query failed.");
+            swoole_php_error(E_WARNING, "http_build_query failed");
             return -1;
         }
         memset(buffer, 0, SW_HTTP2_FRAME_HEADER_SIZE);
@@ -998,7 +998,7 @@ static int http2_client_send_data(http2_client_property *hcc, uint32_t stream_id
     }
     else
     {
-        swoole_php_error(E_WARNING, "unknown data type[%d].", Z_TYPE_P(data) );
+        swoole_php_error(E_WARNING, "unknown data type[%d]", Z_TYPE_P(data) );
         return -1;
     }
     return SW_OK;
@@ -1011,8 +1011,8 @@ static PHP_METHOD(swoole_http2_client_coro, send)
     if (!hcc->streams)
     {
         zend_update_property_long(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION));
-        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server.");
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         RETURN_FALSE;
     }
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &request) == FAILURE)
@@ -1021,7 +1021,7 @@ static PHP_METHOD(swoole_http2_client_coro, send)
     }
     if (Z_TYPE_P(request) != IS_OBJECT || !instanceof_function(Z_OBJCE_P(request), swoole_http2_request_ce_ptr))
     {
-        swoole_php_fatal_error(E_ERROR, "object is not instanceof swoole_http2_request.");
+        swoole_php_fatal_error(E_ERROR, "object is not instanceof swoole_http2_request");
         RETURN_FALSE;
     }
 
@@ -1043,8 +1043,8 @@ static PHP_METHOD(swoole_http2_client_coro, recv)
     if (!hcc->streams)
     {
         zend_update_property_long(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION));
-        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server.");
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         RETURN_FALSE;
     }
 
@@ -1089,14 +1089,14 @@ static void http2_client_onConnect(swClient *cli)
     ret = nghttp2_hd_inflate_new(&hcc->inflater);
     if (ret != 0)
     {
-        swoole_php_error(E_WARNING, "nghttp2_hd_inflate_init() failed with error: %s[%d].", nghttp2_strerror(ret), ret);
+        swoole_php_error(E_WARNING, "nghttp2_hd_inflate_init() failed with error: %s[%d]", nghttp2_strerror(ret), ret);
         cli->close(cli);
         return;
     }
     ret = nghttp2_hd_deflate_new(&hcc->deflater, hcc->local_settings.header_table_size);
     if (ret != 0)
     {
-        swoole_php_error(E_WARNING, "nghttp2_hd_deflate_init() failed with error: %s[%d].", nghttp2_strerror(ret), ret);
+        swoole_php_error(E_WARNING, "nghttp2_hd_deflate_init() failed with error: %s[%d]", nghttp2_strerror(ret), ret);
         cli->close(cli);
         return;
     }
@@ -1234,7 +1234,7 @@ static PHP_METHOD(swoole_http2_client_coro, connect)
 
     if (hcc->client)
     {
-        swoole_php_fatal_error(E_WARNING, "The HTTP2 connection has already been established.");
+        swoole_php_fatal_error(E_WARNING, "The HTTP2 connection has already been established");
         RETURN_FALSE;
     }
 
@@ -1382,8 +1382,8 @@ static PHP_METHOD(swoole_http2_client_coro, write)
     if (!hcc->streams)
     {
         zend_update_property_long(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION));
-        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server.");
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         RETURN_FALSE;
     }
 
@@ -1405,8 +1405,8 @@ static PHP_METHOD(swoole_http2_client_coro, ping)
     if (!hcc->streams)
     {
         zend_update_property_long(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION));
-        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server.");
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         RETURN_FALSE;
     }
 
@@ -1447,8 +1447,8 @@ static PHP_METHOD(swoole_http2_client_coro, goaway)
     if (!hcc->streams)
     {
         zend_update_property_long(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), (SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION));
-        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server.");
-        swoole_php_error(E_WARNING, "client is not connected to server.");
+        zend_update_property_string(swoole_http2_client_coro_ce_ptr, getThis(), ZEND_STRL("errMsg"), "client is not connected to server");
+        swoole_php_error(E_WARNING, "client is not connected to server");
         RETURN_FALSE;
     }
 

--- a/swoole_http_v2_server.cc
+++ b/swoole_http_v2_server.cc
@@ -151,7 +151,7 @@ static ssize_t http_build_trailer(http_context *ctx, uchar *buffer)
         buflen = nghttp2_hd_deflate_bound(deflater, trailer.get(), trailer.len());
         if (buflen > SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE)
         {
-            swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u.", SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE);
+            swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u", SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE);
             return -1;
         }
         rv = nghttp2_hd_deflate_hd(deflater, (uchar *) buffer, buflen, trailer.get(), trailer.len());
@@ -181,7 +181,7 @@ static sw_inline void http2_onRequest(http_context *ctx, int from_fd)
     {
         if (PHPCoroutine::create(fci_cache, 2, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create Http2 onRequest coroutine error.");
+            swoole_php_error(E_WARNING, "create Http2 onRequest coroutine error");
             serv->factory.end(&serv->factory, fd);
         }
     }
@@ -190,7 +190,7 @@ static sw_inline void http2_onRequest(http_context *ctx, int from_fd)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "Http2 onRequest handler error.");
+            swoole_php_error(E_WARNING, "Http2 onRequest handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -334,7 +334,7 @@ static int http2_build_header(http_context *ctx, uchar *buffer, size_t body_leng
     size_t buflen = nghttp2_hd_deflate_bound(deflater, headers.get(), headers.len());
     if (buflen > SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE)
     {
-        swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u.", SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE);
+        swoole_php_error(E_WARNING, "header cannot bigger than remote max_header_list_size %u", SW_HTTP2_DEFAULT_MAX_HEADER_LIST_SIZE);
         return -1;
     }
     ssize_t rv = nghttp2_hd_deflate_hd(deflater, (uchar *) buffer, buflen, headers.get(), headers.len());
@@ -509,7 +509,7 @@ static int http2_parse_header(http2_session *client, http_context *ctx, int flag
         int ret = nghttp2_hd_inflate_new(&inflater);
         if (ret != 0)
         {
-            swWarn("nghttp2_hd_inflate_init() failed, Error: %s[%d].", nghttp2_strerror(ret), ret);
+            swWarn("nghttp2_hd_inflate_init() failed, Error: %s[%d]", nghttp2_strerror(ret), ret);
             return SW_ERR;
         }
         client->inflater = inflater;
@@ -536,7 +536,7 @@ static int http2_parse_header(http2_session *client, http_context *ctx, int flag
         rv = nghttp2_hd_inflate_hd(inflater, &nv, &inflate_flags, (uchar *) in, inlen, 1);
         if (rv < 0)
         {
-            swWarn("inflate failed, Error: %s[%zd].", nghttp2_strerror(rv), rv);
+            swWarn("inflate failed, Error: %s[%zd]", nghttp2_strerror(rv), rv);
             return SW_ERR;
         }
 
@@ -604,7 +604,7 @@ static int http2_parse_header(http2_session *client, http_context *ctx, int flag
                         int boundary_len = nv.valuelen - strlen("multipart/form-data; boundary=");
                         if (boundary_len <= 0)
                         {
-                            swWarn("invalid multipart/form-data body fd:%d.", ctx->fd);
+                            swWarn("invalid multipart/form-data body fd:%d", ctx->fd);
                             return SW_ERR;
                         }
                         swoole_http_parse_form_data(ctx, (char*) nv.value + nv.valuelen - boundary_len, boundary_len);
@@ -707,27 +707,27 @@ int swoole_http2_onFrame(swConnection *conn, swEventData *req)
             switch (id)
             {
             case SW_HTTP2_SETTING_HEADER_TABLE_SIZE:
-                swTraceLog(SW_TRACE_HTTP2, "setting: header_compression_table_max=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: header_compression_table_max=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS:
                 client->max_concurrent_streams = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_concurrent_streams=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_concurrent_streams=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_INIT_WINDOW_SIZE:
                 client->send_window = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: init_send_window=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: init_send_window=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_FRAME_SIZE:
                 client->max_frame_size = value;
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_frame_size=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_frame_size=%u", value);
                 break;
             case SW_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE:
                 // client->max_header_list_size = value; // useless now
-                swTraceLog(SW_TRACE_HTTP2, "setting: max_header_list_size=%u.", value);
+                swTraceLog(SW_TRACE_HTTP2, "setting: max_header_list_size=%u", value);
                 break;
             default:
                 // disable warning and ignore it because some websites are not following http2 protocol totally
-                // swWarn("unknown option[%d]: %d.", id, value);
+                // swWarn("unknown option[%d]: %d", id, value);
                 break;
             }
             buf += sizeof(id) + sizeof(value);
@@ -745,7 +745,7 @@ int swoole_http2_onFrame(swConnection *conn, swEventData *req)
             if (unlikely(!stream->ctx))
             {
                 zval_ptr_dtor(&zdata);
-                swoole_error_log(SW_LOG_WARNING, SW_ERROR_HTTP2_STREAM_NO_HEADER, "http2 create stream#%d context error.", stream_id);
+                swoole_error_log(SW_LOG_WARNING, SW_ERROR_HTTP2_STREAM_NO_HEADER, "http2 create stream#%d context error", stream_id);
                 return SW_ERR;
             }
             client->streams[stream_id] = stream;
@@ -791,7 +791,7 @@ int swoole_http2_onFrame(swConnection *conn, swEventData *req)
         if (stream_iterator == client->streams.end())
         {
             zval_ptr_dtor(&zdata);
-            swoole_error_log(SW_LOG_WARNING, SW_ERROR_HTTP2_STREAM_NOT_FOUND, "http2 stream#%d not found.", stream_id);
+            swoole_error_log(SW_LOG_WARNING, SW_ERROR_HTTP2_STREAM_NOT_FOUND, "http2 stream#%d not found", stream_id);
             return SW_ERR;
         }
         stream = stream_iterator->second;
@@ -840,7 +840,7 @@ int swoole_http2_onFrame(swConnection *conn, swEventData *req)
                 size_t n = multipart_parser_execute(multipart_parser, buffer->str, buffer->length);
                 if (n != (size_t) length)
                 {
-                    swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_INVALID_REQUEST, "parse multipart body failed, n=%zu.", n);
+                    swoole_error_log(SW_LOG_WARNING, SW_ERROR_SERVER_INVALID_REQUEST, "parse multipart body failed, n=%zu", n);
                 }
             }
             http2_onRequest(ctx, from_fd);

--- a/swoole_lock.c
+++ b/swoole_lock.c
@@ -100,7 +100,7 @@ static PHP_METHOD(swoole_lock, __construct)
     swLock *lock = SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swLock));
     if (lock == NULL)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure.", SW_ERROR_MALLOC_FAIL);
+        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
 
@@ -114,7 +114,7 @@ static PHP_METHOD(swoole_lock, __construct)
     case SW_FILELOCK:
         if (filelock_len == 0)
         {
-            zend_throw_exception(swoole_exception_ce_ptr, "filelock requires file name of the lock.", SW_ERROR_INVALID_PARAMS);
+            zend_throw_exception(swoole_exception_ce_ptr, "filelock requires file name of the lock", SW_ERROR_INVALID_PARAMS);
             RETURN_FALSE;
         }
         int fd;
@@ -142,7 +142,7 @@ static PHP_METHOD(swoole_lock, __construct)
     }
     if (ret < 0)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "failed to create lock.", errno);
+        zend_throw_exception(swoole_exception_ce_ptr, "failed to create lock", errno);
         RETURN_FALSE;
     }
     swoole_set_object(getThis(), lock);
@@ -177,7 +177,7 @@ static PHP_METHOD(swoole_lock, lockwait)
     swLock *lock = swoole_get_object(getThis());
     if (lock->type != SW_MUTEX)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "only mutex supports lockwait.", -2);
+        zend_throw_exception(swoole_exception_ce_ptr, "only mutex supports lockwait", -2);
         RETURN_FALSE;
     }
     SW_LOCK_CHECK_RETURN(swMutex_lockwait(lock, (int)timeout * 1000));

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -593,7 +593,7 @@ static ssize_t mysql_decode_row(mysql_client *client, char *buf, uint32_t packet
     bzero(&row, sizeof(row));
     array_init(row_array);
 
-    swTraceLog(SW_TRACE_MYSQL_CLIENT, "mysql_decode_row begin, num_column=%ld, packet_length=%u.", client->response.num_column, packet_length);
+    swTraceLog(SW_TRACE_MYSQL_CLIENT, "mysql_decode_row begin, num_column=%ld, packet_length=%u", client->response.num_column, packet_length);
 
     mysql_field *field = NULL;
 
@@ -774,7 +774,7 @@ static ssize_t mysql_decode_row(mysql_client *client, char *buf, uint32_t packet
             break;
 
         default:
-            swWarn("unknown field type[%d].", field->type);
+            swWarn("unknown field type[%d]", field->type);
             read_n = SW_ERR;
             _error:
             zval_ptr_dtor(row_array);
@@ -881,7 +881,7 @@ static ssize_t mysql_decode_row_prepare(mysql_client *client, char *buf, uint32_
     zval *row_array = sw_malloc_zval();
     array_init(row_array);
 
-    swTraceLog(SW_TRACE_MYSQL_CLIENT, "mysql_decode_row begin, num_column=%ld, packet_length=%u.", client->response.num_column, packet_length);
+    swTraceLog(SW_TRACE_MYSQL_CLIENT, "mysql_decode_row begin, num_column=%ld, packet_length=%u", client->response.num_column, packet_length);
 
     mysql_field *field = NULL;
     for (i = 0; i < client->response.num_column; i++)
@@ -1067,7 +1067,7 @@ static ssize_t mysql_decode_row_prepare(mysql_client *client, char *buf, uint32_
             break;
 
         default:
-            swWarn("unknown field type[%d].", field->type);
+            swWarn("unknown field type[%d]", field->type);
             read_n = SW_ERR;
             _error:
             zval_ptr_dtor(row_array);
@@ -1120,18 +1120,18 @@ static int mysql_query(zval *zobject, mysql_client *client, swString *sql, zval 
     if (!client->cli)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
-        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed.", client->fd);
+        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed", client->fd);
         return SW_ERR;
     }
     if (!client->connected)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
-        swoole_php_error(E_WARNING, "mysql client is not connected to server.");
+        swoole_php_error(E_WARNING, "mysql client is not connected to server");
         return SW_ERR;
     }
     if (client->state != SW_MYSQL_STATE_QUERY)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query.");
+        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query");
         return SW_ERR;
     }
 
@@ -1230,7 +1230,7 @@ static int mysql_parse_prepare_result(mysql_client *client, char *buf, size_t n_
 
     MYSQL_RESPONSE_BUFFER->offset += SW_MYSQL_PACKET_HEADER_SIZE + client->response.packet_length;
 
-    swTraceLog(SW_TRACE_MYSQL_CLIENT, "stmt_id=%u, field_count=%u, param_count=%u, warning_count=%u.", stmt->id,
+    swTraceLog(SW_TRACE_MYSQL_CLIENT, "stmt_id=%u, field_count=%u, param_count=%u, warning_count=%u", stmt->id,
             stmt->field_count, stmt->param_count, stmt->warning_count);
 
     return SW_OK;
@@ -1443,7 +1443,7 @@ static int mysql_read_columns(mysql_client *client)
 
     for (; client->response.index_column < client->response.num_column; client->response.index_column++)
     {
-        swTraceLog(SW_TRACE_MYSQL_CLIENT, "index_index_column=%ld, n_buf=%zu.", client->response.index_column, (uintmax_t) n_buf);
+        swTraceLog(SW_TRACE_MYSQL_CLIENT, "index_index_column=%ld, n_buf=%zu", client->response.index_column, (uintmax_t) n_buf);
 
         // Ensure that we've received the complete packet
         if (mysql_ensure_packet(p, n_buf) == SW_ERR)
@@ -1469,7 +1469,7 @@ static int mysql_read_columns(mysql_client *client)
         }
         else
         {
-            swWarn("mysql_decode_field failed, code=%d.", ret);
+            swWarn("mysql_decode_field failed, code=%d", ret);
             return ret < 0 ? ret : SW_ERR;
         }
     }
@@ -1485,7 +1485,7 @@ static int mysql_read_columns(mysql_client *client)
 
     if (mysql_read_eof(client, p, n_buf) != SW_OK)
     {
-        swWarn("unexpected mysql non-eof packet.");
+        swWarn("unexpected mysql non-eof packet");
         return SW_ERR;
     }
 
@@ -1513,7 +1513,7 @@ static sw_inline int mysql_read_params(mysql_client *client)
         char *p = buffer->str + buffer->offset;
         size_t n_buf = buffer->length - buffer->offset;
 
-        swTraceLog(SW_TRACE_MYSQL_CLIENT, "n_buf=%zu, length=%u.", (uintmax_t) n_buf, client->response.packet_length);
+        swTraceLog(SW_TRACE_MYSQL_CLIENT, "n_buf=%zu, length=%u", (uintmax_t) n_buf, client->response.packet_length);
 
         // Ensure that we've received the complete packet
         if (mysql_ensure_packet(p, n_buf) == SW_ERR)
@@ -1533,7 +1533,7 @@ static sw_inline int mysql_read_params(mysql_client *client)
 
             swMysqlPacketDump(p, SW_MYSQL_PACKET_HEADER_SIZE + client->response.packet_length, "Protocol::ParameterDefinition");
 
-            swTraceLog(SW_TRACE_MYSQL_CLIENT, "read param, count=%d.", client->statement->unreaded_param_count);
+            swTraceLog(SW_TRACE_MYSQL_CLIENT, "read param, count=%d", client->statement->unreaded_param_count);
 
             continue;
         }
@@ -1743,7 +1743,7 @@ static int mysql_response(mysql_client *client)
     while ((n_buf = buffer->length - buffer->offset) > 0)
     {
         p = buffer->str + buffer->offset;
-        swTraceLog(SW_TRACE_MYSQL_CLIENT, "client->state=%d, n_buf=%zu.", client->state, n_buf);
+        swTraceLog(SW_TRACE_MYSQL_CLIENT, "client->state=%d, n_buf=%zu", client->state, n_buf);
 
         switch (client->state)
         {
@@ -1811,7 +1811,7 @@ static int mysql_response(mysql_client *client)
                 }
                 buffer->offset += (SW_MYSQL_PACKET_HEADER_SIZE + ret);
 
-                swTraceLog(SW_TRACE_MYSQL_CLIENT, "ResultSet_Packet: num_of_fields=%lu.", client->response.num_column);
+                swTraceLog(SW_TRACE_MYSQL_CLIENT, "ResultSet_Packet: num_of_fields=%lu", client->response.num_column);
 
                 // easy to the safe side: but under what circumstances would num_column will be 0 in result set?
                 if (client->response.num_column > 0)
@@ -2434,20 +2434,20 @@ static int swoole_mysql_coro_execute(zval *zobject, mysql_client *client, zval *
 
     if (!client->cli || client->state == SW_MYSQL_STATE_CLOSED)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed.", client->fd);
+        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed", client->fd);
         return SW_ERR;
     }
 
     if (client->state != SW_MYSQL_STATE_QUERY)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query.");
+        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query");
         return SW_ERR;
     }
 
     mysql_statement *statement = (mysql_statement *) swoole_get_object(zobject);
     if (!statement)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql preparation is not ready.");
+        swoole_php_fatal_error(E_WARNING, "mysql preparation is not ready");
         return SW_ERR;
     }
 
@@ -2463,7 +2463,7 @@ static int swoole_mysql_coro_execute(zval *zobject, mysql_client *client, zval *
 
     if (param_count != statement->param_count)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql statement#%u expects %u parameter, %u given.", statement->id, statement->param_count, param_count);
+        swoole_php_fatal_error(E_WARNING, "mysql statement#%u expects %u parameter, %u given", statement->id, statement->param_count, param_count);
         return SW_ERR;
     }
 
@@ -2588,7 +2588,7 @@ static int swoole_mysql_coro_parse_response(mysql_client *client, zval **result,
         }
         else // handler error
         {
-            static const char* errmsg = "mysql response packet parse error.";
+            static const char* errmsg = "mysql response packet parse error";
             client->response.response_type = SW_MYSQL_PACKET_ERR;
             client->response.error_code = ret;
             client->response.server_msg = (char *) errmsg;
@@ -2786,7 +2786,7 @@ static int swoole_mysql_coro_close(zval *zobject)
     mysql_client *client = (mysql_client *) swoole_get_object(zobject);
     if (!client)
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql_coro.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql_coro");
         return FAILURE;
     }
 
@@ -2896,7 +2896,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
     mysql_client *client = (mysql_client *) swoole_get_object(getThis());
     if (client->cli)
     {
-        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established.");
+        swoole_php_fatal_error(E_WARNING, "connection to the server has already been established");
         RETURN_FALSE;
     }
 
@@ -2914,7 +2914,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
     }
     else
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "HOST parameter is required.", 11);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "HOST parameter is required", 11);
         RETURN_FALSE;
     }
     if (php_swoole_array_get_value(_ht, "port", value))
@@ -2933,7 +2933,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
     }
     else
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "USER parameter is required.", 11);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "USER parameter is required", 11);
         RETURN_FALSE;
     }
     if (php_swoole_array_get_value(_ht, "password", value))
@@ -2944,7 +2944,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
     }
     else
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "PASSWORD parameter is required.", 11);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "PASSWORD parameter is required", 11);
         RETURN_FALSE;
     }
     if (php_swoole_array_get_value(_ht, "database", value))
@@ -2955,7 +2955,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
     }
     else
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "DATABASE parameter is required.", 11);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "DATABASE parameter is required", 11);
         RETURN_FALSE;
     }
     if (php_swoole_array_get_value(_ht, "timeout", value))
@@ -2973,7 +2973,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
         if (connector->character_set < 0)
         {
             char buf[64];
-            snprintf(buf, sizeof(buf), "unknown charset [%s].", str_charset.val());
+            snprintf(buf, sizeof(buf), "unknown charset [%s]", str_charset.val());
             zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, buf, 11);
             RETURN_FALSE;
         }
@@ -3035,7 +3035,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
         int tcp_nodelay = 1;
         if (setsockopt(cli->socket->fd, IPPROTO_TCP, TCP_NODELAY, (const void *) &tcp_nodelay, sizeof(int)) != 0)
         {
-            swoole_php_sys_error(E_WARNING, "setsockopt(%d, IPPROTO_TCP, TCP_NODELAY) failed.", cli->socket->fd);
+            swoole_php_sys_error(E_WARNING, "setsockopt(%d, IPPROTO_TCP, TCP_NODELAY) failed", cli->socket->fd);
         }
     }
 
@@ -3106,13 +3106,13 @@ static PHP_METHOD(swoole_mysql_coro, query)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
         zend_update_property_long(swoole_mysql_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
-        swoole_php_fatal_error(E_WARNING, "The MySQL connection is not established.");
+        swoole_php_fatal_error(E_WARNING, "The MySQL connection is not established");
         RETURN_FALSE;
     }
 
     if (client->iowait == SW_MYSQL_CORO_STATUS_DONE)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql client is waiting for calling recv, cannot send new sql query.");
+        swoole_php_fatal_error(E_WARNING, "mysql client is waiting for calling recv, cannot send new sql query");
         RETURN_FALSE;
     }
 
@@ -3127,7 +3127,7 @@ static PHP_METHOD(swoole_mysql_coro, query)
 
     if (sql.length <= 0)
     {
-        swoole_php_fatal_error(E_WARNING, "Query is empty.");
+        swoole_php_fatal_error(E_WARNING, "Query is empty");
         RETURN_FALSE;
     }
 
@@ -3194,7 +3194,7 @@ static void swoole_mysql_coro_query_transcation(const char* command, uint8_t in_
     mysql_client *client = (mysql_client *) swoole_get_object(getThis());
     if (!client)
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql");
         RETURN_FALSE;
     }
 
@@ -3208,20 +3208,20 @@ static void swoole_mysql_coro_query_transcation(const char* command, uint8_t in_
         swoole_php_fatal_error(
             E_DEPRECATED,
             "you should not use defer to handle transaction, "
-            "if you want, please use `query` instead."
+            "if you want, please use `query` instead"
         );
         RETURN_FALSE;
     }
 
     if (in_transaction && client->transaction)
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "There is already an active transaction.", 21);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "There is already an active transaction", 21);
         RETURN_FALSE;
     }
 
     if (!in_transaction && !client->transaction)
     {
-        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "There is no active transaction.", 22);
+        zend_throw_exception(swoole_mysql_coro_exception_ce_ptr, "There is no active transaction", 22);
         RETURN_FALSE;
     }
 
@@ -3318,7 +3318,7 @@ static PHP_METHOD(swoole_mysql_coro, recv)
 
     if (client->iowait != SW_MYSQL_CORO_STATUS_WAIT)
     {
-        swoole_php_fatal_error(E_WARNING, "no request.");
+        swoole_php_fatal_error(E_WARNING, "no request");
         RETURN_FALSE;
     }
 
@@ -3338,13 +3338,13 @@ static PHP_METHOD(swoole_mysql_coro, prepare)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
         zend_update_property_long(swoole_mysql_coro_ce_ptr, getThis(), ZEND_STRL("errCode"), SwooleG.error);
-        swoole_php_fatal_error(E_WARNING, "The MySQL connection is not established.");
+        swoole_php_fatal_error(E_WARNING, "The MySQL connection is not established");
         RETURN_FALSE;
     }
 
     if (client->state != SW_MYSQL_STATE_QUERY)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query.");
+        swoole_php_fatal_error(E_WARNING, "mysql client is waiting response, cannot send new sql query");
         RETURN_FALSE;
     }
 
@@ -3358,7 +3358,7 @@ static PHP_METHOD(swoole_mysql_coro, prepare)
     }
     if (sql.length <= 0)
     {
-        swoole_php_fatal_error(E_WARNING, "Query is empty.");
+        swoole_php_fatal_error(E_WARNING, "Query is empty");
         RETURN_FALSE;
     }
 
@@ -3417,7 +3417,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, execute)
     mysql_client *client = stmt->client;
     if (!client->cli)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed.", client->fd);
+        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed", client->fd);
         RETURN_FALSE;
     }
 
@@ -3604,32 +3604,32 @@ static PHP_METHOD(swoole_mysql_coro, escape)
     mysql_client *client = (mysql_client *) swoole_get_object(getThis());
     if (!client)
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_mysql");
         RETURN_FALSE;
     }
     if (!client->cli)
     {
-        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed.", client->fd);
+        swoole_php_fatal_error(E_WARNING, "mysql connection#%d is closed", client->fd);
         RETURN_FALSE;
     }
 
     char *newstr = (char *) safe_emalloc(2, str.length + 1, 1);
     if (newstr == NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "emalloc(%ld) failed.", str.length + 1);
+        swoole_php_fatal_error(E_ERROR, "emalloc(%ld) failed", str.length + 1);
         RETURN_FALSE;
     }
 
     const MYSQLND_CHARSET* cset = mysqlnd_find_charset_nr(client->connector.character_set);
     if (cset == NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "unknown mysql charset[%d].", client->connector.character_set);
+        swoole_php_fatal_error(E_ERROR, "unknown mysql charset[%d]", client->connector.character_set);
         RETURN_FALSE;
     }
     int newstr_len = mysqlnd_cset_escape_slashes(cset, newstr, str.str, str.length);
     if (newstr_len < 0)
     {
-        swoole_php_fatal_error(E_ERROR, "mysqlnd_cset_escape_slashes() failed.");
+        swoole_php_fatal_error(E_ERROR, "mysqlnd_cset_escape_slashes() failed");
         RETURN_FALSE;
     }
     RETVAL_STRINGL(newstr, newstr_len);
@@ -3877,7 +3877,7 @@ static int swoole_mysql_coro_onHandShake(mysql_client *client)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysWarn("Read from socket[%d] failed.", cli->socket->fd);
+            swSysWarn("Read from socket[%d] failed", cli->socket->fd);
             return SW_ERR;
         case SW_CLOSE:
             _system_call_error:
@@ -4073,7 +4073,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
     while(1)
     {
         ret = recv(sock, buffer->str + buffer->length, buffer->size - buffer->length, 0);
-        swTraceLog(SW_TRACE_MYSQL_CLIENT, "recv-ret=%d, buffer-length=%zu.", ret, buffer->length);
+        swTraceLog(SW_TRACE_MYSQL_CLIENT, "recv-ret=%d, buffer-length=%zu", ret, buffer->length);
         if (ret < 0)
         {
             if (errno == EINTR)
@@ -4085,7 +4085,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
                 switch (swConnection_error(errno))
                 {
                 case SW_ERROR:
-                    swSysWarn("Read from socket[%d] failed.", event->fd);
+                    swSysWarn("Read from socket[%d] failed", event->fd);
                     return SW_ERR;
                 case SW_CLOSE:
                     goto _close_fd;
@@ -4151,7 +4151,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
             {
                 if (swString_extend(buffer, buffer->size * 2) < 0)
                 {
-                    swoole_php_fatal_error(E_ERROR, "malloc failed.");
+                    swoole_php_fatal_error(E_ERROR, "malloc failed");
                     reactor->del(SwooleG.main_reactor, event->fd);
                 }
                 continue;

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -3838,7 +3838,7 @@ static int swoole_mysql_coro_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swSysError("getsockopt(%d) failed", event->fd);
+        swSysWarn("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 
@@ -3877,7 +3877,7 @@ static int swoole_mysql_coro_onHandShake(mysql_client *client)
         switch (swConnection_error(errno))
         {
         case SW_ERROR:
-            swSysError("Read from socket[%d] failed.", cli->socket->fd);
+            swSysWarn("Read from socket[%d] failed.", cli->socket->fd);
             return SW_ERR;
         case SW_CLOSE:
             _system_call_error:
@@ -4085,7 +4085,7 @@ static int swoole_mysql_coro_onRead(swReactor *reactor, swEvent *event)
                 switch (swConnection_error(errno))
                 {
                 case SW_ERROR:
-                    swSysError("Read from socket[%d] failed.", event->fd);
+                    swSysWarn("Read from socket[%d] failed.", event->fd);
                     return SW_ERR;
                 case SW_CLOSE:
                     goto _close_fd;

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -3017,7 +3017,7 @@ static PHP_METHOD(swoole_mysql_coro, connect)
 
     if (swClient_create(cli, type, 0) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swClient_create() failed. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "swClient_create() failed");
         _failed:
         if (errno != 0)
         {

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -3838,7 +3838,7 @@ static int swoole_mysql_coro_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swWarn("getsockopt(%d) failed. Error: %s[%d]", event->fd, strerror(errno), errno);
+        swSysError("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -294,7 +294,7 @@ static int swoole_pgsql_coro_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swSysError("getsockopt(%d) failed", event->fd);
+        swSysWarn("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -189,7 +189,7 @@ static PHP_METHOD(swoole_postgresql_coro, connect)
 
     if (SwooleG.main_reactor->add(SwooleG.main_reactor, fd, PHP_SWOOLE_FD_POSTGRESQL | SW_EVENT_WRITE) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swoole_event_add failed.");
+        swoole_php_fatal_error(E_WARNING, "swoole_event_add failed");
         RETURN_FALSE;
     }
 
@@ -257,11 +257,11 @@ static void swoole_pgsql_coro_onTimeout(swTimer *timer, swTimer_node *tnode)
         break;
 
     case CONNECTION_MADE:
-        feedback = "Connected to server...";
+        feedback = "Connected to server..";
         break;
 
     default:
-        feedback = " time out...";
+        feedback = " time out..";
     }
 
     err_msg = PQerrorMessage(object->conn);
@@ -1262,7 +1262,7 @@ static int swoole_postgresql_coro_close(zval *zobject)
     pg_object *object = (pg_object *) swoole_get_object(zobject);
     if (!object)
     {
-        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_postgresql_coro.");
+        swoole_php_fatal_error(E_WARNING, "object is not instanceof swoole_postgresql_coro");
         return FAILURE;
     }
     SwooleG.main_reactor->del(SwooleG.main_reactor, object->fd);

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -294,7 +294,7 @@ static int swoole_pgsql_coro_onWrite(swReactor *reactor, swEvent *event)
     socklen_t len = sizeof(SwooleG.error);
     if (getsockopt(event->fd, SOL_SOCKET, SO_ERROR, &SwooleG.error, &len) < 0)
     {
-        swWarn("getsockopt(%d) failed. Error: %s[%d]", event->fd, strerror(errno), errno);
+        swSysError("getsockopt(%d) failed", event->fd);
         return SW_ERR;
     }
 

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -263,19 +263,19 @@ static PHP_METHOD(swoole_process, __construct)
     //only cli env
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "swoole_process only can be used in PHP CLI mode.");
+        swoole_php_fatal_error(E_ERROR, "swoole_process only can be used in PHP CLI mode");
         RETURN_FALSE;
     }
 
     if (SwooleG.serv && SwooleG.serv->gs->start == 1 && swIsMaster())
     {
-        swoole_php_fatal_error(E_ERROR, "swoole_process can't be used in master process.");
+        swoole_php_fatal_error(E_ERROR, "swoole_process can't be used in master process");
         RETURN_FALSE;
     }
 
     if (SwooleAIO.init)
     {
-        swoole_php_fatal_error(E_ERROR, "unable to create process with async-io threads.");
+        swoole_php_fatal_error(E_ERROR, "unable to create process with async-io threads");
         RETURN_FALSE;
     }
 
@@ -444,7 +444,7 @@ static PHP_METHOD(swoole_process, statQueue)
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (!process->queue)
     {
-        swoole_php_fatal_error(E_WARNING, "no queue, can't get stats of the queue.");
+        swoole_php_fatal_error(E_WARNING, "no queue, can't get stats of the queue");
         RETURN_FALSE;
     }
 
@@ -511,13 +511,13 @@ static PHP_METHOD(swoole_process, signal)
 
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "cannot use swoole_process::signal here.");
+        swoole_php_fatal_error(E_ERROR, "cannot use swoole_process::signal here");
         RETURN_FALSE;
     }
 
     if (signo < 0 || signo >= SW_SIGNO_MAX)
     {
-        swoole_php_fatal_error(E_WARNING, "invalid signal number [%ld].", signo);
+        swoole_php_fatal_error(E_WARNING, "invalid signal number [%ld]", signo);
         RETURN_FALSE;
     }
 
@@ -526,7 +526,7 @@ static PHP_METHOD(swoole_process, signal)
 
     if (handler && handler != php_swoole_onSignal)
     {
-        swoole_php_fatal_error(E_WARNING, "This signal [%ld] processor has been registered by the system.", signo);
+        swoole_php_fatal_error(E_WARNING, "This signal [%ld] processor has been registered by the system", signo);
         RETURN_FALSE
     }
 
@@ -543,7 +543,7 @@ static PHP_METHOD(swoole_process, signal)
         }
         else
         {
-            swoole_php_error(E_WARNING, "no callback.");
+            swoole_php_error(E_WARNING, "no callback");
             RETURN_FALSE;
         }
     }
@@ -606,13 +606,13 @@ static PHP_METHOD(swoole_process, alarm)
 
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "cannot use swoole_process::alarm here.");
+        swoole_php_fatal_error(E_ERROR, "cannot use swoole_process::alarm here");
         RETURN_FALSE;
     }
 
     if (SwooleG.timer.initialized != 0)
     {
-        swoole_php_fatal_error(E_WARNING, "cannot use both 'timer' and 'alarm' at the same time.");
+        swoole_php_fatal_error(E_WARNING, "cannot use both 'timer' and 'alarm' at the same time");
         RETURN_FALSE;
     }
 
@@ -681,7 +681,7 @@ zend_bool php_swoole_signal_isset_handler(int signo)
 {
     if (signo < 0 || signo >= SW_SIGNO_MAX)
     {
-        swoole_php_fatal_error(E_WARNING, "invalid signal number [%d].", signo);
+        swoole_php_fatal_error(E_WARNING, "invalid signal number [%d]", signo);
         return SW_FALSE;
     }
     return signal_callback[signo] != NULL;
@@ -752,7 +752,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
     {
         if (PHPCoroutine::create(&proc->fci_cache, 1, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create process coroutine error.");
+            swoole_php_error(E_WARNING, "create process coroutine error");
             return SW_ERR;
         }
     }
@@ -761,7 +761,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, &proc->fci_cache, retval, 1, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "callback function error.");
+            swoole_php_error(E_WARNING, "callback function error");
         }
         zval_ptr_dtor(retval);
     }
@@ -791,7 +791,7 @@ static PHP_METHOD(swoole_process, start)
 
     if (swKill(process->pid, 0) == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "process has already been started.");
+        swoole_php_fatal_error(E_WARNING, "process has already been started");
         RETURN_FALSE;
     }
 
@@ -834,7 +834,7 @@ static PHP_METHOD(swoole_process, read)
 
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot read from pipe.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot read from pipe");
         RETURN_FALSE;
     }
 
@@ -866,14 +866,14 @@ static PHP_METHOD(swoole_process, write)
 
     if (data_len < 1)
     {
-        swoole_php_fatal_error(E_WARNING, "the data to send is empty.");
+        swoole_php_fatal_error(E_WARNING, "the data to send is empty");
         RETURN_FALSE;
     }
 
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot write into pipe.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot write into pipe");
         RETURN_FALSE;
     }
 
@@ -913,7 +913,7 @@ static PHP_METHOD(swoole_process, exportSocket)
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot export stream.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot export stream");
         RETURN_FALSE;
     }
     php::process *proc = (php::process *) process->ptr2;
@@ -947,12 +947,12 @@ static PHP_METHOD(swoole_process, push)
 
     if (length <= 0)
     {
-        swoole_php_fatal_error(E_WARNING, "the data to push is empty.");
+        swoole_php_fatal_error(E_WARNING, "the data to push is empty");
         RETURN_FALSE;
     }
     else if (length >= sizeof(message.data))
     {
-        swoole_php_fatal_error(E_WARNING, "the data to push is too big.");
+        swoole_php_fatal_error(E_WARNING, "the data to push is too big");
         RETURN_FALSE;
     }
 
@@ -1031,7 +1031,7 @@ static PHP_METHOD(swoole_process, exec)
 
     if (execfile_len < 1)
     {
-        swoole_php_fatal_error(E_WARNING, "exec file name is empty.");
+        swoole_php_fatal_error(E_WARNING, "exec file name is empty");
         RETURN_FALSE;
     }
 
@@ -1111,7 +1111,7 @@ static PHP_METHOD(swoole_process, setaffinity)
     if (sched_setaffinity(getpid(), sizeof(cpu_set), &cpu_set) < 0)
 #endif
     {
-        swoole_php_sys_error(E_WARNING, "sched_setaffinity() failed.");
+        swoole_php_sys_error(E_WARNING, "sched_setaffinity() failed");
         RETURN_FALSE;
     }
     RETURN_TRUE;
@@ -1131,7 +1131,7 @@ static PHP_METHOD(swoole_process, exit)
 
     if (getpid() != process->pid)
     {
-        swoole_php_fatal_error(E_WARNING, "not current process.");
+        swoole_php_fatal_error(E_WARNING, "not current process");
         RETURN_FALSE;
     }
 
@@ -1166,7 +1166,7 @@ static PHP_METHOD(swoole_process, close)
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot close the pipe.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot close the pipe");
         RETURN_FALSE;
     }
 
@@ -1208,7 +1208,7 @@ static PHP_METHOD(swoole_process, setTimeout)
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot setTimeout the pipe.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot setTimeout the pipe");
         RETURN_FALSE;
     }
     SW_CHECK_RETURN(swSocket_set_timeout(process->pipe, seconds));
@@ -1225,7 +1225,7 @@ static PHP_METHOD(swoole_process, setBlocking)
     swWorker *process = (swWorker *) swoole_get_object(getThis());
     if (process->pipe == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "no pipe, cannot setBlocking the pipe.");
+        swoole_php_fatal_error(E_WARNING, "no pipe, cannot setBlocking the pipe");
         RETURN_FALSE;
     }
     if (blocking)

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -492,7 +492,7 @@ static PHP_METHOD(swoole_process, kill)
     {
         if (!(sig == 0 && errno == ESRCH))
         {
-            swoole_php_error(E_WARNING, "swKill(%d, %d) failed. Error: %s[%d]", (int) pid, (int) sig, strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "swKill(%d, %d) failed", (int) pid, (int) sig);
         }
         RETURN_FALSE;
     }
@@ -639,7 +639,7 @@ static PHP_METHOD(swoole_process, alarm)
 
     if (setitimer(type, &timer_set, NULL) < 0)
     {
-        swoole_php_error(E_WARNING, "setitimer() failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "setitimer() failed");
         RETURN_FALSE;
     }
 
@@ -714,7 +714,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
     {
         if (dup2(process->pipe, STDIN_FILENO) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "dup2() failed. Error: %s[%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "dup2() failed");
         }
     }
 
@@ -722,7 +722,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
     {
         if (dup2(process->pipe, STDOUT_FILENO) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "dup2() failed. Error: %s[%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "dup2() failed");
         }
     }
 
@@ -730,7 +730,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
     {
         if (dup2(process->pipe, STDERR_FILENO) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "dup2() failed. Error: %s[%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "dup2() failed");
         }
     }
 
@@ -798,7 +798,7 @@ static PHP_METHOD(swoole_process, start)
     pid_t pid = swoole_fork();
     if (pid < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "fork() failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "fork() failed");
         RETURN_FALSE;
     }
     else if (pid > 0)
@@ -845,7 +845,7 @@ static PHP_METHOD(swoole_process, read)
         efree(buf);
         if (errno != EINTR)
         {
-            swoole_php_error(E_WARNING, "read() failed. Error: %s[%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "read() failed");
         }
         RETURN_FALSE;
     }
@@ -899,7 +899,7 @@ static PHP_METHOD(swoole_process, write)
 
     if (ret < 0)
     {
-        swoole_php_error(E_WARNING, "write() failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "write() failed");
         RETURN_FALSE;
     }
     ZVAL_LONG(return_value, ret);
@@ -1052,7 +1052,7 @@ static PHP_METHOD(swoole_process, exec)
 
     if (execv(execfile, exec_args) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "execv(%s) failed. Error: %s[%d]", execfile, strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "execv(%s) failed", execfile);
         RETURN_FALSE;
     }
     else
@@ -1185,7 +1185,7 @@ static PHP_METHOD(swoole_process, close)
     }
     if (ret < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "close() failed. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "close() failed");
         RETURN_FALSE;
     }
     if (which == 0)

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -109,7 +109,7 @@ static void php_swoole_process_pool_onWorkerStart(swProcessPool *pool, int worke
 
     if (sw_call_user_function_ex(EG(function_table), NULL, pp->onWorkerStart, &retval, 2, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerStart handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerStart handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -139,7 +139,7 @@ static void php_swoole_process_pool_onMessage(swProcessPool *pool, char *data, u
 
     if (sw_call_user_function_ex(EG(function_table), NULL, pp->onMessage, &retval, 2, args, 0, NULL)  == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onMessage handler error.");
+        swoole_php_fatal_error(E_WARNING, "onMessage handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -168,7 +168,7 @@ static void php_swoole_process_pool_onWorkerStop(swProcessPool *pool, int worker
     }
     if (sw_call_user_function_ex(EG(function_table), NULL, pp->onWorkerStop, &retval, 2, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -206,13 +206,13 @@ static PHP_METHOD(swoole_process_pool, __construct)
     //only cli env
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "swoole_process_pool only can be used in PHP CLI mode.");
+        swoole_php_fatal_error(E_ERROR, "swoole_process_pool only can be used in PHP CLI mode");
         RETURN_FALSE;
     }
 
     if (SwooleG.serv)
     {
-        swoole_php_fatal_error(E_ERROR, "swoole_process_pool cannot use in server process.");
+        swoole_php_fatal_error(E_ERROR, "swoole_process_pool cannot use in server process");
         RETURN_FALSE;
     }
 
@@ -261,7 +261,7 @@ static PHP_METHOD(swoole_process_pool, on)
 
     if (pool->started > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to register event callback function.");
+        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to register event callback function");
         RETURN_FALSE;
     }
 
@@ -292,7 +292,7 @@ static PHP_METHOD(swoole_process_pool, on)
     {
         if (pool->ipc_mode == SW_IPC_NONE)
         {
-            swoole_php_fatal_error(E_WARNING, "cannot set onMessage event with ipc_type=0.");
+            swoole_php_fatal_error(E_WARNING, "cannot set onMessage event with ipc_type=0");
             RETURN_TRUE;
         }
         if (pp->onMessage)
@@ -333,7 +333,7 @@ static PHP_METHOD(swoole_process_pool, listen)
 
     if (pool->started > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to listen.");
+        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to listen");
         RETURN_FALSE;
     }
 
@@ -344,7 +344,7 @@ static PHP_METHOD(swoole_process_pool, listen)
 
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
-        swoole_php_fatal_error(E_WARNING, "unsupported ipc type[%d].", pool->ipc_mode);
+        swoole_php_fatal_error(E_WARNING, "unsupported ipc type[%d]", pool->ipc_mode);
         RETURN_FALSE;
     }
 
@@ -375,7 +375,7 @@ static PHP_METHOD(swoole_process_pool, write)
     swProcessPool *pool = (swProcessPool *) swoole_get_object(getThis());
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
-        swoole_php_fatal_error(E_WARNING, "unsupported ipc type[%d].", pool->ipc_mode);
+        swoole_php_fatal_error(E_WARNING, "unsupported ipc type[%d]", pool->ipc_mode);
         RETURN_FALSE;
     }
     if (length == 0)
@@ -390,7 +390,7 @@ static PHP_METHOD(swoole_process_pool, start)
     swProcessPool *pool = (swProcessPool *) swoole_get_object(getThis());
     if (pool->started)
     {
-        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to execute swoole_process_pool->start.");
+        swoole_php_fatal_error(E_WARNING, "process pool is started. unable to execute swoole_process_pool->start");
         RETURN_FALSE;
     }
 

--- a/swoole_redis_coro.cc
+++ b/swoole_redis_coro.cc
@@ -912,7 +912,7 @@ static sw_inline swRedisClient* swoole_get_redis_client(zval *zobject)
     swRedisClient *redis = (swRedisClient *) swoole_get_object(zobject);
     if (UNEXPECTED(!redis))
     {
-        swoole_php_fatal_error(E_ERROR, "you must call Redis constructor first.");
+        swoole_php_fatal_error(E_ERROR, "you must call Redis constructor first");
     }
     return redis;
 }
@@ -992,7 +992,7 @@ static bool swoole_redis_coro_connect(swRedisClient *redis)
 
     if (host.len() == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "The host is empty.");
+        swoole_php_fatal_error(E_WARNING, "The host is empty");
         return false;
     }
 
@@ -1034,7 +1034,7 @@ static bool swoole_redis_coro_connect(swRedisClient *redis)
     {
         if (port <= 0 || port > SW_CLIENT_MAX_PORT)
         {
-            swoole_php_fatal_error(E_WARNING, "The port " ZEND_LONG_FMT " is invalid.", port);
+            swoole_php_fatal_error(E_WARNING, "The port " ZEND_LONG_FMT " is invalid", port);
             return false;
         }
         context = redisConnectWithTimeout(host.val(), (int) port, tv);
@@ -1046,7 +1046,7 @@ static bool swoole_redis_coro_connect(swRedisClient *redis)
     {
         zend_update_property_long(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errType"), SW_REDIS_ERR_ALLOC);
         zend_update_property_long(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errCode"), sw_redis_convert_err(SW_REDIS_ERR_ALLOC));
-        zend_update_property_string(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "cannot allocate redis context.");
+        zend_update_property_string(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "cannot allocate redis context");
         return false;
     }
     if (context->err)
@@ -1061,7 +1061,7 @@ static bool swoole_redis_coro_connect(swRedisClient *redis)
     {
         zend_update_property_long(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errType"), SW_REDIS_ERR_OTHER);
         zend_update_property_long(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errCode"), sw_redis_convert_err(SW_REDIS_ERR_OTHER));
-        zend_update_property_string(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "Can not found the connection.");
+        zend_update_property_string(swoole_redis_coro_ce_ptr, zobject, ZEND_STRL("errMsg"), "Can not found the connection");
         swoole_redis_coro_close(redis);
         return false;
     }
@@ -1119,7 +1119,7 @@ static sw_inline bool swoole_redis_coro_keep_liveness(swRedisClient *redis)
         }
         zend_update_property_long(swoole_redis_coro_ce_ptr, redis->zobject, ZEND_STRL("errType"), SW_REDIS_ERR_CLOSED);
         // Notice: do not update errCode
-        zend_update_property_string(swoole_redis_coro_ce_ptr, redis->zobject, ZEND_STRL("errMsg"), "connection is not available.");
+        zend_update_property_string(swoole_redis_coro_ce_ptr, redis->zobject, ZEND_STRL("errMsg"), "connection is not available");
         return false;
     }
     return true;
@@ -1976,7 +1976,7 @@ static PHP_METHOD(swoole_redis_coro, __construct)
 
     if (redis)
     {
-        swoole_php_fatal_error(E_ERROR, "constructor can only be called once.");
+        swoole_php_fatal_error(E_ERROR, "constructor can only be called once");
         RETURN_FALSE;
     }
 
@@ -2121,7 +2121,7 @@ static PHP_METHOD(swoole_redis_coro, recv)
     }
     if (UNEXPECTED(!redis->defer && !redis->session.subscribe))
     {
-        swoole_php_fatal_error(E_WARNING, "you should not use recv without defer or subscribe.");
+        swoole_php_fatal_error(E_WARNING, "you should not use recv without defer or subscribe");
         RETURN_FALSE;
     }
 

--- a/swoole_redis_server.cc
+++ b/swoole_redis_server.cc
@@ -97,7 +97,7 @@ static int redis_onReceive(swServer *serv, swEventData *req)
     swConnection *conn = swWorker_get_connection(serv, fd);
     if (!conn)
     {
-        swWarn("connection[%d] is closed.", fd);
+        swWarn("connection[%d] is closed", fd);
         return SW_ERR;
     }
 
@@ -177,7 +177,7 @@ static int redis_onReceive(swServer *serv, swEventData *req)
 
     if (command_len >= SW_REDIS_MAX_COMMAND_SIZE)
     {
-        swoole_php_error(E_WARNING, "command is too long.");
+        swoole_php_error(E_WARNING, "command is too long");
         serv->close(serv, fd, 0);
         return SW_OK;
     }
@@ -206,7 +206,7 @@ static int redis_onReceive(swServer *serv, swEventData *req)
     {
         if (PHPCoroutine::create(fci_cache, 2, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create redis server onReceive coroutine error.");
+            swoole_php_error(E_WARNING, "create redis server onReceive coroutine error");
         }
     }
     else
@@ -214,7 +214,7 @@ static int redis_onReceive(swServer *serv, swEventData *req)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "redis server command '%.*s' handler error.", command_len, command);
+            swoole_php_error(E_WARNING, "redis server command '%.*s' handler error", command_len, command);
         }
         if (Z_TYPE_P(retval) == IS_STRING)
         {
@@ -236,7 +236,7 @@ static PHP_METHOD(swoole_redis_server, start)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (serv->gs->start > 0)
     {
-        swoole_php_error(E_WARNING, "Server is running. Unable to execute swoole_server::start.");
+        swoole_php_error(E_WARNING, "Server is running. Unable to execute swoole_server::start");
         RETURN_FALSE;
     }
 
@@ -247,7 +247,7 @@ static PHP_METHOD(swoole_redis_server, start)
     format_buffer = swString_new(SW_BUFFER_SIZE_STD);
     if (!format_buffer)
     {
-        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed.", SW_BUFFER_SIZE_STD);
+        swoole_php_fatal_error(E_ERROR, "[1] swString_new(%d) failed", SW_BUFFER_SIZE_STD);
         RETURN_FALSE;
     }
 
@@ -292,7 +292,7 @@ static PHP_METHOD(swoole_redis_server, setHandler)
 
     if (command_len == 0 || command_len >= SW_REDIS_MAX_COMMAND_SIZE)
     {
-        swoole_php_fatal_error(E_ERROR, "invalid command.");
+        swoole_php_fatal_error(E_ERROR, "invalid command");
         RETURN_FALSE;
     }
 
@@ -403,13 +403,13 @@ static PHP_METHOD(swoole_redis_server, format)
         if (!value)
         {
             no_value:
-            swoole_php_fatal_error(E_WARNING, "require more parameters.");
+            swoole_php_fatal_error(E_WARNING, "require more parameters");
             RETURN_FALSE;
         }
         convert_to_string(value);
         if (Z_STRLEN_P(value) > SW_REDIS_MAX_STRING_SIZE || Z_STRLEN_P(value) < 1)
         {
-            swoole_php_fatal_error(E_WARNING, "invalid string size.");
+            swoole_php_fatal_error(E_WARNING, "invalid string size");
             RETURN_FALSE;
         }
         swString_clear(format_buffer);
@@ -427,7 +427,7 @@ static PHP_METHOD(swoole_redis_server, format)
         }
         if (Z_TYPE_P(value) != IS_ARRAY)
         {
-            swoole_php_fatal_error(E_WARNING, "the second parameter should be an array.");
+            swoole_php_fatal_error(E_WARNING, "the second parameter should be an array");
         }
         swString_clear(format_buffer);
         length = sw_snprintf(message, sizeof(message), "*%d\r\n", zend_hash_num_elements(Z_ARRVAL_P(value)));
@@ -462,7 +462,7 @@ static PHP_METHOD(swoole_redis_server, format)
         }
         if (Z_TYPE_P(value) != IS_ARRAY)
         {
-            swoole_php_fatal_error(E_WARNING, "the second parameter should be an array.");
+            swoole_php_fatal_error(E_WARNING, "the second parameter should be an array");
         }
         swString_clear(format_buffer);
         length = sw_snprintf(message, sizeof(message), "*%d\r\n", 2 * zend_hash_num_elements(Z_ARRVAL_P(value)));

--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -918,7 +918,7 @@ static php_stream *socket_create(
     if (UNEXPECTED(sock->socket == nullptr))
     {
         _failed:
-        swoole_php_fatal_error(E_WARNING, "new Socket() failed. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "new Socket() failed");
         delete sock;
         return NULL;
     }

--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -637,7 +637,7 @@ static inline int socket_xport_api(php_stream *stream, Socket *sock, php_stream_
 
             if (!certfile || !private_key)
             {
-                swoole_php_fatal_error(E_ERROR, "ssl cert/key file not found.");
+                swoole_php_fatal_error(E_ERROR, "ssl cert/key file not found");
                 return FAILURE;
             }
 
@@ -950,7 +950,7 @@ bool PHPCoroutine::enable_hook(int flags)
 {
     if (unlikely(enable_strict_mode))
     {
-        swoole_php_fatal_error(E_ERROR, "unable to enable the coroutine mode after you enable the strict mode.");
+        swoole_php_fatal_error(E_ERROR, "unable to enable the coroutine mode after you enable the strict mode");
         return false;
     }
     if (!hook_init)

--- a/swoole_serialize.c
+++ b/swoole_serialize.c
@@ -1123,12 +1123,12 @@ static void swoole_serialize_object(seriaString *buffer, zval *obj, size_t start
     zend_string *name = Z_OBJCE_P(obj)->name;
 //    if (GC_IS_RECURSIVE(Z_OBJPROP_P(obj)))
 //    {
-//        zend_throw_exception_ex(NULL, 0, "the object %s has cycle ref.", name->val);
+//        zend_throw_exception_ex(NULL, 0, "the object %s has cycle ref", name->val);
 //        return;
 //    }
     if (name->len > 0xffff)
     {
-        zend_throw_exception_ex(NULL, 0, "the object name is too long.");
+        zend_throw_exception_ex(NULL, 0, "the object name is too long");
         return;
     }
     else
@@ -1460,7 +1460,7 @@ again:
             break;
         }
         default:
-            php_error_docref(NULL, E_NOTICE, "the type is not supported by swoole serialize.");
+            php_error_docref(NULL, E_NOTICE, "the type is not supported by swoole serialize");
 
             break;
     }
@@ -1557,7 +1557,7 @@ PHPAPI int php_swoole_unserialize(void *buffer, size_t len, zval *return_value, 
             }
             break;
         default:
-            php_error_docref(NULL, E_NOTICE, "the type is not supported by swoole serialize.");
+            php_error_docref(NULL, E_NOTICE, "the type is not supported by swoole serialize");
             return SW_FALSE;
     }
 
@@ -1569,7 +1569,7 @@ static PHP_METHOD(swoole_serialize, pack)
     zval *zvalue;
     size_t is_fast = 0;
 
-    swoole_php_fatal_error(E_DEPRECATED, "swoole serialize will be removed, you should be using the php serialize instead.");
+    swoole_php_fatal_error(E_DEPRECATED, "swoole serialize will be removed, you should be using the php serialize instead");
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &zvalue, &is_fast) == FAILURE)
     {
@@ -1588,7 +1588,7 @@ static PHP_METHOD(swoole_serialize, unpack)
     zend_long flag = 0;
     zval *args = NULL; //for object
 
-    swoole_php_fatal_error(E_DEPRECATED, "swoole serialize will be removed, you should be using the php serialize instead.");
+    swoole_php_fatal_error(E_DEPRECATED, "swoole serialize will be removed, you should be using the php serialize instead");
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|la", &buffer, &buffer_len, &flag, &args) == FAILURE)
     {

--- a/swoole_serialize.c
+++ b/swoole_serialize.c
@@ -92,7 +92,7 @@ static CPINLINE int swoole_string_new(size_t size, seriaString *str, zend_uchar 
     str->buffer = ecalloc(1, total);
     if (!str->buffer)
     {
-        php_error_docref(NULL, E_ERROR, "malloc Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_ERROR, "malloc failed");
     }
 
     SBucketType real_type = {0};
@@ -113,7 +113,7 @@ static CPINLINE void swoole_check_size(seriaString *str, size_t len)
         str->buffer = erealloc2(str->buffer, new_size, str->offset);
         if (!str->buffer)
         {
-            php_error_docref(NULL, E_ERROR, "realloc Error: %s [%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_ERROR, "erealloc2 failed");
         }
         str->total = new_size;
     }

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -2191,7 +2191,7 @@ static PHP_METHOD(swoole_server, __construct)
         {
             zend_throw_exception_ex(
                 swoole_exception_ce_ptr, errno,
-                "failed to listen server port[%s:" ZEND_LONG_FMT "]. Error: %s[%d]",
+                "failed to listen server port[%s:" ZEND_LONG_FMT "], Error: %s[%d]",
                 serv_host, serv_port, strerror(errno), errno
             );
             RETURN_FALSE;
@@ -3280,7 +3280,7 @@ static PHP_METHOD(swoole_server, reload)
     int sig = only_reload_taskworker ? SIGUSR2 : SIGUSR1;
     if (swKill(serv->gs->manager_pid, sig) < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "failed to send the reload signal. Error: %s[%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "failed to send the reload signal");
         RETURN_FALSE;
     }
     RETURN_TRUE;
@@ -3418,7 +3418,7 @@ static PHP_METHOD(swoole_server, taskwait)
             }
             else
             {
-                swoole_php_error(E_WARNING, "taskwait failed. Error: %s[%d]", strerror(errno), errno);
+                swoole_php_sys_error(E_WARNING, "taskwait failed");
                 break;
             }
         }
@@ -3505,7 +3505,7 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
         sw_atomic_fetch_add(&serv->stats->tasking_num, 1);
         if (swProcessPool_dispatch_blocking(&serv->gs->task_workers, &buf, &dst_worker_id) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "taskwait failed. Error: %s[%d]", strerror(errno), errno);
+            swoole_php_sys_error(E_WARNING, "taskwait failed");
             task_id = -1;
             fail:
             add_index_bool(return_value, i, 0);

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -549,7 +549,7 @@ zval* php_swoole_server_get_callback(swServer *serv, int server_fd, int event_ty
 
     if (unlikely(!port))
     {
-        swWarn("invalid server_fd[%d].", server_fd);
+        swWarn("invalid server_fd[%d]", server_fd);
         return NULL;
     }
     if ((property = (swoole_server_port_property *) port->ptr) && (callback = property->callbacks[event_type]))
@@ -570,7 +570,7 @@ zend_fcall_info_cache* php_swoole_server_get_fci_cache(swServer *serv, int serve
 
     if (unlikely(!port))
     {
-        swWarn("invalid server_fd[%d].", server_fd);
+        swWarn("invalid server_fd[%d]", server_fd);
         return NULL;
     }
     if ((property = (swoole_server_port_property *) port->ptr) && (fci_cache = property->caches[event_type]))
@@ -601,7 +601,7 @@ static int php_swoole_create_dir(const char* path, size_t length)
     {
         if (getcwd(curpath, sizeof(curpath)) == NULL)
         {
-            swoole_php_sys_error(E_WARNING, "getcwd() failed.");
+            swoole_php_sys_error(E_WARNING, "getcwd() failed");
             return -1;
         }
         strcat(curpath, "/");
@@ -632,7 +632,7 @@ static int php_swoole_create_dir(const char* path, size_t length)
             {
                 if (mkdir(curpath, 0755) == -1)
                 {
-                    swoole_php_sys_error(E_WARNING, "mkdir(%s, 0755).", path);
+                    swoole_php_sys_error(E_WARNING, "mkdir(%s, 0755)", path);
                     return -1;
                 }
             }
@@ -688,7 +688,7 @@ int php_swoole_task_pack(swEventData *task, zval *data)
     {
         if (swTaskWorker_large_pack(task, task_data_str, task_data_len) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "large task pack failed.");
+            swoole_php_fatal_error(E_WARNING, "large task pack failed");
             task->info.fd = SW_ERR;
             task->info.len = 0;
         }
@@ -745,17 +745,17 @@ static sw_inline int php_swoole_check_task_param(swServer *serv, int dst_worker_
 {
     if (serv->task_worker_num < 1)
     {
-        swoole_php_fatal_error(E_WARNING, "task method can't be executed, please set 'task_worker_num' > 0.");
+        swoole_php_fatal_error(E_WARNING, "task method can't be executed, please set 'task_worker_num' > 0");
         return SW_ERR;
     }
     if (dst_worker_id >= serv->task_worker_num)
     {
-        swoole_php_fatal_error(E_WARNING, "worker_id must be less than serv->task_worker_num.");
+        swoole_php_fatal_error(E_WARNING, "worker_id must be less than serv->task_worker_num");
         return SW_ERR;
     }
     if (swIsTaskWorker())
     {
-        swoole_php_fatal_error(E_WARNING, "Server->task() cannot use in the task-worker.");
+        swoole_php_fatal_error(E_WARNING, "Server->task() cannot use in the task-worker");
         return SW_ERR;
     }
     return SW_OK;
@@ -985,7 +985,7 @@ void php_swoole_server_before_start(swServer *serv, zval *zobject)
         serv->manager_alarm = serv->request_slowlog_timeout;
         if (swServer_add_hook(serv, SW_SERVER_HOOK_MANAGER_TIMER, php_swoole_trace_check, 1) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to add server hook.");
+            swoole_php_fatal_error(E_ERROR, "Unable to add server hook");
             return;
         }
     }
@@ -1183,7 +1183,7 @@ static void php_swoole_onPipeMessage(swServer *serv, swEventData *req)
     {
         if (PHPCoroutine::create(fci_cache, 3, args) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "create onPipeMessage coroutine error.");
+            swoole_php_fatal_error(E_WARNING, "create onPipeMessage coroutine error");
         }
     }
     else
@@ -1191,7 +1191,7 @@ static void php_swoole_onPipeMessage(swServer *serv, swEventData *req)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 3, args) == FAILURE)
         {
-            swoole_php_fatal_error(E_WARNING, "onPipeMessage handler error.");
+            swoole_php_fatal_error(E_WARNING, "onPipeMessage handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -1214,7 +1214,7 @@ int php_swoole_onReceive(swServer *serv, swEventData *req)
     {
         if (PHPCoroutine::create(fci_cache, 4, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create onReceive coroutine error.");
+            swoole_php_error(E_WARNING, "create onReceive coroutine error");
             serv->close(serv, req->info.fd, 0);
         }
     }
@@ -1223,7 +1223,7 @@ int php_swoole_onReceive(swServer *serv, swEventData *req)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 4, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "onReceive handler error.");
+            swoole_php_error(E_WARNING, "onReceive handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -1286,7 +1286,7 @@ int php_swoole_onPacket(swServer *serv, swEventData *req)
     {
         if (PHPCoroutine::create(fci_cache, 3, args) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "create onPacket coroutine error.");
+            swoole_php_fatal_error(E_WARNING, "create onPacket coroutine error");
         }
     }
     else
@@ -1294,7 +1294,7 @@ int php_swoole_onPacket(swServer *serv, swEventData *req)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 3, args) == FAILURE)
         {
-            swoole_php_fatal_error(E_WARNING, "onPacket handler error.");
+            swoole_php_fatal_error(E_WARNING, "onPacket handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -1328,7 +1328,7 @@ static int php_swoole_onTask(swServer *serv, swEventData *req)
     zend_fcall_info_cache *fci_cache = php_sw_server_caches[SW_SERVER_CB_onTask];
     if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 4, args) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onTask handler error.");
+        swoole_php_fatal_error(E_WARNING, "onTask handler error");
     }
 
     if (UNEXPECTED(EG(exception)))
@@ -1378,7 +1378,7 @@ static int php_swoole_onTaskCo(swServer *serv, swEventData *req)
     zend_fcall_info_cache *cache = php_sw_server_caches[SW_SERVER_CB_onTask];
     if (PHPCoroutine::create(cache, 2, args) < 0)
     {
-        swWarn("create onTask coroutine error.");
+        swWarn("create onTask coroutine error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1412,7 +1412,7 @@ static int php_swoole_onFinish(swServer *serv, swEventData *req)
 
         if (task_co_iterator == task_coroutine_map.end())
         {
-            swWarn("task[%d] has expired.", task_id);
+            swWarn("task[%d] has expired", task_id);
             _fail: sw_zval_free(zdata);
             return SW_OK;
         }
@@ -1449,7 +1449,7 @@ static int php_swoole_onFinish(swServer *serv, swEventData *req)
         }
         if (task_index < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "task[%d] is invalid.", task_id);
+            swoole_php_fatal_error(E_WARNING, "task[%d] is invalid", task_id);
             goto _fail;
         }
         (void) add_index_zval(result, task_index, zdata);
@@ -1498,13 +1498,13 @@ static int php_swoole_onFinish(swServer *serv, swEventData *req)
         if (callback == NULL)
         {
             sw_zval_free(zdata);
-            swoole_php_fatal_error(E_WARNING, "require onFinish callback.");
+            swoole_php_fatal_error(E_WARNING, "require onFinish callback");
             return SW_ERR;
         }
     }
     if (sw_call_user_function_ex(EG(function_table), NULL, callback, &retval, 3, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onFinish handler error.");
+        swoole_php_fatal_error(E_WARNING, "onFinish handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1538,7 +1538,7 @@ static void php_swoole_onStart(swServer *serv)
 
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onStart], &retval, 1, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onStart handler error.");
+        swoole_php_fatal_error(E_WARNING, "onStart handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1565,7 +1565,7 @@ static void php_swoole_onManagerStart(swServer *serv)
 
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onManagerStart], &retval, 1, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onManagerStart handler error.");
+        swoole_php_fatal_error(E_WARNING, "onManagerStart handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1587,7 +1587,7 @@ static void php_swoole_onManagerStop(swServer *serv)
 
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onManagerStop], &retval, 1, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onManagerStop handler error.");
+        swoole_php_fatal_error(E_WARNING, "onManagerStop handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1613,7 +1613,7 @@ static void php_swoole_onShutdown(swServer *serv)
     {
         if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onShutdown], &retval, 1, args, 0, NULL) == FAILURE)
         {
-            swoole_php_fatal_error(E_WARNING, "onShutdown handler error.");
+            swoole_php_fatal_error(E_WARNING, "onShutdown handler error");
         }
         if (UNEXPECTED(EG(exception)))
         {
@@ -1636,7 +1636,7 @@ static void php_swoole_onWorkerStart_coroutine(zval *zserv, int worker_id)
     zend_fcall_info_cache *cache = php_sw_server_caches[SW_SERVER_CB_onWorkerStart];
     if (PHPCoroutine::create(cache, 2, args) < 0)
     {
-        swWarn("create onWorkerStart coroutine error.");
+        swWarn("create onWorkerStart coroutine error");
     }
 }
 
@@ -1650,7 +1650,7 @@ static void php_swoole_onWorkerStart_callback(zval *zserv, int worker_id)
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onWorkerStart], &retval,
             2, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerStart handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerStart handler error");
     }
 
     if (UNEXPECTED(EG(exception)))
@@ -1741,7 +1741,7 @@ static void php_swoole_onWorkerStop(swServer *serv, int worker_id)
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onWorkerStop], &retval, 2, args, 0,
             NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1765,7 +1765,7 @@ static void php_swoole_onWorkerExit(swServer *serv, int worker_id)
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onWorkerExit], &retval, 2, args, 0,
             NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerStop handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1807,7 +1807,7 @@ static void php_swoole_onWorkerError(swServer *serv, int worker_id, pid_t worker
 
     if (sw_call_user_function_ex(EG(function_table), NULL, php_sw_server_callbacks[SW_SERVER_CB_onWorkerError], &retval, 5, args, 0, NULL) == FAILURE)
     {
-        swoole_php_fatal_error(E_WARNING, "onWorkerError handler error.");
+        swoole_php_fatal_error(E_WARNING, "onWorkerError handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1848,7 +1848,7 @@ void php_swoole_onConnect(swServer *serv, swDataHead *info)
         // FIXME: php_swoole_onConnect_finish with info->fd
         if (PHPCoroutine::create(fci_cache, 3, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create onConnect coroutine error.");
+            swoole_php_error(E_WARNING, "create onConnect coroutine error");
         }
     }
     else
@@ -1856,7 +1856,7 @@ void php_swoole_onConnect(swServer *serv, swDataHead *info)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 3, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "onConnect handler error.");
+            swoole_php_error(E_WARNING, "onConnect handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -1874,7 +1874,7 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
             list<php_coro_context *> *coros_list = _i_coros_list->second;
             if (coros_list->size() == 0)
             {
-                swoole_php_fatal_error(E_WARNING, "nothing can resume.");
+                swoole_php_fatal_error(E_WARNING, "nothing can resume");
             }
             else
             {
@@ -1907,7 +1907,7 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
     {
         if (PHPCoroutine::create(fci_cache, 3, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create onClose coroutine error.");
+            swoole_php_error(E_WARNING, "create onClose coroutine error");
         }
     }
     else
@@ -1915,7 +1915,7 @@ void php_swoole_onClose(swServer *serv, swDataHead *info)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 3, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "onClose handler error.");
+            swoole_php_error(E_WARNING, "onClose handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -1938,7 +1938,7 @@ void php_swoole_onBufferFull(swServer *serv, swDataHead *info)
 
     if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
     {
-        swoole_php_error(E_WARNING, "onBufferFull handler error.");
+        swoole_php_error(E_WARNING, "onBufferFull handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -1976,7 +1976,7 @@ static void php_swoole_onSendTimeout(swTimer *timer, swTimer_node *tnode)
     }
     else
     {
-        swWarn("send coroutine[fd=%d] not exists.", fd);
+        swWarn("send coroutine[fd=%d] not exists", fd);
         return;
     }
 
@@ -2082,7 +2082,7 @@ void php_swoole_onBufferEmpty(swServer *serv, swDataHead *info)
             list<php_coro_context *> *coros_list = _i_coros_list->second;
             if (coros_list->size() == 0)
             {
-                swoole_php_fatal_error(E_WARNING, "nothing can resume.");
+                swoole_php_fatal_error(E_WARNING, "nothing can resume");
                 goto _callback;
             }
             php_coro_context *context = coros_list->front();
@@ -2114,7 +2114,7 @@ void php_swoole_onBufferEmpty(swServer *serv, swDataHead *info)
 
     if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
     {
-        swoole_php_error(E_WARNING, "onBufferEmpty handler error.");
+        swoole_php_error(E_WARNING, "onBufferEmpty handler error");
     }
     if (UNEXPECTED(EG(exception)))
     {
@@ -2137,7 +2137,7 @@ static PHP_METHOD(swoole_server, __construct)
     //only cli env
     if (!SWOOLE_G(cli))
     {
-        swoole_php_fatal_error(E_ERROR, "swoole_server only can be used in PHP CLI mode.");
+        swoole_php_fatal_error(E_ERROR, "swoole_server only can be used in PHP CLI mode");
         RETURN_FALSE;
     }
 
@@ -2149,7 +2149,7 @@ static PHP_METHOD(swoole_server, __construct)
 
     if (SwooleG.serv != NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "server is running. unable to create swoole_server.");
+        swoole_php_fatal_error(E_ERROR, "server is running. unable to create swoole_server");
         RETURN_FALSE;
     }
 
@@ -2158,13 +2158,13 @@ static PHP_METHOD(swoole_server, __construct)
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lll", &serv_host, &host_len, &serv_port, &serv_mode, &sock_type) == FAILURE)
     {
-        swoole_php_fatal_error(E_ERROR, "invalid swoole_server parameters.");
+        swoole_php_fatal_error(E_ERROR, "invalid swoole_server parameters");
         RETURN_FALSE;
     }
 
     if (serv_mode != SW_MODE_BASE && serv_mode != SW_MODE_PROCESS)
     {
-        swoole_php_fatal_error(E_ERROR, "invalid $mode parameters %d.", (int) serv_mode);
+        swoole_php_fatal_error(E_ERROR, "invalid $mode parameters %d", (int) serv_mode);
         RETURN_FALSE;
     }
     if (serv_mode == SW_MODE_BASE)
@@ -2180,7 +2180,7 @@ static PHP_METHOD(swoole_server, __construct)
     {
         if (swServer_add_systemd_socket(serv) <= 0)
         {
-            swoole_php_fatal_error(E_ERROR, "failed to add systemd socket.");
+            swoole_php_fatal_error(E_ERROR, "failed to add systemd socket");
             RETURN_FALSE;
         }
     }
@@ -2191,7 +2191,7 @@ static PHP_METHOD(swoole_server, __construct)
         {
             zend_throw_exception_ex(
                 swoole_exception_ce_ptr, errno,
-                "failed to listen server port[%s:" ZEND_LONG_FMT "]. Error: %s[%d].",
+                "failed to listen server port[%s:" ZEND_LONG_FMT "]. Error: %s[%d]",
                 serv_host, serv_port, strerror(errno), errno
             );
             RETURN_FALSE;
@@ -2273,7 +2273,7 @@ static PHP_METHOD(swoole_server, set)
     swServer *serv = (swServer *) swoole_get_object(zobject);
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "server is running. unable to execute function 'swoole_server_set'.");
+        swoole_php_fatal_error(E_WARNING, "server is running. unable to execute function 'swoole_server_set'");
         RETURN_FALSE;
     }
 
@@ -2464,7 +2464,7 @@ static PHP_METHOD(swoole_server, set)
         {
             if (!SwooleG.enable_coroutine)
             {
-                swoole_php_fatal_error(E_ERROR, "server->enable_coroutine must be true.");
+                swoole_php_fatal_error(E_ERROR, "server->enable_coroutine must be true");
                 return;
             }
             serv->task_enable_coroutine = 1;
@@ -2498,7 +2498,7 @@ static PHP_METHOD(swoole_server, set)
         serv->request_slowlog_file = fopen(str_v.val(), "a+");
         if (serv->request_slowlog_file == NULL)
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to open request_slowlog_file[%s].", str_v.val());
+            swoole_php_fatal_error(E_ERROR, "Unable to open request_slowlog_file[%s]", str_v.val());
             return;
         }
         if (serv->request_slowlog_timeout == 0)
@@ -2519,7 +2519,7 @@ static PHP_METHOD(swoole_server, set)
         zend::string str_v(v);
         if (php_swoole_create_dir(str_v.val(), str_v.len()) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to create task_tmpdir[%s].", str_v.val());
+            swoole_php_fatal_error(E_ERROR, "Unable to create task_tmpdir[%s]", str_v.val());
             return;
         }
         if (SwooleG.task_tmpdir)
@@ -2551,7 +2551,7 @@ static PHP_METHOD(swoole_server, set)
 
         if (serv->heartbeat_check_interval > serv->heartbeat_idle_time)
         {
-            swoole_php_fatal_error(E_WARNING, "heartbeat_idle_time must be greater than heartbeat_check_interval.");
+            swoole_php_fatal_error(E_WARNING, "heartbeat_idle_time must be greater than heartbeat_check_interval");
             serv->heartbeat_check_interval = serv->heartbeat_idle_time / 2;
         }
     }
@@ -2644,7 +2644,7 @@ static PHP_METHOD(swoole_server, set)
         zend::string str_v(v);
         if (php_swoole_create_dir(str_v.val(), str_v.len()) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "Unable to create upload_tmp_dir[%s].", str_v.val());
+            swoole_php_fatal_error(E_ERROR, "Unable to create upload_tmp_dir[%s]", str_v.val());
             return;
         }
         if (serv->upload_tmp_dir)
@@ -2665,7 +2665,7 @@ static PHP_METHOD(swoole_server, set)
         zend::string str_v(v);
         if (str_v.len() >= PATH_MAX)
         {
-            swoole_php_fatal_error(E_ERROR, "The length of document_root must be less than %d.", PATH_MAX);
+            swoole_php_fatal_error(E_ERROR, "The length of document_root must be less than %d", PATH_MAX);
             return;
         }
         if (serv->document_root)
@@ -2719,7 +2719,7 @@ static PHP_METHOD(swoole_server, on)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "server is running. unable to register event callback function.");
+        swoole_php_fatal_error(E_WARNING, "server is running. unable to register event callback function");
         RETURN_FALSE;
     }
 
@@ -2801,7 +2801,7 @@ static PHP_METHOD(swoole_server, listen)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "server is running. can't add listener.");
+        swoole_php_fatal_error(E_WARNING, "server is running. can't add listener");
         RETURN_FALSE;
     }
 
@@ -2825,7 +2825,7 @@ static PHP_METHOD(swoole_server, addProcess)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "server is running. can't add process.");
+        swoole_php_fatal_error(E_WARNING, "server is running. can't add process");
         RETURN_FALSE;
     }
 
@@ -2837,13 +2837,13 @@ static PHP_METHOD(swoole_server, addProcess)
 
     if (ZVAL_IS_NULL(process))
     {
-        swoole_php_fatal_error(E_WARNING, "the first parameter can't be empty.");
+        swoole_php_fatal_error(E_WARNING, "the first parameter can't be empty");
         RETURN_FALSE;
     }
 
     if (!instanceof_function(Z_OBJCE_P(process), swoole_process_ce_ptr))
     {
-        swoole_php_fatal_error(E_ERROR, "object is not instanceof swoole_process.");
+        swoole_php_fatal_error(E_ERROR, "object is not instanceof swoole_process");
         RETURN_FALSE;
     }
 
@@ -2864,7 +2864,7 @@ static PHP_METHOD(swoole_server, addProcess)
     int id = swServer_add_worker(serv, worker);
     if (id < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "swServer_add_worker failed.");
+        swoole_php_fatal_error(E_WARNING, "swServer_add_worker failed");
         RETURN_FALSE;
     }
     zend_update_property_long(swoole_process_ce_ptr, process, ZEND_STRL("id"), id);
@@ -2889,7 +2889,7 @@ static PHP_METHOD(swoole_server, start)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "server is running. unable to execute swoole_server->start.");
+        swoole_php_fatal_error(E_WARNING, "server is running. unable to execute swoole_server->start");
         RETURN_FALSE;
     }
 
@@ -2957,7 +2957,7 @@ static PHP_METHOD(swoole_server, send)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -2970,7 +2970,7 @@ static PHP_METHOD(swoole_server, send)
 
     if (UNEXPECTED(ZVAL_IS_NULL(zfd)))
     {
-        swoole_php_fatal_error(E_WARNING, "fd can not be null.");
+        swoole_php_fatal_error(E_WARNING, "fd can not be null");
         RETURN_FALSE;
     }
 
@@ -2979,7 +2979,7 @@ static PHP_METHOD(swoole_server, send)
 
     if (length == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data is empty.");
+        swoole_php_fatal_error(E_WARNING, "data is empty");
         RETURN_FALSE;
     }
 
@@ -3001,7 +3001,7 @@ static PHP_METHOD(swoole_server, send)
     fd = zval_get_long(zfd);
     if (UNEXPECTED((int) fd <= 0))
     {
-        swoole_php_fatal_error(E_WARNING, "invalid fd[" ZEND_LONG_FMT "].", fd);
+        swoole_php_fatal_error(E_WARNING, "invalid fd[" ZEND_LONG_FMT "]", fd);
         RETURN_FALSE;
     }
     ret = serv->send(serv, fd, data, length);
@@ -3030,7 +3030,7 @@ static PHP_METHOD(swoole_server, sendto)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3044,7 +3044,7 @@ static PHP_METHOD(swoole_server, sendto)
 
     if (len == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data is empty.");
+        swoole_php_fatal_error(E_WARNING, "data is empty");
         RETURN_FALSE;
     }
 
@@ -3055,12 +3055,12 @@ static PHP_METHOD(swoole_server, sendto)
 
     if (ipv6 == 0 && serv->udp_socket_ipv4 <= 0)
     {
-        swoole_php_fatal_error(E_WARNING, "UDP listener has to be added before executing sendto.");
+        swoole_php_fatal_error(E_WARNING, "UDP listener has to be added before executing sendto");
         RETURN_FALSE;
     }
     else if (ipv6 == 1 && serv->udp_socket_ipv6 <= 0)
     {
-        swoole_php_fatal_error(E_WARNING, "UDP6 listener has to be added before executing sendto.");
+        swoole_php_fatal_error(E_WARNING, "UDP6 listener has to be added before executing sendto");
         RETURN_FALSE;
     }
 
@@ -3093,7 +3093,7 @@ static PHP_METHOD(swoole_server, sendfile)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3104,7 +3104,7 @@ static PHP_METHOD(swoole_server, sendfile)
 
     if (swIsMaster())
     {
-        swoole_php_fatal_error(E_WARNING, "can't sendfile[%s] to the connections in master process.", filename);
+        swoole_php_fatal_error(E_WARNING, "can't sendfile[%s] to the connections in master process", filename);
         RETURN_FALSE;
     }
 
@@ -3119,13 +3119,13 @@ static PHP_METHOD(swoole_server, close)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
     if (swIsMaster())
     {
-        swoole_php_fatal_error(E_WARNING, "can't close the connections in master process.");
+        swoole_php_fatal_error(E_WARNING, "can't close the connections in master process");
         RETURN_FALSE;
     }
 
@@ -3145,13 +3145,13 @@ static PHP_METHOD(swoole_server, confirm)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
     if (swIsMaster())
     {
-        swoole_php_fatal_error(E_WARNING, "can't confirm the connections in master process.");
+        swoole_php_fatal_error(E_WARNING, "can't confirm the connections in master process");
         RETURN_FALSE;
     }
 
@@ -3170,7 +3170,7 @@ static PHP_METHOD(swoole_server, pause)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3189,7 +3189,7 @@ static PHP_METHOD(swoole_server, resume)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3207,7 +3207,7 @@ static PHP_METHOD(swoole_server, stats)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3268,7 +3268,7 @@ static PHP_METHOD(swoole_server, reload)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3293,7 +3293,7 @@ static PHP_METHOD(swoole_server, heartbeat)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3346,12 +3346,12 @@ static PHP_METHOD(swoole_server, taskwait)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
     if (!swIsWorker())
     {
-        swoole_php_fatal_error(E_WARNING, "taskwait method can only be used in the worker process.");
+        swoole_php_fatal_error(E_WARNING, "taskwait method can only be used in the worker process");
         RETURN_FALSE;
     }
 
@@ -3440,12 +3440,12 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
     if (!swIsWorker())
     {
-        swoole_php_fatal_error(E_WARNING, "taskWaitMulti method can only be used in the worker process.");
+        swoole_php_fatal_error(E_WARNING, "taskWaitMulti method can only be used in the worker process");
         RETURN_FALSE;
     }
 
@@ -3463,7 +3463,7 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
 
     if (n_task >= SW_MAX_CONCURRENT_TASK)
     {
-        swoole_php_fatal_error(E_WARNING, "too many concurrent tasks.");
+        swoole_php_fatal_error(E_WARNING, "too many concurrent tasks");
         RETURN_FALSE;
     }
 
@@ -3497,7 +3497,7 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
         task_id = php_swoole_task_pack(&buf, task);
         if (task_id < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "task pack failed.");
+            swoole_php_fatal_error(E_WARNING, "task pack failed");
             goto fail;
         }
         swTask_type(&buf) |= SW_TASK_WAITALL;
@@ -3591,13 +3591,13 @@ static PHP_METHOD(swoole_server, taskCo)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
     if (!swIsWorker())
     {
-        swoole_php_fatal_error(E_WARNING, "taskCo method can only be used in the worker process.");
+        swoole_php_fatal_error(E_WARNING, "taskCo method can only be used in the worker process");
         RETURN_FALSE;
     }
 
@@ -3613,7 +3613,7 @@ static PHP_METHOD(swoole_server, taskCo)
 
     if (n_task >= SW_MAX_CONCURRENT_TASK)
     {
-        swoole_php_fatal_error(E_WARNING, "too many concurrent tasks.");
+        swoole_php_fatal_error(E_WARNING, "too many concurrent tasks");
         RETURN_FALSE;
     }
 
@@ -3642,7 +3642,7 @@ static PHP_METHOD(swoole_server, taskCo)
         task_id = php_swoole_task_pack(&buf, task);
         if (task_id < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "failed to pack task.");
+            swoole_php_fatal_error(E_WARNING, "failed to pack task");
             goto fail;
         }
         swTask_type(&buf) |= (SW_TASK_NONBLOCK | SW_TASK_COROUTINE);
@@ -3697,7 +3697,7 @@ static PHP_METHOD(swoole_server, task)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3760,7 +3760,7 @@ static PHP_METHOD(swoole_server, sendMessage)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3771,19 +3771,19 @@ static PHP_METHOD(swoole_server, sendMessage)
 
     if (worker_id == SwooleWG.id)
     {
-        swoole_php_fatal_error(E_WARNING, "can't send messages to self.");
+        swoole_php_fatal_error(E_WARNING, "can't send messages to self");
         RETURN_FALSE;
     }
 
     if (worker_id >= serv->worker_num + serv->task_worker_num)
     {
-        swoole_php_fatal_error(E_WARNING, "worker_id[%d] is invalid.", (int) worker_id);
+        swoole_php_fatal_error(E_WARNING, "worker_id[%d] is invalid", (int) worker_id);
         RETURN_FALSE;
     }
 
     if (!serv->onPipeMessage)
     {
-        swoole_php_fatal_error(E_WARNING, "onPipeMessage is null, can't use sendMessage.");
+        swoole_php_fatal_error(E_WARNING, "onPipeMessage is null, can't use sendMessage");
         RETURN_FALSE;
     }
 
@@ -3806,12 +3806,12 @@ static PHP_METHOD(swoole_server, finish)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
     if (unlikely(serv->task_enable_coroutine))
     {
-        swoole_php_fatal_error(E_ERROR, "please use %s->finish instead when task_enable_coroutine is enable.", ZSTR_VAL(swoole_server_task_ce_ptr->name));
+        swoole_php_fatal_error(E_ERROR, "please use %s->finish instead when task_enable_coroutine is enable", ZSTR_VAL(swoole_server_task_ce_ptr->name));
         RETURN_FALSE;
     }
 
@@ -3829,7 +3829,7 @@ static PHP_METHOD(swoole_server_task, finish)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3849,7 +3849,7 @@ static PHP_METHOD(swoole_server, bind)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3912,7 +3912,7 @@ static PHP_METHOD(swoole_server, connection_info)
     swServer *serv = (swServer *) swoole_get_object(zobject);
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -3978,7 +3978,7 @@ static PHP_METHOD(swoole_server, connection_list)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -4052,7 +4052,7 @@ static PHP_METHOD(swoole_server, sendwait)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -4066,13 +4066,13 @@ static PHP_METHOD(swoole_server, sendwait)
 
     if (length == 0)
     {
-        swoole_php_fatal_error(E_WARNING, "data is empty.");
+        swoole_php_fatal_error(E_WARNING, "data is empty");
         RETURN_FALSE;
     }
 
     if (serv->factory_mode != SW_MODE_BASE || swIsTaskWorker())
     {
-        swoole_php_fatal_error(E_WARNING, "can't sendwait.");
+        swoole_php_fatal_error(E_WARNING, "can't sendwait");
         RETURN_FALSE;
     }
 
@@ -4086,7 +4086,7 @@ static PHP_METHOD(swoole_server, exists)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -4118,7 +4118,7 @@ static PHP_METHOD(swoole_server, protect)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -4150,7 +4150,7 @@ static PHP_METHOD(swoole_server, getReceivedTime)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
     if (serv->last_receive_usec > 0)
@@ -4169,13 +4169,13 @@ static PHP_METHOD(swoole_server, shutdown)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
     if (swKill(serv->gs->master_pid, SIGTERM) < 0)
     {
-        swoole_php_sys_error(E_WARNING, "failed to shutdown. swKill(%d, SIGTERM) failed.", serv->gs->master_pid);
+        swoole_php_sys_error(E_WARNING, "failed to shutdown. swKill(%d, SIGTERM) failed", serv->gs->master_pid);
         RETURN_FALSE;
     }
     else
@@ -4189,7 +4189,7 @@ static PHP_METHOD(swoole_server, stop)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        swoole_php_fatal_error(E_WARNING, "server is not running.");
+        swoole_php_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
 
@@ -4217,7 +4217,7 @@ static PHP_METHOD(swoole_server, stop)
         }
         else if (swKill(worker->pid, SIGTERM) < 0)
         {
-            swoole_php_sys_error(E_WARNING, "swKill(%d, SIGTERM) failed.", worker->pid);
+            swoole_php_sys_error(E_WARNING, "swKill(%d, SIGTERM) failed", worker->pid);
             RETURN_FALSE;
         }
     }

--- a/swoole_server_port.cc
+++ b/swoole_server_port.cc
@@ -113,7 +113,7 @@ void swoole_server_port_init(int module_number)
 
 static PHP_METHOD(swoole_server_port, __construct)
 {
-    swoole_php_fatal_error(E_ERROR, "please use the Swoole\\Server->listen method.");
+    swoole_php_fatal_error(E_ERROR, "please use the Swoole\\Server->listen method");
     return;
 }
 
@@ -155,7 +155,7 @@ static PHP_METHOD(swoole_server_port, set)
 
     if (port == NULL || property == NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "please use the swoole_server->listen method.");
+        swoole_php_fatal_error(E_ERROR, "please use the swoole_server->listen method");
         return;
     }
 
@@ -345,7 +345,7 @@ static PHP_METHOD(swoole_server_port, set)
         port->protocol.package_length_offset = (int) zval_get_long(v);
         if (port->protocol.package_length_offset > SW_IPC_BUFFER_SIZE)
         {
-            swoole_php_fatal_error(E_ERROR, "'package_length_offset' value is too large.");
+            swoole_php_fatal_error(E_ERROR, "'package_length_offset' value is too large");
         }
     }
     //package body start
@@ -354,7 +354,7 @@ static PHP_METHOD(swoole_server_port, set)
         port->protocol.package_body_offset = (int) zval_get_long(v);
         if (port->protocol.package_body_offset > SW_IPC_BUFFER_SIZE)
         {
-            swoole_php_fatal_error(E_ERROR, "'package_body_offset' value is too large.");
+            swoole_php_fatal_error(E_ERROR, "'package_body_offset' value is too large");
         }
     }
     //length function
@@ -410,7 +410,7 @@ static PHP_METHOD(swoole_server_port, set)
             zend::string str_v(v);
             if (access(str_v.val(), R_OK) < 0)
             {
-                swoole_php_fatal_error(E_ERROR, "ssl cert file[%s] not found.", str_v.val());
+                swoole_php_fatal_error(E_ERROR, "ssl cert file[%s] not found", str_v.val());
                 return;
             }
             if (port->ssl_option.cert_file)
@@ -425,7 +425,7 @@ static PHP_METHOD(swoole_server_port, set)
             zend::string str_v(v);
             if (access(str_v.val(), R_OK) < 0)
             {
-                swoole_php_fatal_error(E_ERROR, "ssl key file[%s] not found.", str_v.val());
+                swoole_php_fatal_error(E_ERROR, "ssl key file[%s] not found", str_v.val());
                 return;
             }
             if (port->ssl_option.key_file)
@@ -452,7 +452,7 @@ static PHP_METHOD(swoole_server_port, set)
             zend::string str_v(v);
             if (access(str_v.val(), R_OK) < 0)
             {
-                swoole_php_fatal_error(E_ERROR, "ssl_client_cert_file[%s] not found.", str_v.val());
+                swoole_php_fatal_error(E_ERROR, "ssl_client_cert_file[%s] not found", str_v.val());
                 return;
             }
             if (port->ssl_option.client_cert_file)
@@ -511,7 +511,7 @@ static PHP_METHOD(swoole_server_port, set)
         //    }
         if (swPort_enable_ssl_encrypt(port) < 0)
         {
-            swoole_php_fatal_error(E_ERROR, "swPort_enable_ssl_encrypt() failed.");
+            swoole_php_fatal_error(E_ERROR, "swPort_enable_ssl_encrypt() failed");
             RETURN_FALSE;
         }
     }
@@ -532,7 +532,7 @@ static PHP_METHOD(swoole_server_port, on)
     swServer *serv = property->serv;
     if (serv->gs->start > 0)
     {
-        swoole_php_fatal_error(E_WARNING, "can't register event callback function after server started.");
+        swoole_php_fatal_error(E_WARNING, "can't register event callback function after server started");
         RETURN_FALSE;
     }
 

--- a/swoole_socket_coro.cc
+++ b/swoole_socket_coro.cc
@@ -845,13 +845,13 @@ SW_API bool php_swoole_export_socket(zval *zobject, int fd, enum swSocket_type t
     int new_fd = dup(fd);
     if (new_fd < 0)
     {
-        swoole_php_fatal_error(E_WARNING, "dup(%d) failed. Error: %s [%d]", fd, strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "dup(%d) failed", fd);
         return false;
     }
     sock->socket = new Socket(new_fd, type);
     if (UNEXPECTED(sock->socket->socket == nullptr))
     {
-        swoole_php_fatal_error(E_WARNING, "new Socket() failed. Error: %s [%d]", strerror(errno), errno);
+        swoole_php_sys_error(E_WARNING, "new Socket() failed");
         delete sock->socket;
         sock->socket = nullptr;
         OBJ_RELEASE(object);

--- a/swoole_socket_coro.cc
+++ b/swoole_socket_coro.cc
@@ -157,7 +157,7 @@ static const zend_function_entry swoole_socket_coro_methods[] =
         socket_coro* _sock = swoole_socket_coro_fetch_object(Z_OBJ_P(_zobject)); \
         if (UNEXPECTED(!sock->socket)) \
         { \
-            swoole_php_fatal_error(E_ERROR, "you must call Socket constructor first."); \
+            swoole_php_fatal_error(E_ERROR, "you must call Socket constructor first"); \
         } \
         if (UNEXPECTED(_sock->socket == SW_BAD_SOCKET)) { \
             zend_update_property_long(swoole_socket_coro_ce_ptr, _zobject, ZEND_STRL("errCode"), EBADF); \
@@ -1518,7 +1518,7 @@ static PHP_METHOD(swoole_socket_coro, setOption)
     retval = setsockopt(sock->socket->get_fd(), level, optname, opt_ptr, optlen);
     if (retval != 0)
     {
-        swoole_php_sys_error(E_WARNING, "setsockopt(%d) failed.", sock->socket->get_fd());
+        swoole_php_sys_error(E_WARNING, "setsockopt(%d) failed", sock->socket->get_fd());
         RETURN_FALSE
     }
 

--- a/swoole_table.c
+++ b/swoole_table.c
@@ -296,7 +296,7 @@ PHP_METHOD(swoole_table, __construct)
     swTable *table = swTable_new(table_size, conflict_proportion);
     if (table == NULL)
     {
-        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure.", SW_ERROR_MALLOC_FAIL);
+        zend_throw_exception(swoole_exception_ce_ptr, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
     swoole_set_object(getThis(), table);
@@ -315,7 +315,7 @@ PHP_METHOD(swoole_table, column)
     }
     if (type == SW_TABLE_STRING && size < 1)
     {
-        swoole_php_fatal_error(E_WARNING, "the length of string type values has to be more than zero.");
+        swoole_php_fatal_error(E_WARNING, "the length of string type values has to be more than zero");
         RETURN_FALSE;
     }
     //default int32
@@ -326,7 +326,7 @@ PHP_METHOD(swoole_table, column)
     swTable *table = swoole_get_object(getThis());
     if (table->memory)
     {
-        swoole_php_fatal_error(E_WARNING, "can't add column after the creation of swoole table.");
+        swoole_php_fatal_error(E_WARNING, "can't add column after the creation of swoole table");
         RETURN_FALSE;
     }
     swTableColumn_add(table, name, len, type, size);
@@ -338,12 +338,12 @@ static PHP_METHOD(swoole_table, create)
     swTable *table = swoole_get_object(getThis());
     if (table->memory)
     {
-        swoole_php_fatal_error(E_WARNING, "the swoole table has been created already.");
+        swoole_php_fatal_error(E_WARNING, "the swoole table has been created already");
         RETURN_FALSE;
     }
     if (swTable_create(table) < 0)
     {
-        swoole_php_fatal_error(E_ERROR, "unable to allocate memory.");
+        swoole_php_fatal_error(E_ERROR, "unable to allocate memory");
         RETURN_FALSE;
     }
     zend_update_property_long(swoole_buffer_ce_ptr, getThis(), ZEND_STRL("size"), table->size);
@@ -356,7 +356,7 @@ static PHP_METHOD(swoole_table, destroy)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -378,7 +378,7 @@ static PHP_METHOD(swoole_table, set)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -387,7 +387,7 @@ static PHP_METHOD(swoole_table, set)
     if (!row)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_error(E_WARNING, "unable to allocate memory.");
+        swoole_php_error(E_WARNING, "unable to allocate memory");
         RETURN_FALSE;
     }
 
@@ -450,7 +450,7 @@ static PHP_METHOD(swoole_table, incr)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -458,7 +458,7 @@ static PHP_METHOD(swoole_table, incr)
     if (!row)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "unable to allocate memory.");
+        swoole_php_fatal_error(E_WARNING, "unable to allocate memory");
         RETURN_FALSE;
     }
 
@@ -467,13 +467,13 @@ static PHP_METHOD(swoole_table, incr)
     if (column == NULL)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist.", col);
+        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist", col);
         RETURN_FALSE;
     }
     else if (column->type == SW_TABLE_STRING)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "can't execute 'incr' on a string type column.");
+        swoole_php_fatal_error(E_WARNING, "can't execute 'incr' on a string type column");
         RETURN_FALSE;
     }
     else if (column->type == SW_TABLE_FLOAT)
@@ -526,7 +526,7 @@ static PHP_METHOD(swoole_table, decr)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -534,7 +534,7 @@ static PHP_METHOD(swoole_table, decr)
     if (!row)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "unable to allocate memory.");
+        swoole_php_fatal_error(E_WARNING, "unable to allocate memory");
         RETURN_FALSE;
     }
 
@@ -543,13 +543,13 @@ static PHP_METHOD(swoole_table, decr)
     if (column == NULL)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist.", col);
+        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist", col);
         RETURN_FALSE;
     }
     else if (column->type == SW_TABLE_STRING)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "can't execute 'decr' on a string type column.");
+        swoole_php_fatal_error(E_WARNING, "can't execute 'decr' on a string type column");
         RETURN_FALSE;
     }
     else if (column->type == SW_TABLE_FLOAT)
@@ -601,7 +601,7 @@ static PHP_METHOD(swoole_table, get)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -637,7 +637,7 @@ static PHP_METHOD(swoole_table, offsetGet)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "Must create table first.");
+        swoole_php_fatal_error(E_ERROR, "Must create table first");
         RETURN_FALSE;
     }
 
@@ -674,7 +674,7 @@ static PHP_METHOD(swoole_table, exists)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -709,7 +709,7 @@ static PHP_METHOD(swoole_table, del)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     SW_CHECK_RETURN(swTableRow_del(table, key, keylen));
@@ -735,7 +735,7 @@ static PHP_METHOD(swoole_table, count)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -767,7 +767,7 @@ static PHP_METHOD(swoole_table, rewind)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     swTable_iterator_rewind(table);
@@ -779,7 +779,7 @@ static PHP_METHOD(swoole_table, current)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     swTableRow *row = swTable_iterator_current(table);
@@ -793,7 +793,7 @@ static PHP_METHOD(swoole_table, key)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     swTableRow *row = swTable_iterator_current(table);
@@ -807,7 +807,7 @@ static PHP_METHOD(swoole_table, next)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     swTable_iterator_forward(table);
@@ -818,7 +818,7 @@ static PHP_METHOD(swoole_table, valid)
     swTable *table = swoole_get_object(getThis());
     if (!table->memory)
     {
-        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist.");
+        swoole_php_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
     swTableRow *row = swTable_iterator_current(table);
@@ -872,7 +872,7 @@ static PHP_METHOD(swoole_table_row, offsetSet)
     swTable *table = swoole_get_object(getThis());
     if (table == NULL || table->memory == NULL)
     {
-        swoole_php_fatal_error(E_ERROR, "Must create table first.");
+        swoole_php_fatal_error(E_ERROR, "Must create table first");
         RETURN_FALSE;
     }
 
@@ -883,7 +883,7 @@ static PHP_METHOD(swoole_table_row, offsetSet)
     if (!row)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_error(E_WARNING, "Unable to allocate memory.");
+        swoole_php_error(E_WARNING, "Unable to allocate memory");
         RETURN_FALSE;
     }
 
@@ -892,7 +892,7 @@ static PHP_METHOD(swoole_table_row, offsetSet)
     if (col == NULL)
     {
         swTableRow_unlock(_rowlock);
-        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist.", key);
+        swoole_php_fatal_error(E_WARNING, "column[%s] does not exist", key);
         RETURN_FALSE;
     }
     if (col->type == SW_TABLE_STRING)
@@ -922,7 +922,7 @@ static PHP_METHOD(swoole_table_row, offsetSet)
 
 static PHP_METHOD(swoole_table_row, offsetUnset)
 {
-    swoole_php_fatal_error(E_WARNING, "not supported.");
+    swoole_php_fatal_error(E_WARNING, "not supported");
     RETURN_FALSE;
 }
 

--- a/swoole_timer.cc
+++ b/swoole_timer.cc
@@ -59,7 +59,7 @@ static void php_swoole_onTimeout(swTimer *timer, swTimer_node *tnode)
     {
         if (PHPCoroutine::create(&fci->fci_cache, fci->fci.param_count, fci->fci.params) < 0)
         {
-            swoole_php_fatal_error(E_WARNING, "create onTimer coroutine error.");
+            swoole_php_fatal_error(E_WARNING, "create onTimer coroutine error");
         }
     }
     else
@@ -67,7 +67,7 @@ static void php_swoole_onTimeout(swTimer *timer, swTimer_node *tnode)
         zval retval;
         if (sw_call_user_function_fast_ex(NULL, &fci->fci_cache, &retval, fci->fci.param_count, fci->fci.params) == FAILURE)
         {
-            swoole_php_fatal_error(E_WARNING, "onTimeout handler error.");
+            swoole_php_fatal_error(E_WARNING, "onTimeout handler error");
         }
         zval_ptr_dtor(&retval);
     }
@@ -107,7 +107,7 @@ static void php_swoole_add_timer(INTERNAL_FUNCTION_PARAMETERS, bool persistent)
     tnode = swTimer_add(&SwooleG.timer, ms, persistent, fci, php_swoole_onTimeout);
     if (UNEXPECTED(!tnode))
     {
-        swoole_php_fatal_error(E_WARNING, "add timer failed.");
+        swoole_php_fatal_error(E_WARNING, "add timer failed");
         goto _failed;
     }
     tnode->type = SW_TIMER_TYPE_PHP;

--- a/swoole_trace.c
+++ b/swoole_trace.c
@@ -56,7 +56,7 @@ static void trace_request(swWorker *worker)
     int ret = trace_dump(worker, slowlog);
     if (ret < 0)
     {
-        swSysWarn("failed to trace worker %d, error lint =%d.", worker->pid, -ret);
+        swSysWarn("failed to trace worker %d, error lint =%d", worker->pid, -ret);
     }
     if (0 > ptrace(PTRACE_DETACH, traced_pid, (void *) 1, 0))
     {
@@ -76,7 +76,7 @@ void php_swoole_trace_check(void *arg)
     for (; i < count; i++)
     {
         worker = swServer_get_worker(serv, i);
-        swTraceLog(SW_TRACE_SERVER, "trace request, worker#%d, pid=%d. request_time=%ld.", i, worker->pid, worker->request_time);
+        swTraceLog(SW_TRACE_SERVER, "trace request, worker#%d, pid=%d. request_time=%ld", i, worker->pid, worker->request_time);
         if (!(worker->request_time > 0 && worker->traced == 0 && serv->gs->now - worker->request_time >= timeout))
         {
             continue;

--- a/swoole_trace.c
+++ b/swoole_trace.c
@@ -56,11 +56,11 @@ static void trace_request(swWorker *worker)
     int ret = trace_dump(worker, slowlog);
     if (ret < 0)
     {
-        swSysError("failed to trace worker %d, error lint =%d.", worker->pid, -ret);
+        swSysWarn("failed to trace worker %d, error lint =%d.", worker->pid, -ret);
     }
     if (0 > ptrace(PTRACE_DETACH, traced_pid, (void *) 1, 0))
     {
-        swSysError("failed to ptrace(DETACH) worker %d", worker->pid);
+        swSysWarn("failed to ptrace(DETACH) worker %d", worker->pid);
     }
     fflush(slowlog);
 }
@@ -83,7 +83,7 @@ void php_swoole_trace_check(void *arg)
         }
         if (ptrace(PTRACE_ATTACH, worker->pid, 0, 0) < 0)
         {
-            swSysError("failed to ptrace(ATTACH, %d) worker#%d,", worker->pid, worker->id);
+            swSysWarn("failed to ptrace(ATTACH, %d) worker#%d,", worker->pid, worker->id);
             continue;
         }
         worker->tracer = trace_request;

--- a/swoole_websocket_server.cc
+++ b/swoole_websocket_server.cc
@@ -189,7 +189,7 @@ int php_swoole_websocket_frame_pack(swString *buffer, zval *zdata, zend_bool opc
     }
     if (unlikely(opcode > SW_WEBSOCKET_OPCODE_MAX))
     {
-        swoole_php_fatal_error(E_WARNING, "the maximum value of opcode is %d.", SW_WEBSOCKET_OPCODE_MAX);
+        swoole_php_fatal_error(E_WARNING, "the maximum value of opcode is %d", SW_WEBSOCKET_OPCODE_MAX);
         return SW_ERR;
     }
     zend::string str_zdata;
@@ -216,7 +216,7 @@ void swoole_websocket_onOpen(swServer *serv, http_context *ctx)
     swConnection *conn = swWorker_get_connection(serv, fd);
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "session[%d] is closed.", fd);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "session[%d] is closed", fd);
         return;
     }
 
@@ -237,7 +237,7 @@ void swoole_websocket_onOpen(swServer *serv, http_context *ctx)
     {
         if (PHPCoroutine::create(fci_cache, 2, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create onOpen coroutine error.");
+            swoole_php_error(E_WARNING, "create onOpen coroutine error");
             serv->close(serv, fd, 0);
             return;
         }
@@ -247,7 +247,7 @@ void swoole_websocket_onOpen(swServer *serv, http_context *ctx)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "onOpen handler error.");
+            swoole_php_error(E_WARNING, "onOpen handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -326,7 +326,7 @@ static int websocket_handshake(swServer *serv, swListenPort *port, http_context 
     swConnection *conn = swWorker_get_connection(serv, ctx->fd);
     if (!conn)
     {
-        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "session[%d] is closed.", ctx->fd);
+        swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SESSION_CLOSED, "session[%d] is closed", ctx->fd);
         return SW_ERR;
     }
     conn->websocket_status = WEBSOCKET_STATUS_ACTIVE;
@@ -369,7 +369,7 @@ int swoole_websocket_onMessage(swServer *serv, swEventData *req)
     {
         if (PHPCoroutine::create(fci_cache, 2, args) < 0)
         {
-            swoole_php_error(E_WARNING, "create onMessage coroutine error.");
+            swoole_php_error(E_WARNING, "create onMessage coroutine error");
             SwooleG.serv->factory.end(&SwooleG.serv->factory, fd);
         }
     }
@@ -378,7 +378,7 @@ int swoole_websocket_onMessage(swServer *serv, swEventData *req)
         zval _retval, *retval = &_retval;
         if (sw_call_user_function_fast_ex(NULL, fci_cache, retval, 2, args) == FAILURE)
         {
-            swoole_php_error(E_WARNING, "onMessage handler error.");
+            swoole_php_error(E_WARNING, "onMessage handler error");
         }
         zval_ptr_dtor(retval);
     }
@@ -462,7 +462,7 @@ static sw_inline int swoole_websocket_server_push(swServer *serv, int fd, swStri
 {
     if (unlikely(fd <= 0))
     {
-        swoole_php_fatal_error(E_WARNING, "fd[%d] is invalid.", fd);
+        swoole_php_fatal_error(E_WARNING, "fd[%d] is invalid", fd);
         return SW_ERR;
     }
 
@@ -470,7 +470,7 @@ static sw_inline int swoole_websocket_server_push(swServer *serv, int fd, swStri
     if (!conn || conn->websocket_status < WEBSOCKET_STATUS_HANDSHAKE)
     {
         SwooleG.error = SW_ERROR_WEBSOCKET_UNCONNECTED;
-        swoole_php_fatal_error(E_WARNING, "the connected client of connection[%d] is not a websocket client or closed.", (int ) fd);
+        swoole_php_fatal_error(E_WARNING, "the connected client of connection[%d] is not a websocket client or closed", (int ) fd);
         return SW_ERR;
     }
 
@@ -615,7 +615,7 @@ static PHP_METHOD(swoole_websocket_server, isEstablished)
     swServer *serv = (swServer *) swoole_get_object(getThis());
     if (unlikely(!serv->gs->start))
     {
-        php_error_docref(NULL, E_WARNING, "the server is not running.");
+        php_error_docref(NULL, E_WARNING, "the server is not running");
         RETURN_FALSE;
     }
 

--- a/tests/swoole_coroutine/exit_exception_backtrace.phpt
+++ b/tests/swoole_coroutine/exit_exception_backtrace.phpt
@@ -28,7 +28,7 @@ go(function () {
 });
 ?>
 --EXPECTF--
-Fatal error: Uncaught Swoole\ExitException: swoole exit. in %s/tests/swoole_coroutine/exit_exception_backtrace.php:15
+Fatal error: Uncaught Swoole\ExitException: swoole exit in %s/tests/swoole_coroutine/exit_exception_backtrace.php:15
 Stack trace:
 #0 %s/tests/swoole_coroutine/exit_exception_backtrace.php(10): char(%d)
 #1 %s/tests/swoole_coroutine/exit_exception_backtrace.php(5): bar('%s...')

--- a/tests/swoole_coroutine/max_num.phpt
+++ b/tests/swoole_coroutine/max_num.phpt
@@ -19,4 +19,4 @@ Assert::eq($info['coroutine_num'], 3000);
 Assert::eq($info['coroutine_peak_num'], 3000);
 ?>
 --EXPECTF--
-Warning: go(): exceed max number of coroutine 3000. in %s/tests/swoole_coroutine/max_num.php on line 9
+Warning: go(): exceed max number of coroutine 3000 in %s/tests/swoole_coroutine/max_num.php on line 9

--- a/tests/swoole_coroutine/new_process.phpt
+++ b/tests/swoole_coroutine/new_process.phpt
@@ -11,4 +11,7 @@ go(function () {
 });
 ?>
 --EXPECTF--
-[%s]	ERROR	must be forked outside the coroutine
+[%s]	ERROR	(PHP Fatal Error: %d):
+Swoole\Process::start: must be forked outside the coroutine
+Stack trace:
+#0  Swoole\Process->start() called at [%s/tests/swoole_coroutine/new_process.php:%d]

--- a/tests/swoole_coroutine/new_process.phpt
+++ b/tests/swoole_coroutine/new_process.phpt
@@ -11,4 +11,4 @@ go(function () {
 });
 ?>
 --EXPECTF--
-[%s]	ERROR	must be forked outside the coroutine.
+[%s]	ERROR	must be forked outside the coroutine

--- a/tests/swoole_coroutine/new_server.phpt
+++ b/tests/swoole_coroutine/new_server.phpt
@@ -12,4 +12,7 @@ go(function () {
 });
 ?>
 --EXPECTF--
-[%s]	ERROR	must be forked outside the coroutine
+[%s]	ERROR	(PHP Fatal Error: %d):
+Swoole\Server::start: must be forked outside the coroutine
+Stack trace:
+#0  Swoole\Server->start() called at [%s/tests/swoole_coroutine/new_server.php:%d]

--- a/tests/swoole_coroutine/new_server.phpt
+++ b/tests/swoole_coroutine/new_server.phpt
@@ -12,4 +12,4 @@ go(function () {
 });
 ?>
 --EXPECTF--
-[%s]	ERROR	must be forked outside the coroutine.
+[%s]	ERROR	must be forked outside the coroutine

--- a/tests/swoole_global/channel_construct_check.phpt
+++ b/tests/swoole_global/channel_construct_check.phpt
@@ -17,4 +17,4 @@ go(function () {
 });
 ?>
 --EXPECTF--
-Fatal error: Swoole\Coroutine\Channel::push(): you must call Channel constructor first. in %s on line %d
+Fatal error: Swoole\Coroutine\Channel::push(): you must call Channel constructor first in %s on line %d

--- a/tests/swoole_global/socket_construct_check.phpt
+++ b/tests/swoole_global/socket_construct_check.phpt
@@ -17,4 +17,4 @@ go(function () {
 });
 ?>
 --EXPECTF--
-Fatal error: Swoole\Coroutine\Socket::connect(): you must call Socket constructor first. in %s on line %d
+Fatal error: Swoole\Coroutine\Socket::connect(): you must call Socket constructor first in %s on line %d

--- a/tests/swoole_http2_client_coro/error.phpt
+++ b/tests/swoole_http2_client_coro/error.phpt
@@ -16,6 +16,6 @@ go(function () {
 Swoole\Event::wait();
 ?>
 --EXPECTF--
-Warning: Swoole\Coroutine\Http2\Client::send(): client is not connected to server. in %s on line %d
+Warning: Swoole\Coroutine\Http2\Client::send(): client is not connected to server in %s on line %d
 
-Warning: Swoole\Coroutine\Http2\Client::recv(): client is not connected to server. in %s on line %d
+Warning: Swoole\Coroutine\Http2\Client::recv(): client is not connected to server in %s on line %d

--- a/tests/swoole_http2_server/huge_headers.phpt
+++ b/tests/swoole_http2_server/huge_headers.phpt
@@ -66,5 +66,5 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Warning: Swoole\Coroutine\Http2\Client::send(): header cannot bigger than remote max_header_list_size %d. in %s on line %d
-[%s]	WARNING	http2_client_send_request: http2_client_build_header() failed.
+Warning: Swoole\Coroutine\Http2\Client::send(): header cannot bigger than remote max_header_list_size %d in %s on line %d
+[%s]	WARNING	http2_client_send_request: http2_client_build_header() failed

--- a/tests/swoole_http_client_coro/construct_failed.phpt
+++ b/tests/swoole_http_client_coro/construct_failed.phpt
@@ -8,7 +8,7 @@ require __DIR__ . '/../include/bootstrap.php';
 $http = new Co\Http\Client('');
 ?>
 --EXPECTF--
-Fatal error: Uncaught Swoole\Coroutine\Http\Client\Exception: host is empty. in %s/tests/swoole_http_client_coro/construct_failed.php:3
+Fatal error: Uncaught Swoole\Coroutine\Http\Client\Exception: host is empty in %s/tests/swoole_http_client_coro/construct_failed.php:3
 Stack trace:
 #0 %s/tests/swoole_http_client_coro/construct_failed.php(3): Swoole\Coroutine\Http\Client->__construct('')
 #1 {main}

--- a/tests/swoole_http_server/buffer_output_size.phpt
+++ b/tests/swoole_http_server/buffer_output_size.phpt
@@ -39,5 +39,5 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-[%s]	WARNING	swFactoryProcess_finish (ERRNO %d): The length of data [%d] exceeds the output buffer size[%d], please use the sendfile, chunked transfer mode or adjust the buffer_output_size.
+[%s]	WARNING	swFactoryProcess_finish (ERRNO %d): The length of data [%d] exceeds the output buffer size[%d], please use the sendfile, chunked transfer mode or adjust the buffer_output_size
 DONE

--- a/tests/swoole_http_server/max_coro_num.phpt
+++ b/tests/swoole_http_server/max_coro_num.phpt
@@ -33,8 +33,8 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Warning: Swoole\Server::start(): exceed max number of coroutine 1. in %s/tests/swoole_http_server/max_coro_num.php on line 25
+Warning: Swoole\Server::start(): exceed max number of coroutine 1 in %s/tests/swoole_http_server/max_coro_num.php on line 25
 
-Warning: Swoole\Server::start(): create Http onRequest coroutine error. in %s/tests/swoole_http_server/max_coro_num.php on line 25
+Warning: Swoole\Server::start(): create Http onRequest coroutine error in %s/tests/swoole_http_server/max_coro_num.php on line 25
 
 503

--- a/tests/swoole_http_server/task/enable_coroutine_with_wrong_usage.phpt
+++ b/tests/swoole_http_server/task/enable_coroutine_with_wrong_usage.phpt
@@ -35,4 +35,4 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Fatal error: Swoole\Server::finish(): please use Swoole\Server\Task->finish instead when task_enable_coroutine is enable. in %s/task/enable_coroutine_with_wrong_usage.php on line %d
+Fatal error: Swoole\Server::finish(): please use Swoole\Server\Task->finish instead when task_enable_coroutine is enable in %s/task/enable_coroutine_with_wrong_usage.php on line %d

--- a/tests/swoole_mysql_coro/illegal_extends.phpt
+++ b/tests/swoole_mysql_coro/illegal_extends.phpt
@@ -56,4 +56,4 @@ go(function () {
 
 ?>
 --EXPECTF--
-Warning: Swoole\Coroutine\MySQL::query(): mysql connection#%d is closed. in %s on line %d
+Warning: Swoole\Coroutine\MySQL::query(): mysql connection#%d is closed in %s on line %d

--- a/tests/swoole_mysql_coro/transaction.phpt
+++ b/tests/swoole_mysql_coro/transaction.phpt
@@ -46,10 +46,10 @@ go(function () {
 });
 ?>
 --EXPECTF--
-Deprecated: Swoole\Coroutine\MySQL::%s(): %s. in %s on line %d
+Deprecated: Swoole\Coroutine\MySQL::%s(): %s in %s on line %d
 
-Deprecated: Swoole\Coroutine\MySQL::%s(): %s. in %s on line %d
+Deprecated: Swoole\Coroutine\MySQL::%s(): %s in %s on line %d
 
-Deprecated: Swoole\Coroutine\MySQL::%s(): %s. in %s on line %d
+Deprecated: Swoole\Coroutine\MySQL::%s(): %s in %s on line %d
 
-Deprecated: Swoole\Coroutine\MySQL::%s(): %s. in %s on line %d
+Deprecated: Swoole\Coroutine\MySQL::%s(): %s in %s on line %d

--- a/tests/swoole_redis_coro/request_without_connected.phpt
+++ b/tests/swoole_redis_coro/request_without_connected.phpt
@@ -12,5 +12,5 @@ go(function () {
 });
 ?>
 --EXPECTF--
-Warning: Swoole\Coroutine\Redis::get(): The host is empty. in %s/tests/swoole_redis_coro/request_without_connected.php on line 5
+Warning: Swoole\Coroutine\Redis::get(): The host is empty in %s/tests/swoole_redis_coro/request_without_connected.php on line 5
 DONE

--- a/tests/swoole_server/bug_2308.phpt
+++ b/tests/swoole_server/bug_2308.phpt
@@ -47,4 +47,4 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Fatal error: Swoole\Coroutine::create(): Unable to use async-io in manager process. in %s on line %d
+Fatal error: Swoole\Coroutine::create(): Unable to use async-io in manager process in %s on line %d

--- a/tests/swoole_server/force_reload.phpt
+++ b/tests/swoole_server/force_reload.phpt
@@ -58,11 +58,11 @@ $pm->run();
 %d [%d] start
 %d [%d] start
 %s start to reload
-[%s]	INFO	Server is reloading all workers now.
-[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill.
-[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill.
-[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill.
-[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill.
+[%s]	INFO	Server is reloading all workers now
+[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill
+[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill
+[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill
+[%s]	WARNING	swManager_kill_timeout_process (ERRNO 9012): [Manager] Worker#%d[pid=%d] exit timeout, forced kill
 [%s]	WARNING	swManager_check_exit_status: worker#%d[pid=%d] abnormal exit, status=0, signal=9
 [%s]	WARNING	swManager_check_exit_status: worker#%d[pid=%d] abnormal exit, status=0, signal=9
 [%s]	WARNING	swManager_check_exit_status: worker#%d[pid=%d] abnormal exit, status=0, signal=9
@@ -71,4 +71,4 @@ $pm->run();
 %d [%d] start
 %d [%d] start
 %d [%d] start
-[%s]	INFO	Server is shutdown now.
+[%s]	INFO	Server is shutdown now

--- a/tests/swoole_server/force_reload2.phpt
+++ b/tests/swoole_server/force_reload2.phpt
@@ -49,11 +49,11 @@ $pm->run();
 %s
 %s
 1 [%s] start to reload
-[%s]	INFO	reload workers.
-[%s]	WARNING	swProcessPool_killTimeout: swKill(%d, SIGKILL) [%d].
-[%s]	WARNING	swProcessPool_killTimeout: swKill(%d, SIGKILL) [%d].
+[%s]	INFO	reload workers
+[%s]	WARNING	swProcessPool_killTimeout: swKill(%d, SIGKILL) [%d]
+[%s]	WARNING	swProcessPool_killTimeout: swKill(%d, SIGKILL) [%d]
 [%s]	WARNING	swProcessPool_wait: worker#%d abnormal exit, status=0, signal=9
 [%s]	WARNING	swProcessPool_wait: worker#%d abnormal exit, status=0, signal=9
 %s
 %s
-[%s]	INFO	Server is shutdown now.
+[%s]	INFO	Server is shutdown now

--- a/tests/swoole_server/invalid_fd.phpt
+++ b/tests/swoole_server/invalid_fd.phpt
@@ -40,9 +40,9 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Warning: Swoole\Server::send(): fd can not be null. in %s/tests/swoole_server/invalid_fd.php on line %d
+Warning: Swoole\Server::send(): fd can not be null in %s/tests/swoole_server/invalid_fd.php on line %d
 
-Warning: Swoole\Server::send(): invalid fd[-1]. in %s/tests/swoole_server/invalid_fd.php on line %d
-[%s]	NOTICE	swReactorProcess_send2client (ERRNO 1005): send %d byte failed, session#100 does not exist.
+Warning: Swoole\Server::send(): invalid fd[-1] in %s/tests/swoole_server/invalid_fd.php on line %d
+[%s]	NOTICE	swReactorProcess_send2client (ERRNO 1005): send %d byte failed, session#100 does not exist
 
-Warning: Swoole\Server::send(): invalid fd[9223372036854775807]. in %s/tests/swoole_server/invalid_fd.php on line %d%s
+Warning: Swoole\Server::send(): invalid fd[9223372036854775807] in %s/tests/swoole_server/invalid_fd.php on line %d%s

--- a/tests/swoole_server/unregistered_signal.phpt
+++ b/tests/swoole_server/unregistered_signal.phpt
@@ -37,4 +37,4 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-[%s]	WARNING	%s (ERRNO 707): Unable to find callback function for signal Broken pipe: 13.
+[%s]	WARNING	%s (ERRNO 707): Unable to find callback function for signal Broken pipe: 13

--- a/tests/swoole_socket_coro/setopt/bindtodevice.phpt
+++ b/tests/swoole_socket_coro/setopt/bindtodevice.phpt
@@ -26,4 +26,4 @@ $retval_2 = $socket->setOption(SOL_SOCKET, SO_BINDTODEVICE, "ethIDONOTEXIST");
 assert($retval_2 === false);
 ?>
 --EXPECTF--
-Warning: Swoole\Coroutine\Socket::setOption(): setsockopt(%d) failed. Error: No such device[%d]. in %s on line %d
+Warning: Swoole\Coroutine\Socket::setOption(): setsockopt(%d) failed, Error: No such device[%d] in %s on line %d

--- a/thirdparty/swoole_http_parser.c
+++ b/thirdparty/swoole_http_parser.c
@@ -1228,7 +1228,7 @@ size_t swoole_http_parser_execute (swoole_http_parser *parser,
 
           case h_connection:
           case h_transfer_encoding:
-            assert(0 && "Shouldn't get here.");
+            assert(0 && "Shouldn't get here");
             break;
 
           case h_content_length:


### PR DESCRIPTION
* 将`swSysError`重命名`为swSysWarn`(非致命错误退出, 仅警告), 系统调用错误统一使用`swSysWarn`, 会导致程式不可继续运行的使用`swSysError`
* 将原先的`错误警告+exit`统一替换为对应的指令如 `swError`, `swSysError`, `swFatalError`
* php层系统调用错误警告统一使用`swoole_php_sys_error`
