### PR TITLE
在不改变defer原有含义的情况下，扩展它

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -676,7 +676,7 @@ void PHPCoroutine::main_func(void *arg)
             tasks->pop();
             zval *params = (zval *) ecalloc(defer_fci->fci.param_count + 1, sizeof(zval));
 
-            if (Z_TYPE_P(retval) != IS_NULL) // no return
+            if (Z_TYPE_P(retval) != IS_NULL)
             {
                 for (i = 0; i < defer_fci->fci.param_count; i++)
                 {
@@ -685,7 +685,6 @@ void PHPCoroutine::main_func(void *arg)
                 defer_fci->fci.params = params;
                 defer_fci->fci.param_count += 1;
                 ZVAL_COPY(defer_fci->fci.params, retval);
-                
             }
 
             if (UNEXPECTED(sw_zend_call_function_anyway(&defer_fci->fci, &defer_fci->fci_cache) != SUCCESS))


### PR DESCRIPTION
```php
<?php

namespace Swoole;

go(function () {
    $a = 1;
    echo "start" . PHP_EOL;

    defer(function ($ret) {
        echo "$ret" . PHP_EOL;
    });

    echo "end" . PHP_EOL;

    return "ret";
});
```
打印出：
```shell
start
end
ret
```

```php
<?php

namespace Swoole;

go(function () {
    $a = 1;
    echo "start" . PHP_EOL;

    defer(function ($ret, $b) {
        echo "$ret" . PHP_EOL;
        echo "$b" . PHP_EOL;
    }, 'b');

    echo "end" . PHP_EOL;

    return "ret";
});
```
打印出：
```shell
start
end
ret
b
```

```php
<?php

namespace Swoole;

go(function () {
    $a = 1;
    echo "start" . PHP_EOL;

    defer(function ($b) {
        echo "$b" . PHP_EOL;
    }, 'b');

    echo "end" . PHP_EOL;
});
```
打印出：
```shell
start
end
b
```