### PR TITLE
fix for stream changes in 7.4.0beta1

### DIFF
--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -38,8 +38,13 @@ static PHP_FUNCTION(swoole_user_func_handler);
 }
 
 static int socket_set_option(php_stream *stream, int option, int value, void *ptrparam);
+#if PHP_VERSION_ID < 70400
 static size_t socket_read(php_stream *stream, char *buf, size_t count);
 static size_t socket_write(php_stream *stream, const char *buf, size_t count);
+#else
+static ssize_t socket_read(php_stream *stream, char *buf, size_t count);
+static ssize_t socket_write(php_stream *stream, const char *buf, size_t count);
+#endif
 static int socket_flush(php_stream *stream);
 static int socket_close(php_stream *stream, int close_handle);
 static int socket_stat(php_stream *stream, php_stream_statbuf *ssb);
@@ -259,7 +264,11 @@ static inline char *parse_ip_address_ex(const char *str, size_t str_len, int *po
     return host;
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t socket_write(php_stream *stream, const char *buf, size_t count)
+#else
+static ssize_t socket_write(php_stream *stream, const char *buf, size_t count)
+#endif
 {
     php_swoole_netstream_data_t *abstract = (php_swoole_netstream_data_t *) stream->abstract;
     if (UNEXPECTED(!abstract))
@@ -277,15 +286,21 @@ static size_t socket_write(php_stream *stream, const char *buf, size_t count)
     {
         php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), didwrite, 0);
     }
+#if PHP_VERSION_ID < 70400
     if (didwrite < 0)
     {
         didwrite = 0;
     }
+#endif
 
     return didwrite;
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t socket_read(php_stream *stream, char *buf, size_t count)
+#else
+static ssize_t socket_read(php_stream *stream, char *buf, size_t count)
+#endif
 {
     php_swoole_netstream_data_t *abstract = (php_swoole_netstream_data_t *) stream->abstract;
     if (UNEXPECTED(!abstract))
@@ -309,10 +324,12 @@ static size_t socket_read(php_stream *stream, char *buf, size_t count)
         php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), nr_bytes, 0);
     }
 
+#if PHP_VERSION_ID < 70400
     if (nr_bytes < 0)
     {
         nr_bytes = 0;
     }
+#endif
 
     return nr_bytes;
 }

--- a/thirdparty/php/streams/plain_wrapper.c
+++ b/thirdparty/php/streams/plain_wrapper.c
@@ -59,8 +59,13 @@ extern int php_get_gid_by_name(const char *name, gid_t *gid);
 # define PLAIN_WRAP_BUF_SIZE(st) (st)
 #endif
 
+#if PHP_VERSION_ID < 70400
 static size_t php_stdiop_write(php_stream *stream, const char *buf, size_t count);
 static size_t php_stdiop_read(php_stream *stream, char *buf, size_t count);
+#else
+static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t count);
+static ssize_t php_stdiop_read(php_stream *stream, char *buf, size_t count);
+#endif
 static int sw_php_stdiop_close(php_stream *stream, int close_handle);
 static int php_stdiop_stat(php_stream *stream, php_stream_statbuf *ssb);
 static int php_stdiop_flush(php_stream *stream);
@@ -216,7 +221,11 @@ static php_stream *_sw_php_stream_fopen_from_fd_int(int fd, const char *mode, co
     return php_stream_alloc_rel(&sw_php_stream_stdio_ops, self, persistent_id, mode);
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t php_stdiop_write(php_stream *stream, const char *buf, size_t count)
+#else
+static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t count)
+#endif
 {
     php_stdio_stream_data *data = (php_stdio_stream_data*) stream->abstract;
 
@@ -225,11 +234,15 @@ static size_t php_stdiop_write(php_stream *stream, const char *buf, size_t count
     if (data->fd >= 0)
     {
         int bytes_written = write(data->fd, buf, count);
+#if PHP_VERSION_ID < 70400
         if (bytes_written < 0)
         {
             return 0;
         }
         return (size_t) bytes_written;
+#else
+        return bytes_written;
+#endif
     }
     else
     {
@@ -237,7 +250,11 @@ static size_t php_stdiop_write(php_stream *stream, const char *buf, size_t count
     }
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t php_stdiop_read(php_stream *stream, char *buf, size_t count)
+#else
+static ssize_t php_stdiop_read(php_stream *stream, char *buf, size_t count)
+#endif
 {
     php_stdio_stream_data *data = (php_stdio_stream_data*) stream->abstract;
     size_t ret;
@@ -737,7 +754,11 @@ static int php_stdiop_set_option(php_stream *stream, int option, int value, void
 /* }}} */
 
 /* {{{ plain files opendir/readdir implementation */
+#if PHP_VERSION_ID < 70400
 static size_t php_plain_files_dirstream_read(php_stream *stream, char *buf, size_t count)
+#else
+static ssize_t php_plain_files_dirstream_read(php_stream *stream, char *buf, size_t count)
+#endif
 {
     DIR *dir = (DIR*) stream->abstract;
     struct dirent *result;


### PR DESCRIPTION
Else:
```

BUILDSTDERR: /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/swoole_runtime.cc:69:1: error: invalid conversion from 'size_t (*)(php_stream*, const char*, size_t)' {aka 'long unsigned int (*)(_php_stream*, const char*, long unsigned int)'} to 'ssize_t (*)(php_stream*, const char*, size_t)' {aka 'long int (*)(_php_stream*, const char*, long unsigned int)'} [-fpermissive]
BUILDSTDERR:  };
BUILDSTDERR:  ^
BUILDSTDERR: /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/swoole_runtime.cc:69:1: error: invalid conversion from 'size_t (*)(php_stream*, char*, size_t)' {aka 'long unsigned int (*)(_php_stream*, char*, long unsigned int)'} to 'ssize_t (*)(php_stream*, char*, size_t)' {aka 'long int (*)(_php_stream*, char*, long unsigned int)'} [-fpermissive]
BUILDSTDERR: In file included from /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/swoole_runtime.cc:115:
BUILDSTDERR: /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/thirdparty/php/streams/plain_wrapper.c:189:1: error: invalid conversion from 'size_t (*)(php_stream*, const char*, size_t)' {aka 'long unsigned int (*)(_php_stream*, const char*, long unsigned int)'} to 'ssize_t (*)(php_stream*, const char*, size_t)' {aka 'long int (*)(_php_stream*, const char*, long unsigned int)'} [-fpermissive]
BUILDSTDERR:  };
BUILDSTDERR:  ^
BUILDSTDERR: /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/thirdparty/php/streams/plain_wrapper.c:189:1: error: invalid conversion from 'size_t (*)(php_stream*, char*, size_t)' {aka 'long unsigned int (*)(_php_stream*, char*, long unsigned int)'} to 'ssize_t (*)(php_stream*, char*, size_t)' {aka 'long int (*)(_php_stream*, char*, long unsigned int)'} [-fpermissive]
BUILDSTDERR: /builddir/build/BUILD/php74-php-pecl-swoole4-4.4.1/NTS/thirdparty/php/streams/plain_wrapper.c:777:1: error: invalid conversion from 'size_t (*)(php_stream*, char*, size_t)' {aka 'long unsigned int (*)(_php_stream*, char*, long unsigned int)'} to 'ssize_t (*)(php_stream*, char*, size_t)' {aka 'long int (*)(_php_stream*, char*, long unsigned int)'} [-fpermissive]
BUILDSTDERR:  };
BUILDSTDERR:  ^

```