### PR TITLE
fix Swoole\Coroutine\Http\Client->setCookies() bug

### DIFF
--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -1686,14 +1686,10 @@ static PHP_METHOD(swoole_http_client_coro, setCookies)
     zval *cookies;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ARRAY(cookies)
+        Z_PARAM_ARRAY_EX(cookies, 0, 1)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    zval *newCookies = sw_zend_read_and_convert_property_array(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), 0);
-
-    php_array_merge(Z_ARRVAL_P(newCookies), Z_ARRVAL_P(cookies));
-
-    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), newCookies);
+    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), cookies);
 
     RETURN_TRUE;
 }

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -1683,13 +1683,18 @@ static PHP_METHOD(swoole_http_client_coro, setBasicAuth)
 
 static PHP_METHOD(swoole_http_client_coro, setCookies)
 {
-    zval *cookies;
+    zval *cookies, newCookies;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_ARRAY(cookies)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), cookies);
+    array_init(&newCookies);
+    php_array_merge(Z_ARRVAL_P(&newCookies), Z_ARRVAL_P(cookies));
+
+    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), &newCookies);
+
+    zval_ptr_dtor(&newCookies);
 
     RETURN_TRUE;
 }

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -1683,18 +1683,17 @@ static PHP_METHOD(swoole_http_client_coro, setBasicAuth)
 
 static PHP_METHOD(swoole_http_client_coro, setCookies)
 {
-    zval *cookies, newCookies;
+    zval *cookies;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_ARRAY(cookies)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    array_init(&newCookies);
-    php_array_merge(Z_ARRVAL_P(&newCookies), Z_ARRVAL_P(cookies));
+    zval *newCookies = sw_zend_read_and_convert_property_array(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), 0);
 
-    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), &newCookies);
+    php_array_merge(Z_ARRVAL_P(newCookies), Z_ARRVAL_P(cookies));
 
-    zval_ptr_dtor(&newCookies);
+    zend_update_property(swoole_http_client_coro_ce, getThis(), ZEND_STRL("cookies"), newCookies);
 
     RETURN_TRUE;
 }

--- a/tests/swoole_http_client_coro/cookies_set_bug.phpt
+++ b/tests/swoole_http_client_coro/cookies_set_bug.phpt
@@ -1,0 +1,50 @@
+--TEST--
+swoole_http_client_coro: cookies set bug
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_in_travis('travis network');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+function getCookies()
+{
+    $result = [];
+    var_dump($result); // must be empty array
+    return $result;
+}
+
+go(function () {
+    $url_info = parse_url('http://httpbin.org/cookies/set/a/1');
+    $domain = $url_info['host'];
+    $path = $url_info['path'];
+    $cli = new Swoole\Coroutine\Http\Client($domain);
+    $cli->set(['timeout' => 5]);
+    $cli->setHeaders([
+        'Host' => $domain,
+        'User-Agent' => 'Chrome/49.0.2587.3',
+        'Accept' => 'text/html,application/xhtml+xml,application/xml',
+        'Accept-Encoding' => 'gzip'
+    ]);
+
+    // first request
+    $cookies = getCookies();
+    $cli->setCookies($cookies);
+
+    Assert::assert($cli->get($path));
+
+    // second request
+    $cookies = getCookies();
+    $cli->setCookies($cookies);
+
+    Assert::assert($cli->get('/cookies'));
+});
+
+?>
+--EXPECTF--
+array(0) {
+}
+array(0) {
+}


### PR DESCRIPTION
下面代码 `test()` 方法注释处，当第一个请求有`Set-Cookie` 时，第二次请求输出不是空数组。

```php
<?php
function test()
{
    $result = [];
    // 第二次执行，我都赋值为[]了，还输出被 Swoole\Coroutine\Http\Client 改变了的值
    var_dump($result);
    return $result;
}

go(function(){
    $client = new Swoole\Coroutine\Http\Client('httpbin.org', 80);
    $client->setMethod('GET');
    $cookies = test();
    $client->setCookies($cookies);
    $client->execute('/cookies/set/a/1');

    $client->setMethod('GET');
    $cookies = test();
    $client->setCookies($cookies);
    $client->execute('/cookies');

});
```