### PR TITLE
fix bug: Fixed swoole_curl_error panic

### DIFF
--- a/library/ext/curl.php
+++ b/library/ext/curl.php
@@ -56,7 +56,7 @@ class swoole_curl_handler
     public $headers = [];
 
     public $errCode;
-    public $errMsg;
+    public $errMsg = '';
 
     const ERRORS = [
         CURLE_URL_MALFORMAT => 'No URL set!',

--- a/php_swoole_library.h
+++ b/php_swoole_library.h
@@ -93,7 +93,7 @@ static const char* swoole_library_source_ext_curl =
     "    public $headers = [];\n"
     "\n"
     "    public $errCode;\n"
-    "    public $errMsg;\n"
+    "    public $errMsg = '';\n"
     "\n"
     "    const ERRORS = [\n"
     "        CURLE_URL_MALFORMAT => 'No URL set!',\n"


### PR DESCRIPTION
This value of  ``$obj->errMsg`` may be null, causing the php kernel to report an error.

Modify the attribute default value to an empty string to avoid NULL cases.