### PR TITLE
Max request settings fix

### DIFF
--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -97,7 +97,7 @@ int swReactorProcess_start(swServer *serv)
     {
         return SW_ERR;
     }
-    swProcessPool_set_max_request(pool, serv->task_max_request, serv->task_max_request_grace);
+    swProcessPool_set_max_request(pool, serv->max_request, serv->max_request_grace);
 
     /**
      * store to swProcessPool object

--- a/tests/swoole_server/max_request_grace_disabled.phpt
+++ b/tests/swoole_server/max_request_grace_disabled.phpt
@@ -1,0 +1,101 @@
+--TEST--
+swoole_server: max_request_grace disabled
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm)
+{
+    $client = new swoole_client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'open_eof_check' => true,
+        'package_eof' => "\r\n\r\n",
+    ]);
+    Assert::assert($client->connect('127.0.0.1', $pm->getFreePort(), -1));
+    for ($i = 0; $i < 48; $i++) {
+        $client->send("request $i\r\n\r\n");
+        echo $client->recv() . "\n";
+    }
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm)
+{
+    $serv = new swoole_server('127.0.0.1', $pm->getFreePort());
+    $serv->set([
+        'worker_num'        => 2,
+        'dispatch_mode'     => 1,
+        'max_request'       => 12,
+        'max_request_grace' => 0,
+        'open_eof_check'    => true,
+        'package_eof'       => "\r\n\r\n",
+        'log_file'          => '/dev/null',
+    ]);
+    $serv->on('workerStart', function ()  use ($pm) {
+        $pm->wakeup();
+    });
+    $count = 0;
+    $serv->on('receive', function (swoole_server $serv, $fd, $reactorId, $data) use (&$count) {
+        $count++;
+        $serv->send($fd, "Worker $serv->worker_id served $count request(s) since start");
+    });
+    $serv->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+Worker 0 served 1 request(s) since start
+Worker 1 served 1 request(s) since start
+Worker 0 served 2 request(s) since start
+Worker 1 served 2 request(s) since start
+Worker 0 served 3 request(s) since start
+Worker 1 served 3 request(s) since start
+Worker 0 served 4 request(s) since start
+Worker 1 served 4 request(s) since start
+Worker 0 served 5 request(s) since start
+Worker 1 served 5 request(s) since start
+Worker 0 served 6 request(s) since start
+Worker 1 served 6 request(s) since start
+Worker 0 served 7 request(s) since start
+Worker 1 served 7 request(s) since start
+Worker 0 served 8 request(s) since start
+Worker 1 served 8 request(s) since start
+Worker 0 served 9 request(s) since start
+Worker 1 served 9 request(s) since start
+Worker 0 served 10 request(s) since start
+Worker 1 served 10 request(s) since start
+Worker 0 served 11 request(s) since start
+Worker 1 served 11 request(s) since start
+Worker 0 served 12 request(s) since start
+Worker 1 served 12 request(s) since start
+Worker 0 served 1 request(s) since start
+Worker 1 served 1 request(s) since start
+Worker 0 served 2 request(s) since start
+Worker 1 served 2 request(s) since start
+Worker 0 served 3 request(s) since start
+Worker 1 served 3 request(s) since start
+Worker 0 served 4 request(s) since start
+Worker 1 served 4 request(s) since start
+Worker 0 served 5 request(s) since start
+Worker 1 served 5 request(s) since start
+Worker 0 served 6 request(s) since start
+Worker 1 served 6 request(s) since start
+Worker 0 served 7 request(s) since start
+Worker 1 served 7 request(s) since start
+Worker 0 served 8 request(s) since start
+Worker 1 served 8 request(s) since start
+Worker 0 served 9 request(s) since start
+Worker 1 served 9 request(s) since start
+Worker 0 served 10 request(s) since start
+Worker 1 served 10 request(s) since start
+Worker 0 served 11 request(s) since start
+Worker 1 served 11 request(s) since start
+Worker 0 served 12 request(s) since start
+Worker 1 served 12 request(s) since start

--- a/tests/swoole_server/max_request_grace_enabled.phpt
+++ b/tests/swoole_server/max_request_grace_enabled.phpt
@@ -1,0 +1,56 @@
+--TEST--
+swoole_server: max_request_grace enabled
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm)
+{
+    $client = new swoole_client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'open_eof_check' => true,
+        'package_eof' => "\r\n\r\n",
+    ]);
+    Assert::assert($client->connect('127.0.0.1', $pm->getFreePort(), -1));
+    $count = 0;
+    for ($i = 0; $i < 16; $i++) {
+        $client->send("request $i\r\n\r\n");
+        $count = max($count, (int)$client->recv());
+    }
+    echo "Worker served $count request(s) since start\n";
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm)
+{
+    $serv = new swoole_server('127.0.0.1', $pm->getFreePort());
+    $serv->set([
+        'worker_num'        => 2,
+        'dispatch_mode'     => 1,
+        'max_request'       => 4,
+        'max_request_grace' => PHP_INT_MAX,
+        'open_eof_check'    => true,
+        'package_eof'       => "\r\n\r\n",
+        'log_file'          => '/dev/null',
+    ]);
+    $serv->on('workerStart', function ()  use ($pm) {
+        $pm->wakeup();
+    });
+    $counter = 0;
+    $serv->on('receive', function (swoole_server $serv, $fd, $reactorId, $data) use (&$counter) {
+        $counter++;
+        $serv->send($fd, $counter);
+    });
+    $serv->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+Worker served 8 request(s) since start

--- a/tests/swoole_server/max_request_threshold.phpt
+++ b/tests/swoole_server/max_request_threshold.phpt
@@ -1,0 +1,92 @@
+--TEST--
+swoole_server: max_request threshold
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm)
+{
+    $client = new swoole_client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'open_eof_check' => true,
+        'package_eof' => "\r\n\r\n",
+    ]);
+    Assert::assert($client->connect('127.0.0.1', $pm->getFreePort(), -1));
+    for ($i = 0; $i < 40; $i++) {
+        $client->send("request $i\r\n\r\n");
+        echo $client->recv() . "\n";
+    }
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm)
+{
+    $serv = new swoole_server('127.0.0.1', $pm->getFreePort());
+    $serv->set([
+        'worker_num'        => 2,
+        'dispatch_mode'     => 1,
+        'max_request'       => 10,
+        'open_eof_check'    => true,
+        'package_eof'       => "\r\n\r\n",
+        'log_file'          => '/dev/null',
+    ]);
+    $serv->on('workerStart', function ()  use ($pm) {
+        $pm->wakeup();
+    });
+    $count = 0;
+    $serv->on('receive', function (swoole_server $serv, $fd, $reactorId, $data) use (&$count) {
+        $count++;
+        $serv->send($fd, "Worker $serv->worker_id served $count request(s) since start");
+    });
+    $serv->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+Worker 0 served 1 request(s) since start
+Worker 1 served 1 request(s) since start
+Worker 0 served 2 request(s) since start
+Worker 1 served 2 request(s) since start
+Worker 0 served 3 request(s) since start
+Worker 1 served 3 request(s) since start
+Worker 0 served 4 request(s) since start
+Worker 1 served 4 request(s) since start
+Worker 0 served 5 request(s) since start
+Worker 1 served 5 request(s) since start
+Worker 0 served 6 request(s) since start
+Worker 1 served 6 request(s) since start
+Worker 0 served 7 request(s) since start
+Worker 1 served 7 request(s) since start
+Worker 0 served 8 request(s) since start
+Worker 1 served 8 request(s) since start
+Worker 0 served 9 request(s) since start
+Worker 1 served 9 request(s) since start
+Worker 0 served 10 request(s) since start
+Worker 1 served 10 request(s) since start
+Worker 0 served 1 request(s) since start
+Worker 1 served 1 request(s) since start
+Worker 0 served 2 request(s) since start
+Worker 1 served 2 request(s) since start
+Worker 0 served 3 request(s) since start
+Worker 1 served 3 request(s) since start
+Worker 0 served 4 request(s) since start
+Worker 1 served 4 request(s) since start
+Worker 0 served 5 request(s) since start
+Worker 1 served 5 request(s) since start
+Worker 0 served 6 request(s) since start
+Worker 1 served 6 request(s) since start
+Worker 0 served 7 request(s) since start
+Worker 1 served 7 request(s) since start
+Worker 0 served 8 request(s) since start
+Worker 1 served 8 request(s) since start
+Worker 0 served 9 request(s) since start
+Worker 1 served 9 request(s) since start
+Worker 0 served 10 request(s) since start
+Worker 1 served 10 request(s) since start


### PR DESCRIPTION
- Fix event worker settings having no effect
- Fix task worker settings mistakenly applying to event workers
- Cover `max_request` and `max_request_grace` settings with tests