### PR TITLE
Increase form field name limit

### DIFF
--- a/swoole_config.h
+++ b/swoole_config.h
@@ -192,6 +192,7 @@
  */
 #define SW_HTTP_SERVER_SOFTWARE          "swoole-http-server"
 #define SW_HTTP_PARAM_MAX_NUM            128
+#define SW_HTTP_FORM_KEYLEN              512
 #define SW_HTTP_COOKIE_KEYLEN            128
 #define SW_HTTP_COOKIE_VALLEN            4096
 #define SW_HTTP_RESPONSE_INIT_SIZE       65536

--- a/swoole_http_request.cc
+++ b/swoole_http_request.cc
@@ -479,7 +479,7 @@ static int multipart_body_on_header_field(multipart_parser* p, const char *at, s
 
 static int multipart_body_on_header_value(multipart_parser* p, const char *at, size_t length)
 {
-    char value_buf[SW_HTTP_COOKIE_KEYLEN];
+    char value_buf[SW_HTTP_FORM_KEYLEN];
     int value_len;
 
     http_context *ctx = (http_context *) p->data;
@@ -518,7 +518,7 @@ static int multipart_body_on_header_value(multipart_parser* p, const char *at, s
             return SW_OK;
         }
 
-        if (Z_STRLEN_P(zform_name) >= SW_HTTP_COOKIE_KEYLEN)
+        if (Z_STRLEN_P(zform_name) >= SW_HTTP_FORM_KEYLEN)
         {
             swWarn("form_name[%s] is too large", Z_STRVAL_P(zform_name));
             return SW_OK;
@@ -538,7 +538,7 @@ static int multipart_body_on_header_value(multipart_parser* p, const char *at, s
         //upload file
         else
         {
-            if (Z_STRLEN_P(zfilename) >= SW_HTTP_COOKIE_KEYLEN)
+            if (Z_STRLEN_P(zfilename) >= SW_HTTP_FORM_KEYLEN)
             {
                 swWarn("filename[%s] is too large", Z_STRVAL_P(zfilename));
                 return SW_OK;


### PR DESCRIPTION
- Increase form field name length 128 -> 512 characters
- Resolve #2733 Cannot pass long field names in multipart/form-data