### PR TITLE
Fixed spaces are converted to `+` when using cookie.

### DIFF
--- a/php_swoole.h
+++ b/php_swoole.h
@@ -1049,6 +1049,15 @@ static sw_inline char* sw_php_url_encode(char *value, size_t value_len, int* ext
     return return_str;
 }
 
+static sw_inline char* sw_php_raw_url_encode(char *value, size_t value_len, int* exten)
+{
+    zend_string *str = php_raw_url_encode(value, value_len);
+    *exten = ZSTR_LEN(str);
+    char *return_str = estrndup(ZSTR_VAL(str), ZSTR_LEN(str));
+    zend_string_release(str);
+    return return_str;
+}
+
 static sw_inline char* sw_http_build_query(zval *zdata, size_t *length, smart_str *formstr)
 {
     if (php_url_encode_hash_ex(HASH_OF(zdata), formstr, NULL, 0, NULL, 0, NULL, 0, NULL, NULL, (int) PHP_QUERY_RFC1738) == FAILURE)

--- a/swoole_http_server.cc
+++ b/swoole_http_server.cc
@@ -2000,7 +2000,7 @@ static void swoole_http_response_cookie(INTERNAL_FUNCTION_PARAMETERS, bool url_e
         {
             char *encoded_value;
             int encoded_value_len;
-            encoded_value = sw_php_url_encode(value, value_len, &encoded_value_len);
+            encoded_value = sw_php_raw_url_encode(value, value_len, &encoded_value_len);
             cookie_size += encoded_value_len;
             cookie = (char *) emalloc(cookie_size);
             snprintf(cookie, cookie_size, "%s=%s", name, encoded_value);


### PR DESCRIPTION
`urlencode` 与 `rawurlencode` 效果基本一致，除了空格会被编码为加号。
所以这里我觉得应该使用 `rawurlencode` 而非 `urlencode`。

但也有可能是我考虑不周。