### PR TITLE
Support bailout in coroutine

### DIFF
--- a/include/coroutine.h
+++ b/include/coroutine.h
@@ -227,7 +227,7 @@ protected:
         {
             close();
         }
-        if (unlikely(on_bailout))
+        else if (unlikely(on_bailout))
         {
             on_bailout();
         }

--- a/include/coroutine.h
+++ b/include/coroutine.h
@@ -229,6 +229,7 @@ protected:
         }
         else if (unlikely(on_bailout))
         {
+            SW_ASSERT(current == nullptr);
             on_bailout();
         }
     }

--- a/swoole.cc
+++ b/swoole.cc
@@ -458,18 +458,9 @@ void php_swoole_register_shutdown_function_prepend(const char *function)
     }
     BG(user_shutdown_function_names) = NULL;
     php_swoole_register_shutdown_function(function);
-
-#ifdef SW_CORO_ZEND_TRY
-    zend_try
-#endif
-    {
-        old_user_shutdown_function_names->pDestructor = php_swoole_old_shutdown_function_move;
-        zend_hash_destroy(old_user_shutdown_function_names);
-        FREE_HASHTABLE(old_user_shutdown_function_names);
-    }
-#ifdef SW_CORO_ZEND_TRY
-    zend_end_try();
-#endif
+    old_user_shutdown_function_names->pDestructor = php_swoole_old_shutdown_function_move;
+    zend_hash_destroy(old_user_shutdown_function_names);
+    FREE_HASHTABLE(old_user_shutdown_function_names);
 }
 
 static void php_swoole_fatal_error(int code, const char *format, ...)

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -256,8 +256,8 @@
  * Coroutine
  */
 #define SW_DEFAULT_C_STACK_SIZE          (2 *1024 * 1024)
-#define SW_CORO_SWAP_BAILOUT
-// #define SW_CORO_ZEND_TRY
+#define SW_CORO_SUPPORT_BAILOUT          1
+#define SW_CORO_SWAP_BAILOUT             1
 
 #ifdef SW_DEBUG
 #ifndef SW_LOG_TRACE_OPEN

--- a/tests/swoole_coroutine/bailout/error.phpt
+++ b/tests/swoole_coroutine/bailout/error.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_coroutine/bailout: error
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+register_shutdown_function(function () {
+    echo 'shutdown' . PHP_EOL;
+});
+go(function () {
+    throw new Error;
+});
+?>
+--EXPECTF--
+Fatal error: Uncaught Error in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d
+shutdown

--- a/tests/swoole_coroutine/bailout/exit.phpt
+++ b/tests/swoole_coroutine/bailout/exit.phpt
@@ -16,7 +16,7 @@ $process = new Swoole\Process(function () {
 $process->start();
 $status = $process::wait();
 if (Assert::isArray($status)) {
-    [$pid, $code, $signal] = array_values($status);
+    list($pid, $code, $signal) = array_values($status);
     Assert::greaterThan($pid, 0);
     Assert::eq($code, 0);
     Assert::eq($signal, 0);

--- a/tests/swoole_coroutine/bailout/exit.phpt
+++ b/tests/swoole_coroutine/bailout/exit.phpt
@@ -1,0 +1,26 @@
+--TEST--
+swoole_coroutine/bailout: error
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+$process = new Swoole\Process(function () {
+    register_shutdown_function(function () {
+        echo 'shutdown' . PHP_EOL;
+    });
+    go(function () {
+        exit(0);
+    });
+});
+$process->start();
+$status = $process::wait();
+if (Assert::isArray($status)) {
+    [$pid, $code, $signal] = array_values($status);
+    Assert::greaterThan($pid, 0);
+    Assert::eq($code, 0);
+    Assert::eq($signal, 0);
+}
+?>
+--EXPECT--
+shutdown

--- a/tests/swoole_coroutine/call_not_exists_func.phpt
+++ b/tests/swoole_coroutine/call_not_exists_func.phpt
@@ -29,7 +29,11 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to undefined function none() in %s/tests/swoole_coroutine/call_not_exists_func.php:%d
+Fatal error: Uncaught Error: Call to undefined function none() in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %s/tests/swoole_coroutine/call_not_exists_func.php on line %d
+  thrown in %s on line %d
+[%s]	ERROR	zm_deactivate_swoole (ERRNO %d): Fatal error: Uncaught Error: Call to undefined function none() in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/tests/swoole_coroutine/exception.phpt
+++ b/tests/swoole_coroutine/exception.phpt
@@ -28,7 +28,11 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: whoops in %s/tests/swoole_coroutine/exception.php:%d
+Fatal error: Uncaught Exception: whoops in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %s/tests/swoole_coroutine/exception.php on line %d
+  thrown in %s on line %d
+[%s]	ERROR	zm_deactivate_swoole (ERRNO %d): Fatal error: Uncaught Exception: whoops in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
支持在协程中bailout

### 背景介绍

由于协程切换了C栈, 导致在协程中出现`FatalErro`r(或产生其它类似的PHP进程退出行为时), 无法正确地通过`LONGJUMP`回到`zend_try`的位置(本来回到此位置后, 程序将会进入PHP标准退出流程), 出于安全考虑, Swoole底层清理了`bailout`指针, 避免了内存错乱, 但其副作用是出现上述情况时, 进程会直接退出, 而不是走PHP的标准退出流程, 最显著的影响是, 丢失了PHP进程生命周期中的shutdown阶段, 使程序行为出现预期外的变化

### 变化

#### C层
此修改增加了`Coroutine::bailout`方法:
1. 此时进程空间若处于main中, 会直接调用参数传入的bailout回调并结束(若未在bailout回调中`exit`, 则会走向`exit(1)`错误)
2. 若处于协程中, 则会通过协程链表遍历找到离main最近的协程, 进行一次`yield`操作(此时jump_context会将C栈切回main空间, 但也会导致操作协程的上下文丢失, 但在bailout中, 保证了程序一定会退出, 那么协程上下文丢失与否没有意义), 回到main空间后, 按照协程调度流程, 会检查`ctx.end`是否销毁上下文, 若`ctx.end`为假, 那么需要检查是否有bailout, 如有则调用bailout方法(此时一定在main空间)

#### PHP层
此修改将整个协程中的PHP执行流程包上了`zend_first_try`, 并进行`zend_catch`, 在catch中调用`Coroutine::bailout`回到main空间并进行`zend_bailout` (异常捕获与`do_cli`一致了)

### 优点
完全符合预期的程序行为

### 缺点
多了一个指针检查的开销
