### PR TITLE
Convert php_error_docref0() to php_error_docref()

### DIFF
--- a/thirdparty/php/sockets/conversions.cc
+++ b/thirdparty/php/sockets/conversions.cc
@@ -120,7 +120,7 @@ static void do_to_zval_err(res_context *ctx, const char *fmt, ...)
 void err_msg_dispose(struct err_s *err)
 {
 	if (err->msg != NULL) {
-		php_error_docref0(NULL, err->level, "%s", err->msg);
+		php_error_docref(NULL, err->level, "%s", err->msg);
 		if (err->should_free) {
 			efree(err->msg);
 		}

--- a/thirdparty/php/sockets/sendrecvmsg.cc
+++ b/thirdparty/php/sockets/sendrecvmsg.cc
@@ -31,7 +31,7 @@
 #define LONG_CHECK_VALID_INT(l) \
 	do { \
 		if ((l) < INT_MIN && (l) > INT_MAX) { \
-			php_error_docref0(NULL, E_WARNING, "The value " ZEND_LONG_FMT " does not fit inside " \
+			php_error_docref(NULL, E_WARNING, "The value " ZEND_LONG_FMT " does not fit inside " \
 					"the boundaries of a native integer", (l)); \
 			return; \
 		} \


### PR DESCRIPTION
Convert ``php_error_docref0()`` usage to "standard" ``php_error_docref()`` function.

See php/php-src#4394