### PR TITLE
Add Missing Methods in Class \Swoole\Event

### DIFF
--- a/swoole.c
+++ b/swoole.c
@@ -209,6 +209,8 @@ static const zend_function_entry swoole_event_methods[] =
     ZEND_FENTRY(wait, ZEND_FN(swoole_event_wait), arginfo_swoole_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_FENTRY(defer, ZEND_FN(swoole_event_defer), arginfo_swoole_event_defer, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     ZEND_FENTRY(cycle, ZEND_FN(swoole_event_cycle), arginfo_swoole_event_cycle, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_FENTRY(dispatch, ZEND_FN(swoole_event_dispatch), arginfo_swoole_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    ZEND_FENTRY(isset, ZEND_FN(swoole_event_isset), arginfo_swoole_event_isset, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_FE_END
 };
 


### PR DESCRIPTION
Following methods are missing from class _\Swoole\Event_:

* dispatch(): same as the procedural function _swoole_event_dispatch()_.
* isset():  same as the procedural function _swoole_event_isset()_.