### PR TITLE
Support PHP error control operators

### DIFF
--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -289,7 +289,7 @@ static int coro_exit_handler(zend_execute_data *execute_data)
 static int coro_begin_silence_handler(zend_execute_data *execute_data)
 {
     php_coro_task *task = PHPCoroutine::get_task();
-    task->in_silence = 1;
+    task->in_silence = true;
     task->ori_error_reporting = EG(error_reporting);
     return ZEND_USER_OPCODE_DISPATCH;
 }
@@ -297,7 +297,7 @@ static int coro_begin_silence_handler(zend_execute_data *execute_data)
 static int coro_end_silence_handler(zend_execute_data *execute_data)
 {
     php_coro_task *task = PHPCoroutine::get_task();
-    task->in_silence = 0;
+    task->in_silence = false;
     return ZEND_USER_OPCODE_DISPATCH;
 }
 
@@ -727,9 +727,6 @@ void PHPCoroutine::main_func(void *arg)
     EG(exception_class) = NULL;
     EG(exception) = NULL;
 
-    save_vm_stack(task);
-    record_last_msec(task);
-
     task->output_ptr = NULL;
     task->array_walk_fci = NULL;
     task->in_silence = false;
@@ -740,6 +737,9 @@ void PHPCoroutine::main_func(void *arg)
     task->pcid = task->co->get_origin_cid();
     task->context = nullptr;
     task->enable_scheduler = 1;
+
+    save_vm_stack(task);
+    record_last_msec(task);
 
     swTraceLog(
         SW_TRACE_COROUTINE, "Create coro id: %ld, origin cid: %ld, coro total count: %zu, heap size: %zu",

--- a/swoole_coroutine.h
+++ b/swoole_coroutine.h
@@ -62,6 +62,10 @@ struct php_coro_task
     zend_output_globals *output_ptr;
     /* for array_walk non-reentrancy */
     php_swoole_fci *array_walk_fci;
+    /* for error control `@` */
+    bool in_silence;
+    int ori_error_reporting;
+    int tmp_error_reporting;
     swoole::Coroutine *co;
     std::stack<php_swoole_fci *> *defer_tasks;
     long pcid;


### PR DESCRIPTION
```php
Swoole\Runtime::enableCoroutine();
Swoole\Coroutine\run(function () {
    for ($n = 256; $n--;) {
        Swoole\Coroutine::create(function () {
            $context = stream_context_create(['http' => ['timeout' => 1]]);
            @file_get_contents('http://127.0.0.1:65535', false, $context);
        });
    }
});
```

EXPECT: no warning
