### PR TITLE
improve the error info

### DIFF
--- a/swoole_coroutine_util.cc
+++ b/swoole_coroutine_util.cc
@@ -447,7 +447,7 @@ static PHP_METHOD(swoole_coroutine_util, resume)
     auto coroutine_iterator = user_yield_coros.find(cid);
     if (coroutine_iterator == user_yield_coros.end())
     {
-        swoole_php_fatal_error(E_WARNING, "you can not resume the coroutine which is in IO operation");
+        swoole_php_fatal_error(E_WARNING, "you can not resume the coroutine which is in IO operation or non-existent");
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
例如：
```php
<?php

use Swoole\Coroutine;

$cid = go(function () {
    echo "co 1 start\n";
    co::yield();
    echo "co 1 end\n";
});

go(function () use ($cid) {
    echo "co 2 start\n";
    co::resume(-10);
    echo "co 2 end\n";
});

```
显示了在IO操作的警告。