### PR TITLE
Max request grace config

### DIFF
--- a/include/server.h
+++ b/include/server.h
@@ -367,6 +367,7 @@ struct _swServer
      * worker process max request
      */
     uint32_t max_request;
+    uint32_t max_request_grace;
 
     int udp_socket_ipv4;
     int udp_socket_ipv6;
@@ -501,6 +502,7 @@ struct _swServer
     uint16_t task_worker_num;
     uint8_t task_ipc_mode;
     uint16_t task_max_request;
+    uint16_t task_max_request_grace;
     swPipe *task_notify;
     swEventData *task_result;
 

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -1824,6 +1824,7 @@ struct _swProcessPool
 
     int worker_num;
     int max_request;
+    int max_request_grace;
 
     int (*onTask)(struct _swProcessPool *pool, swEventData *task);
 
@@ -2041,7 +2042,7 @@ int swReactorKqueue_create(swReactor *reactor, int max_event_num);
 int swReactorSelect_create(swReactor *reactor);
 
 /*----------------------------Process Pool-------------------------------*/
-int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, key_t msgqueue_key, int ipc_mode);
+int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, int max_request_grace, key_t msgqueue_key, int ipc_mode);
 int swProcessPool_create_unix_socket(swProcessPool *pool, char *socket_file, int blacklog);
 int swProcessPool_create_tcp_socket(swProcessPool *pool, char *host, int port, int blacklog);
 int swProcessPool_set_protocol(swProcessPool *pool, int task_protocol, uint32_t max_packet_size);

--- a/src/network/process_pool.c
+++ b/src/network/process_pool.c
@@ -61,7 +61,7 @@ static void swProcessPool_kill_timeout_worker(swTimer *timer, swTimer_node *tnod
 /**
  * Process manager
  */
-int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, key_t msgqueue_key, int ipc_mode)
+int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, int max_request_grace, key_t msgqueue_key, int ipc_mode)
 {
     bzero(pool, sizeof(swProcessPool));
 
@@ -69,6 +69,7 @@ int swProcessPool_create(swProcessPool *pool, int worker_num, int max_request, k
 
     pool->worker_num = worker_num;
     pool->max_request = max_request;
+    pool->max_request_grace = max_request_grace;
 
     /**
      * Shared memory is used here
@@ -442,13 +443,9 @@ int swProcessPool_get_max_request(swProcessPool *pool)
     else
     {
         task_n = pool->max_request;
-        if (pool->max_request > 10)
+        if (pool->max_request_grace > 0)
         {
-            int n = swoole_system_random(1, pool->max_request / 2);
-            if (n > 0)
-            {
-                task_n += n;
-            }
+            task_n += swoole_system_random(1, pool->max_request_grace);
         }
     }
     return task_n;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -385,7 +385,7 @@ int swServer_create_task_worker(swServer *serv)
     }
 
     swProcessPool *pool = &serv->gs->task_workers;
-    if (swProcessPool_create(pool, serv->task_worker_num, serv->task_max_request, key, ipc_mode) < 0)
+    if (swProcessPool_create(pool, serv->task_worker_num, serv->task_max_request, serv->task_max_request_grace, key, ipc_mode) < 0)
     {
         swWarn("[Master] create task_workers failed");
         return SW_ERR;
@@ -460,13 +460,9 @@ int swServer_worker_init(swServer *serv, swWorker *worker)
     else
     {
         SwooleWG.max_request = serv->max_request;
-        if (SwooleWG.max_request > 10)
+        if (serv->max_request_grace > 0)
         {
-            int n = swoole_system_random(1, SwooleWG.max_request / 2);
-            if (n > 0)
-            {
-                SwooleWG.max_request += n;
-            }
+            SwooleWG.max_request += swoole_system_random(1, serv->max_request_grace);
         }
     }
 

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -92,7 +92,7 @@ int swReactorProcess_start(swServer *serv)
         }
     }
 
-    if (swProcessPool_create(&serv->gs->event_workers, serv->worker_num, serv->max_request, 0, SW_IPC_UNIXSOCK) < 0)
+    if (swProcessPool_create(&serv->gs->event_workers, serv->worker_num, serv->max_request, serv->max_request_grace, 0, SW_IPC_UNIXSOCK) < 0)
     {
         return SW_ERR;
     }

--- a/swoole_config.h
+++ b/swoole_config.h
@@ -101,6 +101,7 @@
 
 #define SW_WORKER_USE_SIGNALFD           1
 #define SW_WORKER_MAX_WAIT_TIME          30
+#define SW_WORKER_MIN_REQUEST            10
 
 #define SW_REACTOR_MAXEVENTS             4096
 #define SW_SESSION_LIST_SIZE             (1*1024*1024)

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -231,7 +231,7 @@ static PHP_METHOD(swoole_process_pool, __construct)
     }
 
     swProcessPool *pool = (swProcessPool *) emalloc(sizeof(swProcessPool));
-    if (swProcessPool_create(pool, worker_num, 0, (key_t) msgq_key, ipc_type) < 0)
+    if (swProcessPool_create(pool, worker_num, 0, 0, (key_t) msgq_key, ipc_type) < 0)
     {
         zend_throw_exception_ex(swoole_exception_ce, errno, "failed to create process pool");
         RETURN_FALSE;

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -2332,6 +2332,15 @@ static PHP_METHOD(swoole_server, set)
     if (php_swoole_array_get_value(vht, "task_max_request", v))
     {
         serv->task_max_request = (uint16_t) zval_get_long(v);
+        //task_max_request_grace
+        if (php_swoole_array_get_value(vht, "task_max_request_grace", v))
+        {
+            serv->task_max_request_grace = (uint16_t) zval_get_long(v);
+        }
+        else if (serv->task_max_request > SW_WORKER_MIN_REQUEST)
+        {
+            serv->task_max_request_grace = serv->task_max_request / 2;
+        }
     }
     //max_connection
     if (php_swoole_array_get_value(vht, "max_connection", v) || php_swoole_array_get_value(vht, "max_conn", v))
@@ -2362,6 +2371,15 @@ static PHP_METHOD(swoole_server, set)
     if (php_swoole_array_get_value(vht, "max_request", v))
     {
         serv->max_request = (uint32_t) zval_get_long(v);
+        //max_request_grace
+        if (php_swoole_array_get_value(vht, "max_request_grace", v))
+        {
+            serv->max_request_grace = (uint32_t) zval_get_long(v);
+        }
+        else if (serv->max_request > SW_WORKER_MIN_REQUEST)
+        {
+            serv->max_request_grace = serv->max_request / 2;
+        }
     }
     //reload async
     if (php_swoole_array_get_value(vht, "reload_async", v))


### PR DESCRIPTION
- Introduce `max_request_grace` setting for app & task workers
- Default `max_request_grace = max_request / 2` on high req limit
- Support `max_request_grace = 0` to disable grace logic
- Reduce grace logic duplication between app & task workers