### PR TITLE
fix taskWorker "worker exit timeout, forced to terminate"

### DIFF
--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -598,7 +598,16 @@ void swWorker_stop(swWorker *worker)
 
 static int swWorker_reactor_is_empty(swReactor *reactor)
 {
-    swServer *serv = (swServer *) reactor->ptr;
+    swServer *serv;
+    if(SwooleG.process_type == SW_PROCESS_TASKWORKER)
+    {
+        swProcessPool *pool = (swProcessPool *) reactor->ptr;
+        serv = (swServer *) pool->ptr;
+    }
+    else
+    {
+        serv = (swServer *) reactor->ptr;
+    }
     uint8_t call_worker_exit_func = 0;
 
     while (1)


### PR DESCRIPTION
解决当 `task_enable_coroutine=true` 时，taskWorker 报错：`worker exit timeout, forced to terminate`

复现代码：

```php
<?php
$http = new Swoole\Http\Server("127.0.0.1", 9501);
$http->set([
    'worker_num'        =>  1,
    'task_worker_num'   =>  1,
    'task_enable_coroutine'   =>  true, // 加这个重启会报错
    'max_wait_time' =>  30,
]);
$http->on('request', function ($request, $response) {
    $response->end("<h1>Hello Swoole. #".rand(1000, 9999)."</h1>");
});
$http->on('workerstart', function($serv){
    var_dump('workerstart');
    $serv->tick( 1000, function() use ( $serv ){
        
	});
});
$http->on('workerexit', function(){
    \Swoole\Timer::clearAll();
});
$http->on('Task', function ($serv, int $task_id, int $src_worker_id, $data) {
    var_dump($data);
});
$http->start();
```

reload：`kill -USR1 PID`

会报错：

```
WARNING swWorker_reactor_is_empty (ERRNO 9012): worker exit timeout, forced to terminate
```