### PR TITLE
Remove unused MISSING_MSGHDR_MSGFLAGS

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -184,12 +184,6 @@ AC_DEFUN([AC_SWOOLE_CHECK_SOCKETS], [
 
     AC_CHECK_FUNCS([hstrerror socketpair if_nametoindex if_indextoname])
     AC_CHECK_HEADERS([netdb.h netinet/tcp.h sys/un.h sys/sockio.h])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/socket.h>
-    ]], [[static struct msghdr tp; int n = (int) tp.msg_flags; return n]])],[],
-        [AC_DEFINE(MISSING_MSGHDR_MSGFLAGS, 1, [ ])]
-    )
     AC_DEFINE([HAVE_SOCKETS], 1, [ ])
 
     dnl Check for fied ss_family in sockaddr_storage (missing in AIX until 5.3)


### PR DESCRIPTION
Hello, this check is not needed and not used in the code.

Thank you.