### PR TITLE
Refactor swoole_objects

### DIFF
--- a/php_swoole.h
+++ b/php_swoole.h
@@ -97,20 +97,6 @@ extern zend_module_entry swoole_module_entry;
 #define ifr_hwaddr ifr_addr
 #endif
 
-#define SWOOLE_PROPERTY_MAX     32
-#define SWOOLE_OBJECT_DEFAULT   8
-#define SWOOLE_OBJECT_MAX       10000000
-
-typedef struct
-{
-    void **array;
-    uint32_t size;
-    void **property[SWOOLE_PROPERTY_MAX];
-    uint32_t property_size[SWOOLE_PROPERTY_MAX];
-} swoole_object_array;
-
-extern swoole_object_array swoole_objects;
-
 #define SW_CHECK_RETURN(s)      if(s<0){RETURN_FALSE;}else{RETURN_TRUE;}
 #define SW_LOCK_CHECK_RETURN(s) if(s==0){RETURN_TRUE;}else{zend_update_property_long(NULL,ZEND_THIS,SW_STRL("errCode"),s);RETURN_FALSE;}
 
@@ -379,44 +365,6 @@ zval* php_swoole_task_unpack(swEventData *task_result);
 #ifdef SW_HAVE_ZLIB
 int php_swoole_zlib_decompress(z_stream *stream, swString *buffer, char *body, int length);
 #endif
-
-static sw_inline void* swoole_get_object_by_handle(uint32_t handle)
-{
-    assert(handle < swoole_objects.size);
-    return swoole_objects.array[handle];
-}
-
-static sw_inline void* swoole_get_property_by_handle(uint32_t handle, int property_id)
-{
-    if (sw_unlikely(handle >= swoole_objects.property_size[property_id]))
-    {
-        return NULL;
-    }
-    return swoole_objects.property[property_id][handle];
-}
-
-static sw_inline void* swoole_get_object(zval *zobject)
-{
-    return swoole_get_object_by_handle(Z_OBJ_HANDLE_P(zobject));
-}
-
-static sw_inline void* swoole_get_property(zval *zobject, int property_id)
-{
-    return swoole_get_property_by_handle(Z_OBJ_HANDLE_P(zobject), property_id);
-}
-
-void swoole_set_object_by_handle(uint32_t handle, void *ptr);
-void swoole_set_property_by_handle(uint32_t handle, int property_id, void *ptr);
-
-static sw_inline void swoole_set_object(zval *zobject, void *ptr)
-{
-    swoole_set_object_by_handle(Z_OBJ_HANDLE_P(zobject), ptr);
-}
-
-static sw_inline void swoole_set_property(zval *zobject, int property_id, void *ptr)
-{
-    swoole_set_property_by_handle(Z_OBJ_HANDLE_P(zobject), property_id, ptr);
-}
 
 int swoole_convert_to_fd(zval *zsocket);
 int swoole_convert_to_fd_ex(zval *zsocket, int *async);

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -98,7 +98,7 @@ extern zend_module_entry swoole_module_entry;
 #endif
 
 #define SWOOLE_PROPERTY_MAX     32
-#define SWOOLE_OBJECT_DEFAULT   65536
+#define SWOOLE_OBJECT_DEFAULT   8
 #define SWOOLE_OBJECT_MAX       10000000
 
 typedef struct

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -196,7 +196,7 @@ typedef struct
     swServer *serv;
     swListenPort *port;
     zval *zsetting;
-} swoole_server_port_property;
+} php_swoole_server_port_property;
 //---------------------------------------------------------
 #define SW_FLAG_KEEP                        (1u << 12)
 #define SW_FLAG_ASYNC                       (1u << 10)

--- a/swoole.cc
+++ b/swoole.cc
@@ -1008,12 +1008,3 @@ PHP_FUNCTION(swoole_internal_call_user_shutdown_begin)
         RETURN_FALSE;
     }
 }
-
-/*
- * Local variables:
- * tab-width: 4
- * c-basic-offset: 4
- * End:
- * vim600: noet sw=4 ts=4 fdm=marker
- * vim<600: noet sw=4 ts=4
- */

--- a/swoole.cc
+++ b/swoole.cc
@@ -188,100 +188,6 @@ static void php_swoole_init_globals(zend_swoole_globals *swoole_globals)
     swoole_globals->rshutdown_functions = NULL;
 }
 
-static sw_inline uint32_t swoole_get_new_size(uint32_t old_size, int handle)
-{
-    uint32_t new_size = old_size * 2;
-    if (handle > SWOOLE_OBJECT_MAX)
-    {
-        php_swoole_fatal_error(E_ERROR, "handle %d exceed %d", handle, SWOOLE_OBJECT_MAX);
-        return 0;
-    }
-    while (new_size <= (uint32_t) handle)
-    {
-        new_size *= 2;
-    }
-    if (new_size > SWOOLE_OBJECT_MAX)
-    {
-        new_size = SWOOLE_OBJECT_MAX;
-    }
-    return new_size;
-}
-
-void swoole_set_object_by_handle(uint32_t handle, void *ptr)
-{
-    assert(handle < SWOOLE_OBJECT_MAX);
-
-    if (sw_unlikely(handle >= swoole_objects.size))
-    {
-        uint32_t old_size = swoole_objects.size;
-        uint32_t new_size = swoole_get_new_size(old_size, handle);
-
-        void *old_ptr = swoole_objects.array;
-        void *new_ptr = NULL;
-
-        new_ptr = sw_realloc(old_ptr, sizeof(void*) * new_size);
-        if (!new_ptr)
-        {
-            php_swoole_fatal_error(E_ERROR, "malloc(%d) failed", (int )(new_size * sizeof(void *)));
-            return;
-        }
-        bzero((char*) new_ptr + (old_size * sizeof(void*)), (new_size - old_size) * sizeof(void*));
-        swoole_objects.array = (void**) new_ptr;
-        swoole_objects.size = new_size;
-    }
-#ifdef ZEND_DEBUG
-    else if (ptr)
-    {
-        assert(swoole_objects.array[handle] == NULL);
-    }
-#endif
-    swoole_objects.array[handle] = ptr;
-}
-
-void swoole_set_property_by_handle(uint32_t handle, int property_id, void *ptr)
-{
-    assert(handle < SWOOLE_OBJECT_MAX);
-
-    if (sw_unlikely(handle >= swoole_objects.property_size[property_id]))
-    {
-        uint32_t old_size = swoole_objects.property_size[property_id];
-        uint32_t new_size = 0;
-
-        void **old_ptr = NULL;
-        void **new_ptr = NULL;
-
-        if (old_size == 0)
-        {
-            new_size = handle < SWOOLE_OBJECT_DEFAULT ? SWOOLE_OBJECT_DEFAULT : swoole_get_new_size(SWOOLE_OBJECT_DEFAULT, handle);
-            new_ptr = (void **) sw_calloc(new_size, sizeof(void *));
-        }
-        else
-        {
-            new_size = swoole_get_new_size(old_size, handle);
-            old_ptr = swoole_objects.property[property_id];
-            new_ptr = (void **) sw_realloc(old_ptr, new_size * sizeof(void *));
-        }
-        if (new_ptr == NULL)
-        {
-            php_swoole_fatal_error(E_ERROR, "malloc(%d) failed", (int )(new_size * sizeof(void *)));
-            return;
-        }
-        if (old_size > 0)
-        {
-            bzero((char *) new_ptr + old_size * sizeof(void*), (new_size - old_size) * sizeof(void*));
-        }
-        swoole_objects.property_size[property_id] = new_size;
-        swoole_objects.property[property_id] = new_ptr;
-    }
-#ifdef ZEND_DEBUG
-    else if (ptr)
-    {
-        assert(swoole_objects.property[property_id][handle] == NULL);
-    }
-#endif
-    swoole_objects.property[property_id][handle] = ptr;
-}
-
 void php_swoole_register_shutdown_function(const char *function)
 {
     php_shutdown_function_entry shutdown_function_entry;
@@ -307,8 +213,6 @@ static void fatal_error(int code, const char *format, ...)
     // should never here
     exit(1);
 }
-
-swoole_object_array swoole_objects;
 
 /* {{{ PHP_MINIT_FUNCTION
  */
@@ -617,14 +521,6 @@ PHP_MINIT_FUNCTION(swoole)
     SwooleG.fatal_error = fatal_error;
     SwooleG.socket_buffer_size = SWOOLE_G(socket_buffer_size);
     SwooleG.dns_cache_refresh_time = 60;
-
-    swoole_objects.size = SWOOLE_OBJECT_DEFAULT;
-    swoole_objects.array = (void**) sw_calloc(swoole_objects.size, sizeof(void*));
-    if (!swoole_objects.array)
-    {
-        php_swoole_fatal_error(E_ERROR, "malloc([swoole_objects]) failed");
-        exit(253);
-    }
 
     // enable pcre.jit and use swoole extension on MacOS will lead to coredump, disable it temporarily
 #if defined(PHP_PCRE_VERSION) && defined(HAVE_PCRE_JIT_SUPPORT) && PHP_VERSION_ID >= 70300 && __MACH__ && !defined(SW_DEBUG)

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -76,27 +76,27 @@ typedef struct
     zend_object std;
 } atomic_t;
 
-static sw_inline atomic_t* swoole_atomic_fetch_object(zend_object *obj)
+static sw_inline atomic_t* php_swoole_atomic_fetch_object(zend_object *obj)
 {
     return (atomic_t *) ((char *) obj - swoole_atomic_handlers.offset);
 }
 
 static sw_atomic_t * php_swoole_atomic_get_ptr(zval *zobject)
 {
-    return swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 void php_swoole_atomic_set_ptr(zval *zobject, sw_atomic_t *ptr)
 {
-    swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_atomic_free_object(zend_object *object)
+static void php_swoole_atomic_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_atomic_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_atomic_create_object(zend_class_entry *ce)
 {
     atomic_t *atomic = (atomic_t *) ecalloc(1, sizeof(atomic_t) + zend_object_properties_size(ce));
     zend_object_std_init(&atomic->std, ce);
@@ -118,27 +118,27 @@ typedef struct
     zend_object std;
 } atomic_long_t;
 
-static sw_inline atomic_long_t* swoole_atomic_long_fetch_object(zend_object *obj)
+static sw_inline atomic_long_t* php_swoole_atomic_long_fetch_object(zend_object *obj)
 {
     return (atomic_long_t *) ((char *) obj - swoole_atomic_long_handlers.offset);
 }
 
 static sw_atomic_long_t * php_swoole_atomic_long_get_ptr(zval *zobject)
 {
-    return swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 void php_swoole_atomic_long_set_ptr(zval *zobject, sw_atomic_long_t *ptr)
 {
-    swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_atomic_long_free_object(zend_object *object)
+static void php_swoole_atomic_long_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_atomic_long_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_atomic_long_create_object(zend_class_entry *ce)
 {
     atomic_long_t *atomic_long = (atomic_long_t *) ecalloc(1, sizeof(atomic_long_t) + zend_object_properties_size(ce));
     zend_object_std_init(&atomic_long->std, ce);
@@ -232,13 +232,13 @@ void php_swoole_atomic_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_atomic, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_atomic, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic, swoole_atomic_create_object, swoole_atomic_free_object, atomic_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic, php_swoole_atomic_create_object, php_swoole_atomic_free_object, atomic_t, std);
 
     SW_INIT_CLASS_ENTRY(swoole_atomic_long, "Swoole\\Atomic\\Long", "swoole_atomic_long", NULL, swoole_atomic_long_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_atomic_long, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_atomic_long, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic_long, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic_long, swoole_atomic_long_create_object, swoole_atomic_long_free_object, atomic_long_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic_long, php_swoole_atomic_long_create_object, php_swoole_atomic_long_free_object, atomic_long_t, std);
 }
 
 PHP_METHOD(swoole_atomic, __construct)

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -81,12 +81,12 @@ static sw_inline atomic_t* swoole_atomic_fetch_object(zend_object *obj)
     return (atomic_t *) ((char *) obj - swoole_atomic_handlers.offset);
 }
 
-static sw_atomic_t * swoole_atomic_get_ptr(zval *zobject)
+static sw_atomic_t * php_swoole_atomic_get_ptr(zval *zobject)
 {
     return swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-void swoole_atomic_set_ptr(zval *zobject, sw_atomic_t *ptr)
+void php_swoole_atomic_set_ptr(zval *zobject, sw_atomic_t *ptr)
 {
     swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -123,12 +123,12 @@ static sw_inline atomic_long_t* swoole_atomic_long_fetch_object(zend_object *obj
     return (atomic_long_t *) ((char *) obj - swoole_atomic_long_handlers.offset);
 }
 
-static sw_atomic_long_t * swoole_atomic_long_get_ptr(zval *zobject)
+static sw_atomic_long_t * php_swoole_atomic_long_get_ptr(zval *zobject)
 {
     return swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-void swoole_atomic_long_set_ptr(zval *zobject, sw_atomic_long_t *ptr)
+void php_swoole_atomic_long_set_ptr(zval *zobject, sw_atomic_long_t *ptr)
 {
     swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -243,7 +243,7 @@ void php_swoole_atomic_minit(int module_number)
 
 PHP_METHOD(swoole_atomic, __construct)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long value = 0;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
@@ -256,7 +256,7 @@ PHP_METHOD(swoole_atomic, __construct)
 
 PHP_METHOD(swoole_atomic, add)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long add_value = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -269,7 +269,7 @@ PHP_METHOD(swoole_atomic, add)
 
 PHP_METHOD(swoole_atomic, sub)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long sub_value = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -282,13 +282,13 @@ PHP_METHOD(swoole_atomic, sub)
 
 PHP_METHOD(swoole_atomic, get)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     RETURN_LONG(*atomic);
 }
 
 PHP_METHOD(swoole_atomic, set)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long set_value;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -300,7 +300,7 @@ PHP_METHOD(swoole_atomic, set)
 
 PHP_METHOD(swoole_atomic, cmpset)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long cmp_value, set_value;
 
     ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -313,7 +313,7 @@ PHP_METHOD(swoole_atomic, cmpset)
 
 PHP_METHOD(swoole_atomic, wait)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     double timeout = 1.0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -344,7 +344,7 @@ PHP_METHOD(swoole_atomic, wait)
 
 PHP_METHOD(swoole_atomic, wakeup)
 {
-    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
+    sw_atomic_t *atomic = php_swoole_atomic_get_ptr(ZEND_THIS);
     zend_long n = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -362,7 +362,7 @@ PHP_METHOD(swoole_atomic, wakeup)
 
 PHP_METHOD(swoole_atomic_long, __construct)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long value = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -376,7 +376,7 @@ PHP_METHOD(swoole_atomic_long, __construct)
 
 PHP_METHOD(swoole_atomic_long, add)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long add_value = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -389,7 +389,7 @@ PHP_METHOD(swoole_atomic_long, add)
 
 PHP_METHOD(swoole_atomic_long, sub)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long sub_value = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -402,13 +402,13 @@ PHP_METHOD(swoole_atomic_long, sub)
 
 PHP_METHOD(swoole_atomic_long, get)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     RETURN_LONG(*atomic_long);
 }
 
 PHP_METHOD(swoole_atomic_long, set)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long set_value;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -420,7 +420,7 @@ PHP_METHOD(swoole_atomic_long, set)
 
 PHP_METHOD(swoole_atomic_long, cmpset)
 {
-    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = php_swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long cmp_value, set_value;
 
     ZEND_PARSE_PARAMETERS_START(2, 2)

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -371,8 +371,6 @@ PHP_METHOD(swoole_atomic_long, __construct)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     *atomic_long = (sw_atomic_long_t) value;
-    swoole_set_object(ZEND_THIS, (void*) atomic_long);
-
     RETURN_TRUE;
 }
 

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -16,22 +16,6 @@
 
 #include "php_swoole.h"
 
-static PHP_METHOD(swoole_atomic, __construct);
-static PHP_METHOD(swoole_atomic, add);
-static PHP_METHOD(swoole_atomic, sub);
-static PHP_METHOD(swoole_atomic, get);
-static PHP_METHOD(swoole_atomic, set);
-static PHP_METHOD(swoole_atomic, cmpset);
-static PHP_METHOD(swoole_atomic, wait);
-static PHP_METHOD(swoole_atomic, wakeup);
-
-static PHP_METHOD(swoole_atomic_long, __construct);
-static PHP_METHOD(swoole_atomic_long, add);
-static PHP_METHOD(swoole_atomic_long, sub);
-static PHP_METHOD(swoole_atomic_long, get);
-static PHP_METHOD(swoole_atomic_long, set);
-static PHP_METHOD(swoole_atomic_long, cmpset);
-
 #ifdef HAVE_FUTEX
 #include <linux/futex.h>
 #include <syscall.h>
@@ -80,6 +64,112 @@ static sw_inline int swoole_futex_wakeup(sw_atomic_t *atomic, int n)
 }
 #endif
 
+zend_class_entry *swoole_atomic_ce;
+static zend_object_handlers swoole_atomic_handlers;
+
+zend_class_entry *swoole_atomic_long_ce;
+static zend_object_handlers swoole_atomic_long_handlers;
+
+typedef struct
+{
+    sw_atomic_t *ptr;
+    zend_object std;
+} atomic_t;
+
+static sw_inline atomic_t* swoole_atomic_fetch_object(zend_object *obj)
+{
+    return (atomic_t *) ((char *) obj - swoole_atomic_handlers.offset);
+}
+
+sw_atomic_t * swoole_atomic_get_ptr(zval *zobject)
+{
+    return swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+void swoole_atomic_set_ptr(zval *zobject, sw_atomic_t *ptr)
+{
+    swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_atomic_free_object(zend_object *object)
+{
+    zend_object_std_dtor(&swoole_atomic_fetch_object(object)->std);
+}
+
+static zend_object *swoole_atomic_create_object(zend_class_entry *ce)
+{
+    atomic_t *atomic = (atomic_t *) ecalloc(1, sizeof(atomic_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&atomic->std, ce);
+    object_properties_init(&atomic->std, ce);
+    atomic->std.handlers = &swoole_atomic_handlers;
+
+    atomic->ptr = (sw_atomic_t *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_t));
+    if (atomic == NULL)
+    {
+        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
+    }
+
+    return &atomic->std;
+}
+
+typedef struct
+{
+    sw_atomic_long_t *ptr;
+    zend_object std;
+} atomic_long_t;
+
+static sw_inline atomic_long_t* swoole_atomic_long_fetch_object(zend_object *obj)
+{
+    return (atomic_long_t *) ((char *) obj - swoole_atomic_long_handlers.offset);
+}
+
+sw_atomic_long_t * swoole_atomic_long_get_ptr(zval *zobject)
+{
+    return swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+void swoole_atomic_long_set_ptr(zval *zobject, sw_atomic_long_t *ptr)
+{
+    swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_atomic_long_free_object(zend_object *object)
+{
+    zend_object_std_dtor(&swoole_atomic_long_fetch_object(object)->std);
+}
+
+static zend_object *swoole_atomic_long_create_object(zend_class_entry *ce)
+{
+    atomic_long_t *atomic_long = (atomic_long_t *) ecalloc(1, sizeof(atomic_long_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&atomic_long->std, ce);
+    object_properties_init(&atomic_long->std, ce);
+    atomic_long->std.handlers = &swoole_atomic_long_handlers;
+
+    atomic_long->ptr = (sw_atomic_long_t *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_long_t));
+    if (atomic_long == NULL)
+    {
+        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
+    }
+
+    return &atomic_long->std;
+}
+
+static PHP_METHOD(swoole_atomic, __construct);
+static PHP_METHOD(swoole_atomic, add);
+static PHP_METHOD(swoole_atomic, sub);
+static PHP_METHOD(swoole_atomic, get);
+static PHP_METHOD(swoole_atomic, set);
+static PHP_METHOD(swoole_atomic, cmpset);
+static PHP_METHOD(swoole_atomic, wait);
+static PHP_METHOD(swoole_atomic, wakeup);
+
+static PHP_METHOD(swoole_atomic_long, __construct);
+static PHP_METHOD(swoole_atomic_long, add);
+static PHP_METHOD(swoole_atomic_long, sub);
+static PHP_METHOD(swoole_atomic_long, get);
+static PHP_METHOD(swoole_atomic_long, set);
+static PHP_METHOD(swoole_atomic_long, cmpset);
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_atomic_construct, 0, 0, 0)
     ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -112,12 +202,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_atomic_waitup, 0, 0, 0)
     ZEND_ARG_INFO(0, count)
 ZEND_END_ARG_INFO()
 
-zend_class_entry *swoole_atomic_ce;
-static zend_object_handlers swoole_atomic_handlers;
-
-zend_class_entry *swoole_atomic_long_ce;
-static zend_object_handlers swoole_atomic_long_handlers;
-
 static const zend_function_entry swoole_atomic_methods[] =
 {
     PHP_ME(swoole_atomic, __construct, arginfo_swoole_atomic_construct, ZEND_ACC_PUBLIC)
@@ -148,17 +232,18 @@ void php_swoole_atomic_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_atomic, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_atomic, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_atomic);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic, swoole_atomic_create_object, swoole_atomic_free_object, atomic_t, std);
 
     SW_INIT_CLASS_ENTRY(swoole_atomic_long, "Swoole\\Atomic\\Long", "swoole_atomic_long", NULL, swoole_atomic_long_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_atomic_long, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_atomic_long, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic_long, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_atomic_long);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic_long, swoole_atomic_long_create_object, swoole_atomic_long_free_object, atomic_long_t, std);
 }
 
 PHP_METHOD(swoole_atomic, __construct)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long value = 0;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
@@ -166,22 +251,13 @@ PHP_METHOD(swoole_atomic, __construct)
         Z_PARAM_LONG(value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    sw_atomic_t *atomic = (sw_atomic_t *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_t));
-    if (atomic == NULL)
-    {
-        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
-        RETURN_FALSE;
-    }
     *atomic = (sw_atomic_t) value;
-    swoole_set_object(ZEND_THIS, (void*) atomic);
-
-    RETURN_TRUE;
 }
 
 PHP_METHOD(swoole_atomic, add)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long add_value = 1;
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -193,8 +269,8 @@ PHP_METHOD(swoole_atomic, add)
 
 PHP_METHOD(swoole_atomic, sub)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long sub_value = 1;
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -206,13 +282,13 @@ PHP_METHOD(swoole_atomic, sub)
 
 PHP_METHOD(swoole_atomic, get)
 {
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     RETURN_LONG(*atomic);
 }
 
 PHP_METHOD(swoole_atomic, set)
 {
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long set_value;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -224,8 +300,8 @@ PHP_METHOD(swoole_atomic, set)
 
 PHP_METHOD(swoole_atomic, cmpset)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long cmp_value, set_value;
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(2, 2)
         Z_PARAM_LONG(cmp_value)
@@ -237,8 +313,8 @@ PHP_METHOD(swoole_atomic, cmpset)
 
 PHP_METHOD(swoole_atomic, wait)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     double timeout = 1.0;
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -268,8 +344,8 @@ PHP_METHOD(swoole_atomic, wait)
 
 PHP_METHOD(swoole_atomic, wakeup)
 {
+    sw_atomic_t *atomic = swoole_atomic_get_ptr(ZEND_THIS);
     zend_long n = 1;
-    sw_atomic_t *atomic = (sw_atomic_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -286,6 +362,7 @@ PHP_METHOD(swoole_atomic, wakeup)
 
 PHP_METHOD(swoole_atomic_long, __construct)
 {
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long value = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -293,71 +370,65 @@ PHP_METHOD(swoole_atomic_long, __construct)
         Z_PARAM_LONG(value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(sw_atomic_long_t));
-    if (atomic == NULL)
-    {
-        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
-        RETURN_FALSE;
-    }
-    *atomic = (sw_atomic_long_t) value;
-    swoole_set_object(ZEND_THIS, (void*) atomic);
+    *atomic_long = (sw_atomic_long_t) value;
+    swoole_set_object(ZEND_THIS, (void*) atomic_long);
 
     RETURN_TRUE;
 }
 
 PHP_METHOD(swoole_atomic_long, add)
 {
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long add_value = 1;
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(add_value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    RETURN_LONG(sw_atomic_add_fetch(atomic, (sw_atomic_long_t) add_value));
+    RETURN_LONG(sw_atomic_add_fetch(atomic_long, (sw_atomic_long_t) add_value));
 }
 
 PHP_METHOD(swoole_atomic_long, sub)
 {
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long sub_value = 1;
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
         Z_PARAM_LONG(sub_value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    RETURN_LONG(sw_atomic_sub_fetch(atomic, (sw_atomic_long_t) sub_value));
+    RETURN_LONG(sw_atomic_sub_fetch(atomic_long, (sw_atomic_long_t) sub_value));
 }
 
 PHP_METHOD(swoole_atomic_long, get)
 {
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) swoole_get_object(ZEND_THIS);
-    RETURN_LONG(*atomic);
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
+    RETURN_LONG(*atomic_long);
 }
 
 PHP_METHOD(swoole_atomic_long, set)
 {
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) swoole_get_object(ZEND_THIS);
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long set_value;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_LONG(set_value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    *atomic = (sw_atomic_long_t) set_value;
+    *atomic_long = (sw_atomic_long_t) set_value;
 }
 
 PHP_METHOD(swoole_atomic_long, cmpset)
 {
+    sw_atomic_long_t *atomic_long = swoole_atomic_long_get_ptr(ZEND_THIS);
     zend_long cmp_value, set_value;
-    sw_atomic_long_t *atomic = (sw_atomic_long_t *) swoole_get_object(ZEND_THIS);
 
     ZEND_PARSE_PARAMETERS_START(2, 2)
         Z_PARAM_LONG(cmp_value)
         Z_PARAM_LONG(set_value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    RETURN_BOOL(sw_atomic_cmp_set(atomic, (sw_atomic_long_t) cmp_value, (sw_atomic_long_t) set_value));
+    RETURN_BOOL(sw_atomic_cmp_set(atomic_long, (sw_atomic_long_t) cmp_value, (sw_atomic_long_t) set_value));
 }

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -81,7 +81,7 @@ static sw_inline atomic_t* swoole_atomic_fetch_object(zend_object *obj)
     return (atomic_t *) ((char *) obj - swoole_atomic_handlers.offset);
 }
 
-sw_atomic_t * swoole_atomic_get_ptr(zval *zobject)
+static sw_atomic_t * swoole_atomic_get_ptr(zval *zobject)
 {
     return swoole_atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
@@ -123,7 +123,7 @@ static sw_inline atomic_long_t* swoole_atomic_long_fetch_object(zend_object *obj
     return (atomic_long_t *) ((char *) obj - swoole_atomic_long_handlers.offset);
 }
 
-sw_atomic_long_t * swoole_atomic_long_get_ptr(zval *zobject)
+static sw_atomic_long_t * swoole_atomic_long_get_ptr(zval *zobject)
 {
     return swoole_atomic_long_fetch_object(Z_OBJ_P(zobject))->ptr;
 }

--- a/swoole_atomic.cc
+++ b/swoole_atomic.cc
@@ -93,7 +93,7 @@ void swoole_atomic_set_ptr(zval *zobject, sw_atomic_t *ptr)
 
 static void swoole_atomic_free_object(zend_object *object)
 {
-    zend_object_std_dtor(&swoole_atomic_fetch_object(object)->std);
+    zend_object_std_dtor(object);
 }
 
 static zend_object *swoole_atomic_create_object(zend_class_entry *ce)
@@ -135,7 +135,7 @@ void swoole_atomic_long_set_ptr(zval *zobject, sw_atomic_long_t *ptr)
 
 static void swoole_atomic_long_free_object(zend_object *object)
 {
-    zend_object_std_dtor(&swoole_atomic_long_fetch_object(object)->std);
+    zend_object_std_dtor(object);
 }
 
 static zend_object *swoole_atomic_long_create_object(zend_class_entry *ce)

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -25,14 +25,14 @@ typedef struct
     zend_object std;
 } buffer_t;
 
-static sw_inline buffer_t* swoole_buffer_fetch_object(zend_object *obj)
+static sw_inline buffer_t* php_swoole_buffer_fetch_object(zend_object *obj)
 {
     return (buffer_t *) ((char *) obj - swoole_buffer_handlers.offset);
 }
 
 static swString * php_swoole_buffer_get_ptr(zval *zobject)
 {
-    return swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 static swString * php_swoole_buffer_get_and_check_ptr(zval *zobject)
@@ -47,12 +47,12 @@ static swString * php_swoole_buffer_get_and_check_ptr(zval *zobject)
 
 void php_swoole_buffer_set_ptr(zval *zobject, swString *ptr)
 {
-    swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_buffer_free_object(zend_object *object)
+static void php_swoole_buffer_free_object(zend_object *object)
 {
-    buffer_t *buffer = swoole_buffer_fetch_object(object);
+    buffer_t *buffer = php_swoole_buffer_fetch_object(object);
     if (buffer->ptr)
     {
         swString_free(buffer->ptr);
@@ -60,7 +60,7 @@ static void swoole_buffer_free_object(zend_object *object)
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_buffer_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_buffer_create_object(zend_class_entry *ce)
 {
     buffer_t *buffer = (buffer_t *) ecalloc(1, sizeof(buffer_t) + zend_object_properties_size(ce));
     zend_object_std_init(&buffer->std, ce);
@@ -132,7 +132,7 @@ void php_swoole_buffer_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_buffer, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_buffer, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_buffer, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_buffer, swoole_buffer_create_object, swoole_buffer_free_object, buffer_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_buffer, php_swoole_buffer_create_object, php_swoole_buffer_free_object, buffer_t, std);
 
     zend_declare_property_long(swoole_buffer_ce, ZEND_STRL("capacity"), SW_STRING_BUFFER_DEFAULT, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_buffer_ce, ZEND_STRL("length"), 0, ZEND_ACC_PUBLIC);

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -30,14 +30,14 @@ static sw_inline buffer_t* swoole_buffer_fetch_object(zend_object *obj)
     return (buffer_t *) ((char *) obj - swoole_buffer_handlers.offset);
 }
 
-static swString * swoole_buffer_get_ptr(zval *zobject)
+static swString * php_swoole_buffer_get_ptr(zval *zobject)
 {
     return swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-static swString * swoole_buffer_get_and_check_ptr(zval *zobject)
+static swString * php_swoole_buffer_get_and_check_ptr(zval *zobject)
 {
-    swString *buffer = swoole_buffer_get_ptr(zobject);
+    swString *buffer = php_swoole_buffer_get_ptr(zobject);
     if (!buffer)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Buffer constructor first");
@@ -45,7 +45,7 @@ static swString * swoole_buffer_get_and_check_ptr(zval *zobject)
     return buffer;
 }
 
-void swoole_buffer_set_ptr(zval *zobject, swString *ptr)
+void php_swoole_buffer_set_ptr(zval *zobject, swString *ptr)
 {
     swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -154,7 +154,7 @@ static PHP_METHOD(swoole_buffer, __construct)
         ZSTR_VAL(swoole_buffer_ce->name)
     );
 
-    swString *buffer = swoole_buffer_get_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_ptr(ZEND_THIS);
     if (buffer)
     {
         php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
@@ -185,7 +185,7 @@ static PHP_METHOD(swoole_buffer, __construct)
         RETURN_FALSE;
     }
 
-    swoole_buffer_set_ptr(ZEND_THIS, buffer);
+    php_swoole_buffer_set_ptr(ZEND_THIS, buffer);
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("capacity"), size);
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("length"), 0);
 }
@@ -194,7 +194,7 @@ static PHP_METHOD(swoole_buffer, __destruct) { }
 
 static PHP_METHOD(swoole_buffer, append)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     swString str = { 0 };
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str.str, &str.length) == FAILURE)
@@ -232,7 +232,7 @@ static PHP_METHOD(swoole_buffer, append)
 
 static PHP_METHOD(swoole_buffer, substr)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     zend_long offset;
     zend_long length = -1;
     zend_bool remove = 0;
@@ -275,13 +275,13 @@ static PHP_METHOD(swoole_buffer, substr)
 
 static PHP_METHOD(swoole_buffer, __toString)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     RETURN_STRINGL(buffer->str + buffer->offset, buffer->length - buffer->offset);
 }
 
 static PHP_METHOD(swoole_buffer, write)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     zend_long offset;
     swString str = { 0 };
 
@@ -333,7 +333,7 @@ static PHP_METHOD(swoole_buffer, write)
 
 static PHP_METHOD(swoole_buffer, read)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     zend_long offset;
     zend_long length;
 
@@ -364,7 +364,7 @@ static PHP_METHOD(swoole_buffer, read)
 
 static PHP_METHOD(swoole_buffer, expand)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
     zend_long size = -1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &size) == FAILURE)
@@ -391,7 +391,7 @@ static PHP_METHOD(swoole_buffer, expand)
 
 static PHP_METHOD(swoole_buffer, recycle)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
 
     swoole_buffer_recycle(buffer);
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("length"), buffer->length);
@@ -399,7 +399,7 @@ static PHP_METHOD(swoole_buffer, recycle)
 
 static PHP_METHOD(swoole_buffer, clear)
 {
-    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString *buffer = php_swoole_buffer_get_and_check_ptr(ZEND_THIS);
 
     buffer->length = 0;
     buffer->offset = 0;

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -157,7 +157,7 @@ static PHP_METHOD(swoole_buffer, __construct)
     swString *buffer = swoole_buffer_get_ptr(ZEND_THIS);
     if (buffer)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     zend_long size = SW_STRING_BUFFER_DEFAULT;

--- a/swoole_buffer.c
+++ b/swoole_buffer.c
@@ -16,6 +16,59 @@
 
 #include "php_swoole.h"
 
+zend_class_entry *swoole_buffer_ce;
+static zend_object_handlers swoole_buffer_handlers;
+
+typedef struct
+{
+    swString *ptr;
+    zend_object std;
+} buffer_t;
+
+static sw_inline buffer_t* swoole_buffer_fetch_object(zend_object *obj)
+{
+    return (buffer_t *) ((char *) obj - swoole_buffer_handlers.offset);
+}
+
+static swString * swoole_buffer_get_ptr(zval *zobject)
+{
+    return swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+static swString * swoole_buffer_get_and_check_ptr(zval *zobject)
+{
+    swString *buffer = swoole_buffer_get_ptr(zobject);
+    if (!buffer)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Buffer constructor first");
+    }
+    return buffer;
+}
+
+void swoole_buffer_set_ptr(zval *zobject, swString *ptr)
+{
+    swoole_buffer_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_buffer_free_object(zend_object *object)
+{
+    buffer_t *buffer = swoole_buffer_fetch_object(object);
+    if (buffer->ptr)
+    {
+        swString_free(buffer->ptr);
+    }
+    zend_object_std_dtor(object);
+}
+
+static zend_object *swoole_buffer_create_object(zend_class_entry *ce)
+{
+    buffer_t *buffer = (buffer_t *) ecalloc(1, sizeof(buffer_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&buffer->std, ce);
+    object_properties_init(&buffer->std, ce);
+    buffer->std.handlers = &swoole_buffer_handlers;
+    return &buffer->std;
+}
+
 static PHP_METHOD(swoole_buffer, __construct);
 static PHP_METHOD(swoole_buffer, __destruct);
 static PHP_METHOD(swoole_buffer, __toString);
@@ -73,16 +126,13 @@ static const zend_function_entry swoole_buffer_methods[] =
     PHP_FE_END
 };
 
-zend_class_entry *swoole_buffer_ce;
-static zend_object_handlers swoole_buffer_handlers;
-
 void php_swoole_buffer_minit(int module_number)
 {
     SW_INIT_CLASS_ENTRY(swoole_buffer, "Swoole\\Buffer", "swoole_buffer", NULL, swoole_buffer_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_buffer, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_buffer, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_buffer, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_buffer);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_buffer, swoole_buffer_create_object, swoole_buffer_free_object, buffer_t, std);
 
     zend_declare_property_long(swoole_buffer_ce, ZEND_STRL("capacity"), SW_STRING_BUFFER_DEFAULT, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_buffer_ce, ZEND_STRL("length"), 0, ZEND_ACC_PUBLIC);
@@ -104,6 +154,12 @@ static PHP_METHOD(swoole_buffer, __construct)
         ZSTR_VAL(swoole_buffer_ce->name)
     );
 
+    swString *buffer = swoole_buffer_get_ptr(ZEND_THIS);
+    if (buffer)
+    {
+        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+    }
+
     zend_long size = SW_STRING_BUFFER_DEFAULT;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
@@ -122,34 +178,24 @@ static PHP_METHOD(swoole_buffer, __construct)
         RETURN_FALSE;
     }
 
-    swString *buffer = swString_new(size);
+    buffer = swString_new(size);
     if (buffer == NULL)
     {
         zend_throw_exception_ex(swoole_exception_ce, errno, "malloc(" ZEND_LONG_FMT ") failed", size);
         RETURN_FALSE;
     }
 
-    swoole_set_object(ZEND_THIS, buffer);
+    swoole_buffer_set_ptr(ZEND_THIS, buffer);
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("capacity"), size);
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("length"), 0);
 }
 
-static PHP_METHOD(swoole_buffer, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    swString *buffer = swoole_get_object(ZEND_THIS);
-    if (buffer)
-    {
-        swString_free(buffer);
-    }
-    swoole_set_object(ZEND_THIS, NULL);
-}
+static PHP_METHOD(swoole_buffer, __destruct) { }
 
 static PHP_METHOD(swoole_buffer, append)
 {
-    swString str;
-    bzero(&str, sizeof(str));
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    swString str = { 0 };
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str.str, &str.length) == FAILURE)
     {
@@ -160,7 +206,6 @@ static PHP_METHOD(swoole_buffer, append)
         php_error_docref(NULL, E_WARNING, "string empty");
         RETURN_FALSE;
     }
-    swString *buffer = swoole_get_object(ZEND_THIS);
 
     if ((str.length + buffer->length) > buffer->size && (str.length + buffer->length) > SW_STRING_BUFFER_MAXLEN)
     {
@@ -187,6 +232,7 @@ static PHP_METHOD(swoole_buffer, append)
 
 static PHP_METHOD(swoole_buffer, substr)
 {
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
     zend_long offset;
     zend_long length = -1;
     zend_bool remove = 0;
@@ -195,7 +241,6 @@ static PHP_METHOD(swoole_buffer, substr)
     {
         RETURN_FALSE;
     }
-    swString *buffer = swoole_get_object(ZEND_THIS);
 
     if (remove && !(offset == 0 && length <= buffer->length))
     {
@@ -230,16 +275,15 @@ static PHP_METHOD(swoole_buffer, substr)
 
 static PHP_METHOD(swoole_buffer, __toString)
 {
-    swString *buffer = swoole_get_object(ZEND_THIS);
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
     RETURN_STRINGL(buffer->str + buffer->offset, buffer->length - buffer->offset);
 }
 
 static PHP_METHOD(swoole_buffer, write)
 {
-    long offset;
-    swString str;
-
-    bzero(&str, sizeof(str));
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    zend_long offset;
+    swString str = { 0 };
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ls", &offset, &str.str, &str.length) == FAILURE)
     {
@@ -251,8 +295,6 @@ static PHP_METHOD(swoole_buffer, write)
         php_error_docref(NULL, E_WARNING, "string to write is empty");
         RETURN_FALSE;
     }
-
-    swString *buffer = swoole_get_object(ZEND_THIS);
 
     if (offset < 0)
     {
@@ -291,15 +333,14 @@ static PHP_METHOD(swoole_buffer, write)
 
 static PHP_METHOD(swoole_buffer, read)
 {
-    long offset;
-    long length;
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    zend_long offset;
+    zend_long length;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &offset, &length) == FAILURE)
     {
         RETURN_FALSE;
     }
-
-    swString *buffer = swoole_get_object(ZEND_THIS);
 
     if (offset < 0)
     {
@@ -323,14 +364,13 @@ static PHP_METHOD(swoole_buffer, read)
 
 static PHP_METHOD(swoole_buffer, expand)
 {
-    long size = -1;
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+    zend_long size = -1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &size) == FAILURE)
     {
         RETURN_FALSE;
     }
-
-    swString *buffer = swoole_get_object(ZEND_THIS);
 
     if (size <= buffer->size)
     {
@@ -351,16 +391,16 @@ static PHP_METHOD(swoole_buffer, expand)
 
 static PHP_METHOD(swoole_buffer, recycle)
 {
-    swString *buffer = swoole_get_object(ZEND_THIS);
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
 
     swoole_buffer_recycle(buffer);
-
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("length"), buffer->length);
 }
 
 static PHP_METHOD(swoole_buffer, clear)
 {
-    swString *buffer = swoole_get_object(ZEND_THIS);
+    swString *buffer = swoole_buffer_get_and_check_ptr(ZEND_THIS);
+
     buffer->length = 0;
     buffer->offset = 0;
     zend_update_property_long(swoole_buffer_ce, ZEND_THIS, ZEND_STRL("length"), 0);

--- a/swoole_channel_coro.cc
+++ b/swoole_channel_coro.cc
@@ -77,14 +77,14 @@ enum swChannelErrorCode
     SW_CHANNEL_CLOSED = -2,
 };
 
-static sw_inline channel_coro* swoole_channel_coro_fetch_object(zend_object *obj)
+static sw_inline channel_coro* php_swoole_channel_coro_fetch_object(zend_object *obj)
 {
     return (channel_coro *) ((char *) obj - swoole_channel_coro_handlers.offset);
 }
 
 static sw_inline Channel * php_swoole_get_channel(zval *zobject)
 {
-    Channel *chan = swoole_channel_coro_fetch_object(Z_OBJ_P(zobject))->chan;
+    Channel *chan = php_swoole_channel_coro_fetch_object(Z_OBJ_P(zobject))->chan;
     if (UNEXPECTED(!chan))
     {
         php_swoole_fatal_error(E_ERROR, "you must call Channel constructor first");
@@ -92,9 +92,9 @@ static sw_inline Channel * php_swoole_get_channel(zval *zobject)
     return chan;
 }
 
-static void swoole_channel_coro_free_object(zend_object *object)
+static void php_swoole_channel_coro_free_object(zend_object *object)
 {
-    channel_coro *chan_t = swoole_channel_coro_fetch_object(object);
+    channel_coro *chan_t = php_swoole_channel_coro_fetch_object(object);
     Channel *chan = chan_t->chan;
     if (chan)
     {
@@ -108,7 +108,7 @@ static void swoole_channel_coro_free_object(zend_object *object)
     zend_object_std_dtor(&chan_t->std);
 }
 
-static zend_object *swoole_channel_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_channel_coro_create_object(zend_class_entry *ce)
 {
     channel_coro *chan_t = (channel_coro *) ecalloc(1, sizeof(channel_coro) + zend_object_properties_size(ce));
     zend_object_std_init(&chan_t->std, ce);
@@ -123,7 +123,7 @@ void php_swoole_channel_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_channel_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_channel_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_channel_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_channel_coro, swoole_channel_coro_create_object, swoole_channel_coro_free_object, channel_coro, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_channel_coro, php_swoole_channel_coro_create_object, php_swoole_channel_coro_free_object, channel_coro, std);
     if (SWOOLE_G(use_shortname))
     {
         SW_CLASS_ALIAS("Chan", swoole_channel_coro);
@@ -151,7 +151,7 @@ static PHP_METHOD(swoole_channel_coro, __construct)
         capacity = 1;
     }
 
-    channel_coro *chan_t = swoole_channel_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
+    channel_coro *chan_t = php_swoole_channel_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
     chan_t->chan = new Channel(capacity);
     zend_update_property_long(swoole_channel_coro_ce, ZEND_THIS, ZEND_STRL("capacity"), capacity);
 }

--- a/swoole_channel_coro.cc
+++ b/swoole_channel_coro.cc
@@ -82,7 +82,7 @@ static sw_inline channel_coro* swoole_channel_coro_fetch_object(zend_object *obj
     return (channel_coro *) ((char *) obj - swoole_channel_coro_handlers.offset);
 }
 
-static sw_inline Channel * swoole_get_channel(zval *zobject)
+static sw_inline Channel * php_swoole_get_channel(zval *zobject)
 {
     Channel *chan = swoole_channel_coro_fetch_object(Z_OBJ_P(zobject))->chan;
     if (UNEXPECTED(!chan))
@@ -158,7 +158,7 @@ static PHP_METHOD(swoole_channel_coro, __construct)
 
 static PHP_METHOD(swoole_channel_coro, push)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     if (chan->is_closed())
     {
         zend_update_property_long(swoole_channel_coro_ce, ZEND_THIS, ZEND_STRL("errCode"), SW_CHANNEL_CLOSED);
@@ -195,7 +195,7 @@ static PHP_METHOD(swoole_channel_coro, push)
 
 static PHP_METHOD(swoole_channel_coro, pop)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     if (chan->is_closed())
     {
         zend_update_property_long(swoole_channel_coro_ce, ZEND_THIS, ZEND_STRL("errCode"), SW_CHANNEL_CLOSED);
@@ -228,31 +228,31 @@ static PHP_METHOD(swoole_channel_coro, pop)
 
 static PHP_METHOD(swoole_channel_coro, close)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     RETURN_BOOL(chan->close());
 }
 
 static PHP_METHOD(swoole_channel_coro, length)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     RETURN_LONG(chan->length());
 }
 
 static PHP_METHOD(swoole_channel_coro, isEmpty)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     RETURN_BOOL(chan->is_empty());
 }
 
 static PHP_METHOD(swoole_channel_coro, isFull)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     RETURN_BOOL(chan->is_full());
 }
 
 static PHP_METHOD(swoole_channel_coro, stats)
 {
-    Channel *chan = swoole_get_channel(ZEND_THIS);
+    Channel *chan = php_swoole_get_channel(ZEND_THIS);
     array_init(return_value);
     add_assoc_long_ex(return_value, ZEND_STRL("consumer_num"), chan->consumer_num());
     add_assoc_long_ex(return_value, ZEND_STRL("producer_num"), chan->producer_num());

--- a/swoole_client.cc
+++ b/swoole_client.cc
@@ -53,47 +53,47 @@ typedef struct
     zend_object std;
 } client_t;
 
-static sw_inline client_t* swoole_client_fetch_object(zend_object *obj)
+static sw_inline client_t* php_swoole_client_fetch_object(zend_object *obj)
 {
     return (client_t *) ((char *) obj - swoole_client_handlers.offset);
 }
 
 static sw_inline swClient* php_swoole_client_get_cli(zval *zobject)
 {
-    return swoole_client_fetch_object(Z_OBJ_P(zobject))->cli;
+    return php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cli;
 }
 
 static sw_inline void php_swoole_client_set_cli(zval *zobject, swClient *cli)
 {
-    swoole_client_fetch_object(Z_OBJ_P(zobject))->cli = cli;
+    php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cli = cli;
 }
 
 static sw_inline zval* php_swoole_client_get_zsocket(zval *zobject)
 {
-    return swoole_client_fetch_object(Z_OBJ_P(zobject))->zsocket;
+    return php_swoole_client_fetch_object(Z_OBJ_P(zobject))->zsocket;
 }
 
 static sw_inline void php_swoole_client_set_zsocket(zval *zobject, zval *zsocket)
 {
-    swoole_client_fetch_object(Z_OBJ_P(zobject))->zsocket = zsocket;
+    php_swoole_client_fetch_object(Z_OBJ_P(zobject))->zsocket = zsocket;
 }
 
 static sw_inline client_callback* php_swoole_client_get_cb(zval *zobject)
 {
-    return swoole_client_fetch_object(Z_OBJ_P(zobject))->cb;
+    return php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cb;
 }
 
 static sw_inline void php_swoole_client_set_cb(zval *zobject, client_callback *cb)
 {
-    swoole_client_fetch_object(Z_OBJ_P(zobject))->cb = cb;
+    php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cb = cb;
 }
 
-static void swoole_client_free_object(zend_object *object)
+static void php_swoole_client_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_client_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_client_create_object(zend_class_entry *ce)
 {
     client_t *client = (client_t *) ecalloc(1, sizeof(client_t) + zend_object_properties_size(ce));
     zend_object_std_init(&client->std, ce);
@@ -231,7 +231,7 @@ void php_swoole_client_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_client, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_client, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_client, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_client, swoole_client_create_object, swoole_client_free_object, client_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_client, php_swoole_client_create_object, php_swoole_client_free_object, client_t, std);
 
     zend_declare_property_long(swoole_client_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_client_ce, ZEND_STRL("sock"), -1, ZEND_ACC_PUBLIC);

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -176,7 +176,7 @@ void php_swoole_client_coro_minit(int module_number)
     zend_declare_property_string(swoole_client_coro_ce, ZEND_STRL("errMsg"), "", ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_client_coro_ce, ZEND_STRL("fd"), -1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_client_coro_ce, ZEND_STRL("socket"), ZEND_ACC_PRIVATE);
-    zend_declare_property_long(swoole_client_coro_ce, ZEND_STRL("type"), 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(swoole_client_coro_ce, ZEND_STRL("type"), SW_SOCK_TCP, ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_client_coro_ce, ZEND_STRL("setting"), ZEND_ACC_PUBLIC);
     zend_declare_property_bool(swoole_client_coro_ce, ZEND_STRL("connected"), 0, ZEND_ACC_PUBLIC);
 

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -604,6 +604,11 @@ bool php_swoole_socket_set_ssl(Socket *sock, zval *zset)
 
 static PHP_METHOD(swoole_client_coro, __construct)
 {
+    if (swoole_get_client(ZEND_THIS)->sock)
+    {
+        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+    }
+
     zend_long type = 0;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
@@ -619,11 +624,6 @@ static PHP_METHOD(swoole_client_coro, __construct)
             class_name, space, get_active_function_name(), 1, type
         );
         RETURN_FALSE;
-    }
-
-    if (swoole_get_client(ZEND_THIS)->sock)
-    {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
     }
 
     zend_update_property_long(swoole_client_coro_ce, ZEND_THIS, ZEND_STRL("type"), type);

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -606,7 +606,7 @@ static PHP_METHOD(swoole_client_coro, __construct)
 {
     if (swoole_get_client(ZEND_THIS)->sock)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     zend_long type = 0;

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -130,14 +130,14 @@ static const zend_function_entry swoole_client_coro_methods[] =
     PHP_FE_END
 };
 
-static sw_inline client_coro* swoole_client_coro_fetch_object(zend_object *obj)
+static sw_inline client_coro* php_swoole_client_coro_fetch_object(zend_object *obj)
 {
     return (client_coro *) ((char *) obj - swoole_client_coro_handlers.offset);
 }
 
 static sw_inline client_coro* php_swoole_get_client(zval *zobject)
 {
-    return swoole_client_coro_fetch_object(Z_OBJ_P(zobject));
+    return php_swoole_client_coro_fetch_object(Z_OBJ_P(zobject));
 }
 
 static sw_inline Socket* php_swoole_get_sock(zval *zobject)
@@ -145,9 +145,9 @@ static sw_inline Socket* php_swoole_get_sock(zval *zobject)
     return php_swoole_get_client(zobject)->sock;
 }
 
-static void swoole_client_coro_free_object(zend_object *object)
+static void php_swoole_client_coro_free_object(zend_object *object)
 {
-    client_coro *client = swoole_client_coro_fetch_object(object);
+    client_coro *client = php_swoole_client_coro_fetch_object(object);
     if (client->sock)
     {
         php_swoole_client_coro_socket_free(client->sock);
@@ -155,7 +155,7 @@ static void swoole_client_coro_free_object(zend_object *object)
     zend_object_std_dtor(&client->std);
 }
 
-static zend_object *swoole_client_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_client_coro_create_object(zend_class_entry *ce)
 {
     client_coro *sock_t = (client_coro *) ecalloc(1, sizeof(client_coro) + zend_object_properties_size(ce));
     zend_object_std_init(&sock_t->std, ce);
@@ -170,7 +170,7 @@ void php_swoole_client_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_client_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_client_coro, swoole_client_coro_create_object, swoole_client_coro_free_object, client_coro, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_client_coro, php_swoole_client_coro_create_object, php_swoole_client_coro_free_object, client_coro, std);
 
     zend_declare_property_long(swoole_client_coro_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_string(swoole_client_coro_ce, ZEND_STRL("errMsg"), "", ZEND_ACC_PUBLIC);

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -150,7 +150,7 @@ static void swoole_client_coro_free_object(zend_object *object)
     client_coro *client = swoole_client_coro_fetch_object(object);
     if (client->sock)
     {
-        delete client->sock;
+        php_swoole_client_coro_socket_free(client->sock);
     }
     zend_object_std_dtor(&client->std);
 }
@@ -631,12 +631,7 @@ static PHP_METHOD(swoole_client_coro, __construct)
     RETURN_TRUE;
 }
 
-static PHP_METHOD(swoole_client_coro, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    client_coro_close(ZEND_THIS);
-}
+static PHP_METHOD(swoole_client_coro, __destruct) { }
 
 static PHP_METHOD(swoole_client_coro, set)
 {

--- a/swoole_client_coro.cc
+++ b/swoole_client_coro.cc
@@ -135,14 +135,14 @@ static sw_inline client_coro* swoole_client_coro_fetch_object(zend_object *obj)
     return (client_coro *) ((char *) obj - swoole_client_coro_handlers.offset);
 }
 
-static sw_inline client_coro* swoole_get_client(zval *zobject)
+static sw_inline client_coro* php_swoole_get_client(zval *zobject)
 {
     return swoole_client_coro_fetch_object(Z_OBJ_P(zobject));
 }
 
-static sw_inline Socket* swoole_get_sock(zval *zobject)
+static sw_inline Socket* php_swoole_get_sock(zval *zobject)
 {
-    return swoole_get_client(zobject)->sock;
+    return php_swoole_get_client(zobject)->sock;
 }
 
 static void swoole_client_coro_free_object(zend_object *object)
@@ -188,7 +188,7 @@ void php_swoole_client_coro_minit(int module_number)
 
 static sw_inline Socket* client_get_ptr(zval *zobject, bool silent = false)
 {
-    Socket *cli = swoole_get_client(zobject)->sock;
+    Socket *cli = php_swoole_get_client(zobject)->sock;
     if (cli)
     {
         return cli;
@@ -235,20 +235,20 @@ static Socket* client_coro_new(zval *zobject, int port)
     }
 #endif
 
-    swoole_get_client(zobject)->sock = cli;
+    php_swoole_get_client(zobject)->sock = cli;
 
     return cli;
 }
 
 static bool client_coro_close(zval *zobject)
 {
-    Socket *cli = swoole_get_sock(zobject);
+    Socket *cli = php_swoole_get_sock(zobject);
     if (cli)
     {
         zend_update_property_bool(Z_OBJCE_P(zobject), zobject, ZEND_STRL("connected"), 0);
         if (!cli->get_bound_cid())
         {
-            swoole_get_client(zobject)->sock = nullptr;
+            php_swoole_get_client(zobject)->sock = nullptr;
         }
         php_swoole_client_coro_socket_free(cli);
         return true;
@@ -604,7 +604,7 @@ bool php_swoole_socket_set_ssl(Socket *sock, zval *zset)
 
 static PHP_METHOD(swoole_client_coro, __construct)
 {
-    if (swoole_get_client(ZEND_THIS)->sock)
+    if (php_swoole_get_client(ZEND_THIS)->sock)
     {
         php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
@@ -680,7 +680,7 @@ static PHP_METHOD(swoole_client_coro, connect)
         RETURN_FALSE;
     }
 
-    Socket *cli = swoole_get_sock(ZEND_THIS);
+    Socket *cli = php_swoole_get_sock(ZEND_THIS);
     if (cli)
     {
         RETURN_FALSE;
@@ -772,7 +772,7 @@ static PHP_METHOD(swoole_client_coro, sendto)
         RETURN_FALSE;
     }
 
-    Socket *cli = swoole_get_sock(ZEND_THIS);
+    Socket *cli = php_swoole_get_sock(ZEND_THIS);
     if (!cli)
     {
         cli = client_coro_new(ZEND_THIS, (int) port);
@@ -799,7 +799,7 @@ static PHP_METHOD(swoole_client_coro, recvfrom)
         RETURN_FALSE;
     }
 
-    Socket *cli = swoole_get_sock(ZEND_THIS);
+    Socket *cli = php_swoole_get_sock(ZEND_THIS);
     if (!cli)
     {
         cli = client_coro_new(ZEND_THIS);
@@ -962,7 +962,7 @@ static PHP_METHOD(swoole_client_coro, peek)
 
 static PHP_METHOD(swoole_client_coro, isConnected)
 {
-    Socket *cli = swoole_get_sock(ZEND_THIS);
+    Socket *cli = php_swoole_get_sock(ZEND_THIS);
     if (cli && cli->is_connect())
     {
         RETURN_TRUE;

--- a/swoole_http.h
+++ b/swoole_http.h
@@ -216,8 +216,8 @@ extern swString *swoole_zlib_buffer;
     (strncasecmp(at, ZEND_STRL(const_str)) == 0))
 
 http_context* swoole_http_context_new(int fd);
-http_context* swoole_http_request_get_and_check_context(zval *zobject);
-http_context* swoole_http_response_get_and_check_context(zval *zobject, bool check_end);
+http_context* php_swoole_http_request_get_and_check_context(zval *zobject);
+http_context* php_swoole_http_response_get_and_check_context(zval *zobject, bool check_end);
 void swoole_http_context_free(http_context *ctx);
 void swoole_http_context_copy(http_context *src, http_context *dst);
 
@@ -237,10 +237,10 @@ int swoole_http_parse_form_data(http_context *ctx, const char *boundary_str, int
 void swoole_http_parse_cookie(zval *array, const char *at, size_t length);
 void swoole_http_server_init_context(swServer *serv, http_context *ctx);
 
-http_context * swoole_http_request_get_context(zval *zobject);
-void swoole_http_request_set_context(zval *zobject, http_context *context);
-http_context * swoole_http_response_get_context(zval *zobject);
-void swoole_http_response_set_context(zval *zobject, http_context *context);
+http_context * php_swoole_http_request_get_context(zval *zobject);
+void php_swoole_http_request_set_context(zval *zobject, http_context *context);
+http_context * php_swoole_http_response_get_context(zval *zobject);
+void php_swoole_http_response_set_context(zval *zobject, http_context *context);
 size_t swoole_http_requset_parse(http_context *ctx, const char *data, size_t length);
 
 bool swoole_http_response_set_header(http_context *ctx, const char *k, size_t klen, const char *v, size_t vlen, bool ucwords);

--- a/swoole_http.h
+++ b/swoole_http.h
@@ -216,7 +216,8 @@ extern swString *swoole_zlib_buffer;
     (strncasecmp(at, ZEND_STRL(const_str)) == 0))
 
 http_context* swoole_http_context_new(int fd);
-http_context* swoole_http_context_get(zval *zobject, const bool check_end);
+http_context* swoole_http_request_get_and_check_context(zval *zobject);
+http_context* swoole_http_response_get_and_check_context(zval *zobject, bool check_end);
 void swoole_http_context_free(http_context *ctx);
 void swoole_http_context_copy(http_context *src, http_context *dst);
 
@@ -236,6 +237,10 @@ int swoole_http_parse_form_data(http_context *ctx, const char *boundary_str, int
 void swoole_http_parse_cookie(zval *array, const char *at, size_t length);
 void swoole_http_server_init_context(swServer *serv, http_context *ctx);
 
+http_context * swoole_http_request_get_context(zval *zobject);
+void swoole_http_request_set_context(zval *zobject, http_context *context);
+http_context * swoole_http_response_get_context(zval *zobject);
+void swoole_http_response_set_context(zval *zobject, http_context *context);
 size_t swoole_http_requset_parse(http_context *ctx, const char *data, size_t length);
 
 bool swoole_http_response_set_header(http_context *ctx, const char *k, size_t klen, const char *v, size_t vlen, bool ucwords);

--- a/swoole_http2_client_coro.cc
+++ b/swoole_http2_client_coro.cc
@@ -41,50 +41,6 @@ static zend_object_handlers swoole_http2_request_handlers;
 static zend_class_entry *swoole_http2_response_ce;
 static zend_object_handlers swoole_http2_response_handlers;
 
-class http2_client;
-
-typedef struct
-{
-    http2_client *h2c;
-    zend_object std;
-} http2_client_coro_t;
-
-static sw_inline http2_client_coro_t* swoole_http2_client_coro_fetch_object(zend_object *obj)
-{
-    return (http2_client_coro_t *) ((char *) obj - swoole_http2_client_coro_handlers.offset);
-}
-
-static sw_inline http2_client* swoole_get_h2c(zval *zobject)
-{
-    return swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
-}
-
-static sw_inline void swoole_set_h2c(zval *zobject, http2_client *h2c)
-{
-    swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
-}
-
-static void swoole_http2_client_coro_free_object(zend_object *object)
-{
-    http2_client_coro_t *request = swoole_http2_client_coro_fetch_object(object);
-    http2_client *h2c = request->h2c;
-
-    if (h2c)
-    {
-        delete h2c;
-    }
-    zend_object_std_dtor(&request->std);
-}
-
-static zend_object *swoole_http2_client_coro_create_object(zend_class_entry *ce)
-{
-    http2_client_coro_t *request = (http2_client_coro_t *) ecalloc(1, sizeof(http2_client_coro_t) + zend_object_properties_size(ce));
-    zend_object_std_init(&request->std, ce);
-    object_properties_init(&request->std, ce);
-    request->std.handlers = &swoole_http2_client_coro_handlers;
-    return &request->std;
-}
-
 struct http2_client_stream
 {
     uint32_t stream_id;
@@ -217,6 +173,48 @@ private:
         return true;
     }
 };
+
+typedef struct
+{
+    http2_client *h2c;
+    zend_object std;
+} http2_client_coro_t;
+
+static sw_inline http2_client_coro_t* swoole_http2_client_coro_fetch_object(zend_object *obj)
+{
+    return (http2_client_coro_t *) ((char *) obj - swoole_http2_client_coro_handlers.offset);
+}
+
+static sw_inline http2_client* swoole_get_h2c(zval *zobject)
+{
+    return swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
+}
+
+static sw_inline void swoole_set_h2c(zval *zobject, http2_client *h2c)
+{
+    swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
+}
+
+static void swoole_http2_client_coro_free_object(zend_object *object)
+{
+    http2_client_coro_t *request = swoole_http2_client_coro_fetch_object(object);
+    http2_client *h2c = request->h2c;
+
+    if (h2c)
+    {
+        delete h2c;
+    }
+    zend_object_std_dtor(&request->std);
+}
+
+static zend_object *swoole_http2_client_coro_create_object(zend_class_entry *ce)
+{
+    http2_client_coro_t *request = (http2_client_coro_t *) ecalloc(1, sizeof(http2_client_coro_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&request->std, ce);
+    object_properties_init(&request->std, ce);
+    request->std.handlers = &swoole_http2_client_coro_handlers;
+    return &request->std;
+}
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_void, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/swoole_http2_client_coro.cc
+++ b/swoole_http2_client_coro.cc
@@ -180,24 +180,24 @@ typedef struct
     zend_object std;
 } http2_client_coro_t;
 
-static sw_inline http2_client_coro_t* swoole_http2_client_coro_fetch_object(zend_object *obj)
+static sw_inline http2_client_coro_t* php_swoole_http2_client_coro_fetch_object(zend_object *obj)
 {
     return (http2_client_coro_t *) ((char *) obj - swoole_http2_client_coro_handlers.offset);
 }
 
 static sw_inline http2_client* php_swoole_get_h2c(zval *zobject)
 {
-    return swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
+    return php_swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
 }
 
 static sw_inline void php_swoole_set_h2c(zval *zobject, http2_client *h2c)
 {
-    swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
+    php_swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
 }
 
-static void swoole_http2_client_coro_free_object(zend_object *object)
+static void php_swoole_http2_client_coro_free_object(zend_object *object)
 {
-    http2_client_coro_t *request = swoole_http2_client_coro_fetch_object(object);
+    http2_client_coro_t *request = php_swoole_http2_client_coro_fetch_object(object);
     http2_client *h2c = request->h2c;
 
     if (h2c)
@@ -207,7 +207,7 @@ static void swoole_http2_client_coro_free_object(zend_object *object)
     zend_object_std_dtor(&request->std);
 }
 
-static zend_object *swoole_http2_client_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_http2_client_coro_create_object(zend_class_entry *ce)
 {
     http2_client_coro_t *request = (http2_client_coro_t *) ecalloc(1, sizeof(http2_client_coro_t) + zend_object_properties_size(ce));
     zend_object_std_init(&request->std, ce);
@@ -294,7 +294,7 @@ void php_swoole_http2_client_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http2_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http2_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http2_client_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http2_client_coro, swoole_http2_client_coro_create_object, swoole_http2_client_coro_free_object, http2_client_coro_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http2_client_coro, php_swoole_http2_client_coro_create_object, php_swoole_http2_client_coro_free_object, http2_client_coro_t, std);
 
     SW_INIT_CLASS_ENTRY_EX(swoole_http2_client_coro_exception, "Swoole\\Coroutine\\Http2\\Client\\Exception", NULL, "Co\\Http2\\Client\\Exception", NULL, swoole_exception);
 

--- a/swoole_http2_client_coro.cc
+++ b/swoole_http2_client_coro.cc
@@ -41,6 +41,50 @@ static zend_object_handlers swoole_http2_request_handlers;
 static zend_class_entry *swoole_http2_response_ce;
 static zend_object_handlers swoole_http2_response_handlers;
 
+class http2_client;
+
+typedef struct
+{
+    http2_client *h2c;
+    zend_object std;
+} http2_client_coro_t;
+
+static sw_inline http2_client_coro_t* swoole_http2_client_coro_fetch_object(zend_object *obj)
+{
+    return (http2_client_coro_t *) ((char *) obj - swoole_http2_client_coro_handlers.offset);
+}
+
+static sw_inline http2_client* swoole_get_h2c(zval *zobject)
+{
+    return swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
+}
+
+static sw_inline void swoole_set_h2c(zval *zobject, http2_client *h2c)
+{
+    swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
+}
+
+static void swoole_http2_client_coro_free_object(zend_object *object)
+{
+    http2_client_coro_t *request = swoole_http2_client_coro_fetch_object(object);
+    http2_client *h2c = request->h2c;
+
+    if (h2c)
+    {
+        delete h2c;
+    }
+    zend_object_std_dtor(&request->std);
+}
+
+static zend_object *swoole_http2_client_coro_create_object(zend_class_entry *ce)
+{
+    http2_client_coro_t *request = (http2_client_coro_t *) ecalloc(1, sizeof(http2_client_coro_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&request->std, ce);
+    object_properties_init(&request->std, ce);
+    request->std.handlers = &swoole_http2_client_coro_handlers;
+    return &request->std;
+}
+
 struct http2_client_stream
 {
     uint32_t stream_id;
@@ -252,7 +296,7 @@ void php_swoole_http2_client_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http2_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http2_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http2_client_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http2_client_coro);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http2_client_coro, swoole_http2_client_coro_create_object, swoole_http2_client_coro_free_object, http2_client_coro_t, std);
 
     SW_INIT_CLASS_ENTRY_EX(swoole_http2_client_coro_exception, "Swoole\\Coroutine\\Http2\\Client\\Exception", NULL, "Co\\Http2\\Client\\Exception", NULL, swoole_exception);
 
@@ -770,7 +814,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
 #endif
     }
 
-    swoole_set_object(ZEND_THIS, h2c);
+    swoole_set_h2c(ZEND_THIS, h2c);
 
     zend_update_property_stringl(swoole_http2_client_coro_ce, ZEND_THIS, ZEND_STRL("host"), host, host_len);
     zend_update_property_long(swoole_http2_client_coro_ce, ZEND_THIS, ZEND_STRL("port"), port);
@@ -779,7 +823,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
 
 static PHP_METHOD(swoole_http2_client_coro, set)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     zval *zset;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -940,7 +984,7 @@ int http2_client::parse_header(http2_client_stream *stream, int flags, char *in,
 
 static ssize_t http2_client_build_header(zval *zobject, zval *zrequest, char *buffer)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(zobject);
+    http2_client *h2c = swoole_get_h2c(zobject);
     zval *zmethod = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("method"), 0);
     zval *zpath = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("path"), 0);
     zval *zheaders = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("headers"), 0);
@@ -1284,7 +1328,7 @@ bool http2_client::send_goaway_frame(zend_long error_code, const char *debug_dat
 static PHP_METHOD(swoole_http2_client_coro, send)
 {
     zval *request;
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1314,7 +1358,7 @@ static PHP_METHOD(swoole_http2_client_coro, send)
 
 static PHP_METHOD(swoole_http2_client_coro, recv)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
 
     double timeout = 0;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &timeout) == FAILURE)
@@ -1348,28 +1392,17 @@ static PHP_METHOD(swoole_http2_client_coro, recv)
     }
 }
 
-static PHP_METHOD(swoole_http2_client_coro, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
-    if (!h2c)
-    {
-        return;
-    }
-    delete h2c;
-    swoole_set_object(ZEND_THIS, nullptr);
-}
+static PHP_METHOD(swoole_http2_client_coro, __destruct) { }
 
 static PHP_METHOD(swoole_http2_client_coro, close)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     RETURN_BOOL(h2c->close());
 }
 
 static PHP_METHOD(swoole_http2_client_coro, connect)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     RETURN_BOOL(h2c->connect());
 }
 
@@ -1385,7 +1418,7 @@ static sw_inline void http2_settings_to_array(swHttp2_settings *settings, zval* 
 
 static PHP_METHOD(swoole_http2_client_coro, stats)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     zval _zarray, *zarray = &_zarray;
     swString key = {0};
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &key.str, &key.length) == FAILURE)
@@ -1442,7 +1475,7 @@ static PHP_METHOD(swoole_http2_client_coro, isStreamExist)
         RETURN_FALSE;
     }
 
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     if (!h2c->client)
     {
         RETURN_FALSE;
@@ -1464,7 +1497,7 @@ static PHP_METHOD(swoole_http2_client_coro, isStreamExist)
 
 static PHP_METHOD(swoole_http2_client_coro, write)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1483,7 +1516,7 @@ static PHP_METHOD(swoole_http2_client_coro, write)
 
 static PHP_METHOD(swoole_http2_client_coro, ping)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1504,7 +1537,7 @@ static PHP_METHOD(swoole_http2_client_coro, ping)
  */
 static PHP_METHOD(swoole_http2_client_coro, goaway)
 {
-    http2_client *h2c = (http2_client *) swoole_get_object(ZEND_THIS);
+    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
     zend_long error_code = SW_HTTP2_ERROR_NO_ERROR;
     char* debug_data = NULL;
     size_t debug_data_len = 0;

--- a/swoole_http2_client_coro.cc
+++ b/swoole_http2_client_coro.cc
@@ -185,12 +185,12 @@ static sw_inline http2_client_coro_t* swoole_http2_client_coro_fetch_object(zend
     return (http2_client_coro_t *) ((char *) obj - swoole_http2_client_coro_handlers.offset);
 }
 
-static sw_inline http2_client* swoole_get_h2c(zval *zobject)
+static sw_inline http2_client* php_swoole_get_h2c(zval *zobject)
 {
     return swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c;
 }
 
-static sw_inline void swoole_set_h2c(zval *zobject, http2_client *h2c)
+static sw_inline void php_swoole_set_h2c(zval *zobject, http2_client *h2c)
 {
     swoole_http2_client_coro_fetch_object(Z_OBJ_P(zobject))->h2c = h2c;
 }
@@ -812,7 +812,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
 #endif
     }
 
-    swoole_set_h2c(ZEND_THIS, h2c);
+    php_swoole_set_h2c(ZEND_THIS, h2c);
 
     zend_update_property_stringl(swoole_http2_client_coro_ce, ZEND_THIS, ZEND_STRL("host"), host, host_len);
     zend_update_property_long(swoole_http2_client_coro_ce, ZEND_THIS, ZEND_STRL("port"), port);
@@ -821,7 +821,7 @@ static PHP_METHOD(swoole_http2_client_coro, __construct)
 
 static PHP_METHOD(swoole_http2_client_coro, set)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     zval *zset;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -982,7 +982,7 @@ int http2_client::parse_header(http2_client_stream *stream, int flags, char *in,
 
 static ssize_t http2_client_build_header(zval *zobject, zval *zrequest, char *buffer)
 {
-    http2_client *h2c = swoole_get_h2c(zobject);
+    http2_client *h2c = php_swoole_get_h2c(zobject);
     zval *zmethod = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("method"), 0);
     zval *zpath = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("path"), 0);
     zval *zheaders = sw_zend_read_property(swoole_http2_request_ce, zrequest, ZEND_STRL("headers"), 0);
@@ -1326,7 +1326,7 @@ bool http2_client::send_goaway_frame(zend_long error_code, const char *debug_dat
 static PHP_METHOD(swoole_http2_client_coro, send)
 {
     zval *request;
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1356,7 +1356,7 @@ static PHP_METHOD(swoole_http2_client_coro, send)
 
 static PHP_METHOD(swoole_http2_client_coro, recv)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
 
     double timeout = 0;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|d", &timeout) == FAILURE)
@@ -1394,13 +1394,13 @@ static PHP_METHOD(swoole_http2_client_coro, __destruct) { }
 
 static PHP_METHOD(swoole_http2_client_coro, close)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     RETURN_BOOL(h2c->close());
 }
 
 static PHP_METHOD(swoole_http2_client_coro, connect)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     RETURN_BOOL(h2c->connect());
 }
 
@@ -1416,7 +1416,7 @@ static sw_inline void http2_settings_to_array(swHttp2_settings *settings, zval* 
 
 static PHP_METHOD(swoole_http2_client_coro, stats)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     zval _zarray, *zarray = &_zarray;
     swString key = {0};
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &key.str, &key.length) == FAILURE)
@@ -1473,7 +1473,7 @@ static PHP_METHOD(swoole_http2_client_coro, isStreamExist)
         RETURN_FALSE;
     }
 
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     if (!h2c->client)
     {
         RETURN_FALSE;
@@ -1495,7 +1495,7 @@ static PHP_METHOD(swoole_http2_client_coro, isStreamExist)
 
 static PHP_METHOD(swoole_http2_client_coro, write)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1514,7 +1514,7 @@ static PHP_METHOD(swoole_http2_client_coro, write)
 
 static PHP_METHOD(swoole_http2_client_coro, ping)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
 
     if (!h2c->is_available())
     {
@@ -1535,7 +1535,7 @@ static PHP_METHOD(swoole_http2_client_coro, ping)
  */
 static PHP_METHOD(swoole_http2_client_coro, goaway)
 {
-    http2_client *h2c = swoole_get_h2c(ZEND_THIS);
+    http2_client *h2c = php_swoole_get_h2c(ZEND_THIS);
     zend_long error_code = SW_HTTP2_ERROR_NO_ERROR;
     char* debug_data = NULL;
     size_t debug_data_len = 0;

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -1592,14 +1592,14 @@ http_client::~http_client()
     }
 }
 
-static sw_inline http_client_coro* swoole_http_client_coro_fetch_object(zend_object *obj)
+static sw_inline http_client_coro* php_swoole_http_client_coro_fetch_object(zend_object *obj)
 {
     return (http_client_coro *) ((char *) obj - swoole_http_client_coro_handlers.offset);
 }
 
 static sw_inline http_client * php_swoole_get_phc(zval *zobject)
 {
-    http_client *phc = swoole_http_client_coro_fetch_object(Z_OBJ_P(zobject))->phc;
+    http_client *phc = php_swoole_http_client_coro_fetch_object(Z_OBJ_P(zobject))->phc;
     if (UNEXPECTED(!phc))
     {
         php_swoole_fatal_error(E_ERROR, "you must call Http Client constructor first");
@@ -1607,9 +1607,9 @@ static sw_inline http_client * php_swoole_get_phc(zval *zobject)
     return phc;
 }
 
-static void swoole_http_client_coro_free_object(zend_object *object)
+static void php_swoole_http_client_coro_free_object(zend_object *object)
 {
-    http_client_coro *hcc = swoole_http_client_coro_fetch_object(object);
+    http_client_coro *hcc = php_swoole_http_client_coro_fetch_object(object);
     if (hcc->phc)
     {
         delete hcc->phc;
@@ -1618,7 +1618,7 @@ static void swoole_http_client_coro_free_object(zend_object *object)
     zend_object_std_dtor(&hcc->std);
 }
 
-static zend_object *swoole_http_client_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_http_client_coro_create_object(zend_class_entry *ce)
 {
     http_client_coro *hcc = (http_client_coro *) ecalloc(1, sizeof(http_client_coro) + zend_object_properties_size(ce));
     zend_object_std_init(&hcc->std, ce);
@@ -1633,7 +1633,7 @@ void php_swoole_http_client_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_client_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_client_coro, swoole_http_client_coro_create_object, swoole_http_client_coro_free_object, http_client_coro, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_client_coro, php_swoole_http_client_coro_create_object, php_swoole_http_client_coro_free_object, http_client_coro, std);
 
     // client status
     zend_declare_property_long(swoole_http_client_coro_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);
@@ -1679,7 +1679,7 @@ void php_swoole_http_client_coro_minit(int module_number)
 
 static PHP_METHOD(swoole_http_client_coro, __construct)
 {
-    http_client_coro *hcc = swoole_http_client_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
+    http_client_coro *hcc = php_swoole_http_client_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
     char *host;
     size_t host_len;
     zend_long port = 80;

--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -1597,7 +1597,7 @@ static sw_inline http_client_coro* swoole_http_client_coro_fetch_object(zend_obj
     return (http_client_coro *) ((char *) obj - swoole_http_client_coro_handlers.offset);
 }
 
-static sw_inline http_client * swoole_get_phc(zval *zobject)
+static sw_inline http_client * php_swoole_get_phc(zval *zobject)
 {
     http_client *phc = swoole_http_client_coro_fetch_object(Z_OBJ_P(zobject))->phc;
     if (UNEXPECTED(!phc))
@@ -1719,7 +1719,7 @@ static PHP_METHOD(swoole_http_client_coro, __destruct) { }
 
 static PHP_METHOD(swoole_http_client_coro, set)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     zval *zset;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -1741,14 +1741,14 @@ static PHP_METHOD(swoole_http_client_coro, set)
 
 static PHP_METHOD(swoole_http_client_coro, getDefer)
 {
-    http_client *phc = swoole_get_phc(ZEND_THIS);
+    http_client *phc = php_swoole_get_phc(ZEND_THIS);
 
     RETURN_BOOL(phc->defer);
 }
 
 static PHP_METHOD(swoole_http_client_coro, setDefer)
 {
-    http_client *phc = swoole_get_phc(ZEND_THIS);
+    http_client *phc = php_swoole_get_phc(ZEND_THIS);
     zend_bool defer = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -1791,7 +1791,7 @@ static PHP_METHOD(swoole_http_client_coro, setHeaders)
 
 static PHP_METHOD(swoole_http_client_coro, setBasicAuth)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *username, *password;
     size_t username_len, password_len;
 
@@ -1962,7 +1962,7 @@ static PHP_METHOD(swoole_http_client_coro, addData)
 
 static PHP_METHOD(swoole_http_client_coro, execute)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *path = NULL;
     size_t path_len = 0;
 
@@ -1975,7 +1975,7 @@ static PHP_METHOD(swoole_http_client_coro, execute)
 
 static PHP_METHOD(swoole_http_client_coro, get)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *path = NULL;
     size_t path_len = 0;
 
@@ -1990,7 +1990,7 @@ static PHP_METHOD(swoole_http_client_coro, get)
 
 static PHP_METHOD(swoole_http_client_coro, post)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *path = NULL;
     size_t path_len = 0;
     zval *post_data;
@@ -2008,7 +2008,7 @@ static PHP_METHOD(swoole_http_client_coro, post)
 
 static PHP_METHOD(swoole_http_client_coro, download)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *path;
     size_t path_len;
     zval *download_file;
@@ -2029,7 +2029,7 @@ static PHP_METHOD(swoole_http_client_coro, download)
 
 static PHP_METHOD(swoole_http_client_coro, upgrade)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     char *path = NULL;
     size_t path_len = 0;
 
@@ -2042,7 +2042,7 @@ static PHP_METHOD(swoole_http_client_coro, upgrade)
 
 static PHP_METHOD(swoole_http_client_coro, push)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
     zval *zdata;
     zend_long opcode = WEBSOCKET_OPCODE_TEXT;
     zval *zflags = NULL;
@@ -2065,7 +2065,7 @@ static PHP_METHOD(swoole_http_client_coro, push)
 
 static PHP_METHOD(swoole_http_client_coro, recv)
 {
-    http_client *phc = swoole_get_phc(ZEND_THIS);
+    http_client *phc = php_swoole_get_phc(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2086,7 +2086,7 @@ static PHP_METHOD(swoole_http_client_coro, recv)
 
 static PHP_METHOD(swoole_http_client_coro, close)
 {
-    http_client* phc = swoole_get_phc(ZEND_THIS);
+    http_client* phc = php_swoole_get_phc(ZEND_THIS);
 
     RETURN_BOOL(phc->close());
 }
@@ -2113,6 +2113,6 @@ static PHP_METHOD(swoole_http_client_coro, getStatusCode)
 
 static PHP_METHOD(swoole_http_client_coro, getHeaderOut)
 {
-    http_client *phc = swoole_get_phc(ZEND_THIS);
+    http_client *phc = php_swoole_get_phc(ZEND_THIS);
     phc->get_header_out(return_value);
 }

--- a/swoole_http_request.cc
+++ b/swoole_http_request.cc
@@ -220,24 +220,24 @@ typedef struct
     zend_object std;
 } http_request_t;
 
-static sw_inline http_request_t* swoole_http_request_fetch_object(zend_object *obj)
+static sw_inline http_request_t* php_swoole_http_request_fetch_object(zend_object *obj)
 {
     return (http_request_t *) ((char *) obj - swoole_http_request_handlers.offset);
 }
 
 http_context * php_swoole_http_request_get_context(zval *zobject)
 {
-    return swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx;
+    return php_swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx;
 }
 
 void php_swoole_http_request_set_context(zval *zobject, http_context *ctx)
 {
-    swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
+    php_swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
 }
 
-static void swoole_http_request_free_object(zend_object *object)
+static void php_swoole_http_request_free_object(zend_object *object)
 {
-    http_request_t *request = swoole_http_request_fetch_object(object);
+    http_request_t *request = php_swoole_http_request_fetch_object(object);
     http_context *ctx = request->ctx;
     zval zobject, *ztmpfiles;
 
@@ -267,7 +267,7 @@ static void swoole_http_request_free_object(zend_object *object)
     zend_object_std_dtor(&request->std);
 }
 
-static zend_object *swoole_http_request_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_http_request_create_object(zend_class_entry *ce)
 {
     http_request_t *request = (http_request_t *) ecalloc(1, sizeof(http_request_t) + zend_object_properties_size(ce));
     zend_object_std_init(&request->std, ce);
@@ -297,7 +297,7 @@ void php_swoole_http_request_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http_request, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_request, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_request, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_request, swoole_http_request_create_object, swoole_http_request_free_object, http_request_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_request, php_swoole_http_request_create_object, php_swoole_http_request_free_object, http_request_t, std);
 
     zend_declare_property_long(swoole_http_request_ce, ZEND_STRL("fd"), 0, ZEND_ACC_PUBLIC);
 #ifdef SW_USE_HTTP2

--- a/swoole_http_request.cc
+++ b/swoole_http_request.cc
@@ -225,12 +225,12 @@ static sw_inline http_request_t* swoole_http_request_fetch_object(zend_object *o
     return (http_request_t *) ((char *) obj - swoole_http_request_handlers.offset);
 }
 
-http_context * swoole_http_request_get_context(zval *zobject)
+http_context * php_swoole_http_request_get_context(zval *zobject)
 {
     return swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx;
 }
 
-void swoole_http_request_set_context(zval *zobject, http_context *ctx)
+void php_swoole_http_request_set_context(zval *zobject, http_context *ctx)
 {
     swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
 }
@@ -952,7 +952,7 @@ const char* swoole_http_get_content_encoding(http_context *ctx)
 
 static PHP_METHOD(swoole_http_request, rawContent)
 {
-    http_context *ctx = swoole_http_request_get_and_check_context(ZEND_THIS);
+    http_context *ctx = php_swoole_http_request_get_and_check_context(ZEND_THIS);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -976,7 +976,7 @@ static PHP_METHOD(swoole_http_request, rawContent)
 
 static PHP_METHOD(swoole_http_request, getData)
 {
-    http_context *ctx = swoole_http_request_get_and_check_context(ZEND_THIS);
+    http_context *ctx = php_swoole_http_request_get_and_check_context(ZEND_THIS);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;

--- a/swoole_http_request.cc
+++ b/swoole_http_request.cc
@@ -58,13 +58,6 @@ enum http_upload_errno
     HTTP_UPLOAD_ERR_CANT_WRITE,
 };
 
-zend_class_entry *swoole_http_request_ce;
-static zend_object_handlers swoole_http_request_handlers;
-
-static PHP_METHOD(swoole_http_request, getData);
-static PHP_METHOD(swoole_http_request, rawContent);
-static PHP_METHOD(swoole_http_request, __destruct);
-
 static int http_request_on_path(swoole_http_parser *parser, const char *at, size_t length);
 static int http_request_on_query_string(swoole_http_parser *parser, const char *at, size_t length);
 static int http_request_on_body(swoole_http_parser *parser, const char *at, size_t length);
@@ -188,17 +181,6 @@ static sw_inline const char* http_get_method_name(int method)
     }
 }
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_void, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-const zend_function_entry swoole_http_request_methods[] =
-{
-    PHP_ME(swoole_http_request, rawContent, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_http_request, getData, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_http_request, __destruct, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
-
 static const swoole_http_parser_settings http_parser_settings =
 {
     NULL,
@@ -229,13 +211,93 @@ size_t swoole_http_requset_parse(http_context *ctx, const char *data, size_t len
     return swoole_http_parser_execute(&ctx->parser, &http_parser_settings, data, length);
 }
 
+zend_class_entry *swoole_http_request_ce;
+static zend_object_handlers swoole_http_request_handlers;
+
+typedef struct
+{
+    http_context *ctx;
+    zend_object std;
+} http_request_t;
+
+static sw_inline http_request_t* swoole_http_request_fetch_object(zend_object *obj)
+{
+    return (http_request_t *) ((char *) obj - swoole_http_request_handlers.offset);
+}
+
+http_context * swoole_http_request_get_context(zval *zobject)
+{
+    return swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx;
+}
+
+void swoole_http_request_set_context(zval *zobject, http_context *ctx)
+{
+    swoole_http_request_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
+}
+
+static void swoole_http_request_free_object(zend_object *object)
+{
+    http_request_t *request = swoole_http_request_fetch_object(object);
+    http_context *ctx = request->ctx;
+    zval zobject, *ztmpfiles;
+
+    ZVAL_OBJ(&zobject, object);
+    ztmpfiles = sw_zend_read_property(swoole_http_request_ce, &zobject, ZEND_STRL("tmpfiles"), 0);
+    if (ZVAL_IS_ARRAY(ztmpfiles))
+    {
+        zval *z_file_path;
+        SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(ztmpfiles), z_file_path)
+        {
+            if (Z_TYPE_P(z_file_path) != IS_STRING)
+            {
+                continue;
+            }
+            unlink(Z_STRVAL_P(z_file_path));
+            if (SG(rfc1867_uploaded_files))
+            {
+                zend_hash_str_del(SG(rfc1867_uploaded_files), Z_STRVAL_P(z_file_path), Z_STRLEN_P(z_file_path));
+            }
+        }
+        SW_HASHTABLE_FOREACH_END();
+    }
+    if (ctx)
+    {
+        ctx->request.zobject = NULL;
+    }
+    zend_object_std_dtor(&request->std);
+}
+
+static zend_object *swoole_http_request_create_object(zend_class_entry *ce)
+{
+    http_request_t *request = (http_request_t *) ecalloc(1, sizeof(http_request_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&request->std, ce);
+    object_properties_init(&request->std, ce);
+    request->std.handlers = &swoole_http_request_handlers;
+    return &request->std;
+}
+
+static PHP_METHOD(swoole_http_request, getData);
+static PHP_METHOD(swoole_http_request, rawContent);
+static PHP_METHOD(swoole_http_request, __destruct);
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_http_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+const zend_function_entry swoole_http_request_methods[] =
+{
+    PHP_ME(swoole_http_request, rawContent, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_http_request, getData, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_http_request, __destruct, arginfo_swoole_http_void, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
 void php_swoole_http_request_minit(int module_number)
 {
     SW_INIT_CLASS_ENTRY(swoole_http_request, "Swoole\\Http\\Request", "swoole_http_request", NULL, swoole_http_request_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_http_request, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_request, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_request, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http_request);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_request, swoole_http_request_create_object, swoole_http_request_free_object, http_request_t, std);
 
     zend_declare_property_long(swoole_http_request_ce, ZEND_STRL("fd"), 0, ZEND_ACC_PUBLIC);
 #ifdef SW_USE_HTTP2
@@ -890,7 +952,7 @@ const char* swoole_http_get_content_encoding(http_context *ctx)
 
 static PHP_METHOD(swoole_http_request, rawContent)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_request_get_and_check_context(ZEND_THIS);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -914,7 +976,7 @@ static PHP_METHOD(swoole_http_request, rawContent)
 
 static PHP_METHOD(swoole_http_request, getData)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_request_get_and_check_context(ZEND_THIS);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -936,33 +998,4 @@ static PHP_METHOD(swoole_http_request, getData)
     RETURN_EMPTY_STRING();
 }
 
-static PHP_METHOD(swoole_http_request, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    zval *ztmpfiles = sw_zend_read_property(swoole_http_request_ce, ZEND_THIS, ZEND_STRL("tmpfiles"), 0);
-    //upload files
-    if (ztmpfiles && ZVAL_IS_ARRAY(ztmpfiles))
-    {
-        zval *z_file_path;
-        SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(ztmpfiles), z_file_path)
-        {
-            if (Z_TYPE_P(z_file_path) != IS_STRING)
-            {
-                continue;
-            }
-            unlink(Z_STRVAL_P(z_file_path));
-            if (SG(rfc1867_uploaded_files))
-            {
-                zend_hash_str_del(SG(rfc1867_uploaded_files), Z_STRVAL_P(z_file_path), Z_STRLEN_P(z_file_path));
-            }
-        }
-        SW_HASHTABLE_FOREACH_END();
-    }
-    http_context *ctx = (http_context *) swoole_get_object(ZEND_THIS);
-    if (ctx)
-    {
-        ctx->request.zobject = NULL;
-    }
-    swoole_set_object(ZEND_THIS, NULL);
-}
+static PHP_METHOD(swoole_http_request, __destruct) { }

--- a/swoole_http_response.cc
+++ b/swoole_http_response.cc
@@ -105,12 +105,12 @@ static sw_inline http_response_t* swoole_http_response_fetch_object(zend_object 
     return (http_response_t *) ((char *) obj - swoole_http_response_handlers.offset);
 }
 
-http_context * swoole_http_response_get_context(zval *zobject)
+http_context * php_swoole_http_response_get_context(zval *zobject)
 {
     return swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx;
 }
 
-void swoole_http_response_set_context(zval *zobject, http_context *ctx)
+void php_swoole_http_response_set_context(zval *zobject, http_context *ctx)
 {
     swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
 }
@@ -306,7 +306,7 @@ static PHP_METHOD(swoole_http_response, write)
         RETURN_FALSE;
     }
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -653,7 +653,7 @@ int swoole_http_response_compress(swString *body, int method, int level)
 
 static PHP_METHOD(swoole_http_response, initHeader)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -669,7 +669,7 @@ static PHP_METHOD(swoole_http_response, initHeader)
 
 static PHP_METHOD(swoole_http_response, end)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 1);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 1);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -889,7 +889,7 @@ static PHP_METHOD(swoole_http_response, sendfile)
         RETURN_FALSE;
     }
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -980,7 +980,7 @@ static void swoole_http_response_cookie(INTERNAL_FUNCTION_PARAMETERS, const bool
         Z_PARAM_STRING(samesite, samesite_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1088,7 +1088,7 @@ static PHP_METHOD(swoole_http_response, status)
         Z_PARAM_STRING(reason, reason_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1112,7 +1112,7 @@ static PHP_METHOD(swoole_http_response, header)
         Z_PARAM_BOOL(ucwords)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1133,7 +1133,7 @@ static PHP_METHOD(swoole_http_response, trailer)
         Z_PARAM_STRING_EX(v, vlen, 1, 0)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!ctx || !ctx->stream)
     {
         RETURN_FALSE;
@@ -1164,7 +1164,7 @@ static PHP_METHOD(swoole_http_response, trailer)
 
 static PHP_METHOD(swoole_http_response, ping)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!ctx || !ctx->stream)
     {
         RETURN_FALSE;
@@ -1175,7 +1175,7 @@ static PHP_METHOD(swoole_http_response, ping)
 
 static PHP_METHOD(swoole_http_response, upgrade)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx || !ctx->co_socket))
     {
         RETURN_FALSE;
@@ -1185,7 +1185,7 @@ static PHP_METHOD(swoole_http_response, upgrade)
 
 static PHP_METHOD(swoole_http_response, push)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1227,7 +1227,7 @@ static PHP_METHOD(swoole_http_response, push)
 
 static PHP_METHOD(swoole_http_response, close)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1238,7 +1238,7 @@ static PHP_METHOD(swoole_http_response, close)
 
 static PHP_METHOD(swoole_http_response, recv)
 {
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1280,7 +1280,7 @@ static PHP_METHOD(swoole_http_response, recv)
 
 static PHP_METHOD(swoole_http_response, detach)
 {
-    http_context *context = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *context = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!context)
     {
         RETURN_FALSE;
@@ -1313,7 +1313,7 @@ static PHP_METHOD(swoole_http_response, create)
     swoole_http_server_init_context(SwooleG.serv, ctx);
 
     object_init_ex(return_value, swoole_http_response_ce);
-    swoole_http_response_set_context(return_value, ctx);
+    php_swoole_http_response_set_context(return_value, ctx);
     ctx->response.zobject = return_value;
     sw_copy_to_stack(ctx->response.zobject, ctx->response._zobject);
 
@@ -1331,7 +1331,7 @@ static PHP_METHOD(swoole_http_response, redirect)
         Z_PARAM_ZVAL_EX(zhttp_code, 1, 0)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
+    http_context *ctx = php_swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;

--- a/swoole_http_response.cc
+++ b/swoole_http_response.cc
@@ -100,24 +100,24 @@ typedef struct
     zend_object std;
 } http_response_t;
 
-static sw_inline http_response_t* swoole_http_response_fetch_object(zend_object *obj)
+static sw_inline http_response_t* php_swoole_http_response_fetch_object(zend_object *obj)
 {
     return (http_response_t *) ((char *) obj - swoole_http_response_handlers.offset);
 }
 
 http_context * php_swoole_http_response_get_context(zval *zobject)
 {
-    return swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx;
+    return php_swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx;
 }
 
 void php_swoole_http_response_set_context(zval *zobject, http_context *ctx)
 {
-    swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
+    php_swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
 }
 
-static void swoole_http_response_free_object(zend_object *object)
+static void php_swoole_http_response_free_object(zend_object *object)
 {
-    http_response_t *response = swoole_http_response_fetch_object(object);
+    http_response_t *response = php_swoole_http_response_fetch_object(object);
     http_context *ctx = response->ctx;
     zval ztmp; /* bool, not required to release it */
 
@@ -156,7 +156,7 @@ static void swoole_http_response_free_object(zend_object *object)
     zend_object_std_dtor(&response->std);
 }
 
-static zend_object *swoole_http_response_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_http_response_create_object(zend_class_entry *ce)
 {
     http_response_t *response = (http_response_t *) ecalloc(1, sizeof(http_response_t) + zend_object_properties_size(ce));
     zend_object_std_init(&response->std, ce);
@@ -287,7 +287,7 @@ void php_swoole_http_response_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http_response, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_response, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_response, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_response, swoole_http_response_create_object, swoole_http_response_free_object, http_response_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_response, php_swoole_http_response_create_object, php_swoole_http_response_free_object, http_response_t, std);
 
     zend_declare_property_long(swoole_http_response_ce, ZEND_STRL("fd"), 0,  ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_http_response_ce, ZEND_STRL("socket"), ZEND_ACC_PUBLIC);

--- a/swoole_http_response.cc
+++ b/swoole_http_response.cc
@@ -94,6 +94,77 @@ static inline swString* http_get_write_buffer(http_context *ctx)
     return swoole_http_buffer;
 }
 
+typedef struct
+{
+    http_context *ctx;
+    zend_object std;
+} http_response_t;
+
+static sw_inline http_response_t* swoole_http_response_fetch_object(zend_object *obj)
+{
+    return (http_response_t *) ((char *) obj - swoole_http_response_handlers.offset);
+}
+
+http_context * swoole_http_response_get_context(zval *zobject)
+{
+    return swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx;
+}
+
+void swoole_http_response_set_context(zval *zobject, http_context *ctx)
+{
+    swoole_http_response_fetch_object(Z_OBJ_P(zobject))->ctx = ctx;
+}
+
+static void swoole_http_response_free_object(zend_object *object)
+{
+    http_response_t *response = swoole_http_response_fetch_object(object);
+    http_context *ctx = response->ctx;
+    zval ztmp; /* bool, not required to release it */
+
+    if (ctx)
+    {
+        if (!ctx->end)
+        {
+            if (ctx->response.status == 0)
+            {
+                ctx->response.status = 500;
+            }
+            if (ctx->co_socket)
+            {
+                swoole_http_response_end(ctx, nullptr, &ztmp);
+            }
+            else
+            {
+                swServer *serv = (swServer *) ctx->private_data;
+                swConnection *conn = swWorker_get_connection(serv, ctx->fd);
+                if (!conn || conn->closed || conn->peer_closed || ctx->detached)
+                {
+                    swoole_http_context_free(ctx);
+                    ctx = nullptr;
+                }
+                else
+                {
+                    swoole_http_response_end(ctx, nullptr, &ztmp);
+                }
+            }
+        }
+        if (ctx)
+        {
+            swoole_http_context_free(ctx);
+        }
+    }
+    zend_object_std_dtor(&response->std);
+}
+
+static zend_object *swoole_http_response_create_object(zend_class_entry *ce)
+{
+    http_response_t *response = (http_response_t *) ecalloc(1, sizeof(http_response_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&response->std, ce);
+    object_properties_init(&response->std, ce);
+    response->std.handlers = &swoole_http_response_handlers;
+    return &response->std;
+}
+
 static PHP_METHOD(swoole_http_response, write);
 static PHP_METHOD(swoole_http_response, end);
 static PHP_METHOD(swoole_http_response, sendfile);
@@ -216,7 +287,7 @@ void php_swoole_http_response_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http_response, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_response, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_response, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http_response);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_response, swoole_http_response_create_object, swoole_http_response_free_object, http_response_t, std);
 
     zend_declare_property_long(swoole_http_response_ce, ZEND_STRL("fd"), 0,  ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_http_response_ce, ZEND_STRL("socket"), ZEND_ACC_PUBLIC);
@@ -235,7 +306,7 @@ static PHP_METHOD(swoole_http_response, write)
         RETURN_FALSE;
     }
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -582,7 +653,7 @@ int swoole_http_response_compress(swString *body, int method, int level)
 
 static PHP_METHOD(swoole_http_response, initHeader)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -598,13 +669,13 @@ static PHP_METHOD(swoole_http_response, initHeader)
 
 static PHP_METHOD(swoole_http_response, end)
 {
-    zval *zdata = NULL;
-
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 1);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 1);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
     }
+
+    zval *zdata = NULL;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -818,7 +889,7 @@ static PHP_METHOD(swoole_http_response, sendfile)
         RETURN_FALSE;
     }
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -909,7 +980,7 @@ static void swoole_http_response_cookie(INTERNAL_FUNCTION_PARAMETERS, const bool
         Z_PARAM_STRING(samesite, samesite_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1017,7 +1088,7 @@ static PHP_METHOD(swoole_http_response, status)
         Z_PARAM_STRING(reason, reason_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1041,7 +1112,7 @@ static PHP_METHOD(swoole_http_response, header)
         Z_PARAM_BOOL(ucwords)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1062,7 +1133,7 @@ static PHP_METHOD(swoole_http_response, trailer)
         Z_PARAM_STRING_EX(v, vlen, 1, 0)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!ctx || !ctx->stream)
     {
         RETURN_FALSE;
@@ -1093,7 +1164,7 @@ static PHP_METHOD(swoole_http_response, trailer)
 
 static PHP_METHOD(swoole_http_response, ping)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!ctx || !ctx->stream)
     {
         RETURN_FALSE;
@@ -1104,7 +1175,7 @@ static PHP_METHOD(swoole_http_response, ping)
 
 static PHP_METHOD(swoole_http_response, upgrade)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx || !ctx->co_socket))
     {
         RETURN_FALSE;
@@ -1114,7 +1185,7 @@ static PHP_METHOD(swoole_http_response, upgrade)
 
 static PHP_METHOD(swoole_http_response, push)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1156,7 +1227,7 @@ static PHP_METHOD(swoole_http_response, push)
 
 static PHP_METHOD(swoole_http_response, close)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1167,7 +1238,7 @@ static PHP_METHOD(swoole_http_response, close)
 
 static PHP_METHOD(swoole_http_response, recv)
 {
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx) || !ctx->co_socket || !ctx->upgrade)
     {
         SwooleG.error = SW_ERROR_CLIENT_NO_CONNECTION;
@@ -1209,7 +1280,7 @@ static PHP_METHOD(swoole_http_response, recv)
 
 static PHP_METHOD(swoole_http_response, detach)
 {
-    http_context *context = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *context = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (!context)
     {
         RETURN_FALSE;
@@ -1242,7 +1313,7 @@ static PHP_METHOD(swoole_http_response, create)
     swoole_http_server_init_context(SwooleG.serv, ctx);
 
     object_init_ex(return_value, swoole_http_response_ce);
-    swoole_set_object(return_value, ctx);
+    swoole_http_response_set_context(return_value, ctx);
     ctx->response.zobject = return_value;
     sw_copy_to_stack(ctx->response.zobject, ctx->response._zobject);
 
@@ -1260,7 +1331,7 @@ static PHP_METHOD(swoole_http_response, redirect)
         Z_PARAM_ZVAL_EX(zhttp_code, 1, 0)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    http_context *ctx = swoole_http_context_get(ZEND_THIS, 0);
+    http_context *ctx = swoole_http_response_get_and_check_context(ZEND_THIS, 0);
     if (UNEXPECTED(!ctx))
     {
         RETURN_FALSE;
@@ -1291,41 +1362,4 @@ static PHP_METHOD(swoole_http_response, redirect)
     }
 }
 
-static PHP_METHOD(swoole_http_response, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    http_context *ctx = (http_context *) swoole_get_object(ZEND_THIS);
-    if (ctx)
-    {
-        if (!ctx->end)
-        {
-            if (ctx->response.status == 0)
-            {
-                ctx->response.status = 500;
-            }
-            if (ctx->co_socket)
-            {
-                swoole_http_response_end(ctx, nullptr, return_value);
-            }
-            else
-            {
-                swServer *serv = (swServer *) ctx->private_data;
-                swConnection *conn = swWorker_get_connection(serv, ctx->fd);
-                if (!conn || conn->closed || conn->peer_closed || ctx->detached)
-                {
-                    swoole_http_context_free(ctx);
-                    ctx = nullptr;
-                }
-                else
-                {
-                    swoole_http_response_end(ctx, nullptr, return_value);
-                }
-            }
-        }
-        if (ctx)
-        {
-            swoole_http_context_free(ctx);
-        }
-    }
-}
+static PHP_METHOD(swoole_http_response, __destruct) { }

--- a/swoole_http_server.cc
+++ b/swoole_http_server.cc
@@ -178,7 +178,6 @@ void php_swoole_http_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_http_server, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_http_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_server, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http_server);
 
     zend_declare_property_null(swoole_http_server_ce, ZEND_STRL("onRequest"), ZEND_ACC_PRIVATE);
 }

--- a/swoole_http_server.cc
+++ b/swoole_http_server.cc
@@ -194,12 +194,12 @@ http_context* swoole_http_context_new(int fd)
     zval *zrequest_object = &ctx->request._zobject;
     ctx->request.zobject = zrequest_object;
     object_init_ex(zrequest_object, swoole_http_request_ce);
-    swoole_http_request_set_context(zrequest_object, ctx);
+    php_swoole_http_request_set_context(zrequest_object, ctx);
 
     zval *zresponse_object = &ctx->response._zobject;
     ctx->response.zobject = zresponse_object;
     object_init_ex(zresponse_object, swoole_http_response_ce);
-    swoole_http_response_set_context(zresponse_object, ctx);
+    php_swoole_http_response_set_context(zresponse_object, ctx);
 
     zend_update_property_long(swoole_http_request_ce, zrequest_object, ZEND_STRL("fd"), fd);
     zend_update_property_long(swoole_http_response_ce, zresponse_object, ZEND_STRL("fd"), fd);
@@ -249,9 +249,9 @@ void swoole_http_context_free(http_context *ctx)
 {
     if (ctx->request.zobject)
     {
-        swoole_http_request_set_context(ctx->request.zobject, NULL);
+        php_swoole_http_request_set_context(ctx->request.zobject, NULL);
     }
-    swoole_http_response_set_context(ctx->response.zobject, NULL);
+    php_swoole_http_response_set_context(ctx->response.zobject, NULL);
     http_request *req = &ctx->request;
     http_response *res = &ctx->response;
     if (req->path)
@@ -299,9 +299,9 @@ void php_swoole_http_server_init_global_variant()
     }
 }
 
-http_context* swoole_http_request_get_and_check_context(zval *zobject)
+http_context* php_swoole_http_request_get_and_check_context(zval *zobject)
 {
-    http_context *ctx = swoole_http_request_get_context(zobject);
+    http_context *ctx = php_swoole_http_request_get_context(zobject);
     if (!ctx)
     {
         php_swoole_fatal_error(E_WARNING, "http request is unavailable (maybe it has been ended)");
@@ -309,9 +309,9 @@ http_context* swoole_http_request_get_and_check_context(zval *zobject)
     return ctx;
 }
 
-http_context* swoole_http_response_get_and_check_context(zval *zobject, bool check_end)
+http_context* php_swoole_http_response_get_and_check_context(zval *zobject, bool check_end)
 {
-    http_context *ctx = swoole_http_response_get_context(zobject);
+    http_context *ctx = php_swoole_http_response_get_context(zobject);
     if (!ctx || (check_end && ctx->end))
     {
         php_swoole_fatal_error(E_WARNING, "http response is unavailable (maybe it has been ended or detached)");

--- a/swoole_http_server_coro.cc
+++ b/swoole_http_server_coro.cc
@@ -207,7 +207,7 @@ static const zend_function_entry swoole_http_server_coro_methods[] =
     PHP_FE_END
 };
 
-static zend_object *swoole_http_server_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_http_server_coro_create_object(zend_class_entry *ce)
 {
     http_server_coro_t *hsc = (http_server_coro_t *) ecalloc(1, sizeof(http_server_coro_t) + zend_object_properties_size(ce));
     zend_object_std_init(&hsc->std, ce);
@@ -216,14 +216,14 @@ static zend_object *swoole_http_server_coro_create_object(zend_class_entry *ce)
     return &hsc->std;
 }
 
-static sw_inline http_server_coro_t* swoole_http_server_coro_fetch_object(zend_object *obj)
+static sw_inline http_server_coro_t* php_swoole_http_server_coro_fetch_object(zend_object *obj)
 {
     return (http_server_coro_t *) ((char *) obj - swoole_http_server_coro_handlers.offset);
 }
 
 static sw_inline http_server* http_server_get_object(zend_object *obj)
 {
-    return swoole_http_server_coro_fetch_object(obj)->server;
+    return php_swoole_http_server_coro_fetch_object(obj)->server;
 }
 
 static inline void http_server_set_error(zval *zobject, Socket *sock)
@@ -250,9 +250,9 @@ static bool http_context_disconnect(http_context* ctx)
     return sock->close();
 }
 
-static void swoole_http_server_coro_free_object(zend_object *object)
+static void php_swoole_http_server_coro_free_object(zend_object *object)
 {
-    http_server_coro_t *hsc = swoole_http_server_coro_fetch_object(object);
+    http_server_coro_t *hsc = php_swoole_http_server_coro_fetch_object(object);
     if (hsc->server)
     {
         http_server *hs = hsc->server;
@@ -278,7 +278,7 @@ void php_swoole_http_server_coro_minit(int module_number)
     SW_SET_CLASS_CLONEABLE(swoole_http_server_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_server_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http_server_coro);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_server_coro, swoole_http_server_coro_create_object, swoole_http_server_coro_free_object, http_server_coro_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_server_coro, php_swoole_http_server_coro_create_object, php_swoole_http_server_coro_free_object, http_server_coro_t, std);
     swoole_http_server_coro_ce->ce_flags |= ZEND_ACC_FINAL;
 
     zend_declare_property_long(swoole_http_server_coro_ce, ZEND_STRL("fd"), -1, ZEND_ACC_PUBLIC);
@@ -316,7 +316,7 @@ static PHP_METHOD(swoole_http_server_coro, __construct)
         RETURN_FALSE;
     }
 
-    http_server_coro_t *hsc = swoole_http_server_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
+    http_server_coro_t *hsc = php_swoole_http_server_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
     string host_str(host, l_host);
     hsc->server = new http_server(Socket::convert_to_type(host_str));
     Socket *sock = hsc->server->socket;

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -30,12 +30,12 @@ static sw_inline lock_t* swoole_lock_fetch_object(zend_object *obj)
     return (lock_t *) ((char *) obj - swoole_lock_handlers.offset);
 }
 
-swLock * swoole_lock_get_ptr(zval *zobject)
+static swLock * swoole_lock_get_ptr(zval *zobject)
 {
     return swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-swLock * swoole_lock_get_and_check_ptr(zval *zobject)
+static swLock * swoole_lock_get_and_check_ptr(zval *zobject)
 {
     swLock *lock = swoole_lock_get_ptr(zobject);
     if (!lock)

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -30,14 +30,14 @@ static sw_inline lock_t* swoole_lock_fetch_object(zend_object *obj)
     return (lock_t *) ((char *) obj - swoole_lock_handlers.offset);
 }
 
-static swLock * swoole_lock_get_ptr(zval *zobject)
+static swLock * php_swoole_lock_get_ptr(zval *zobject)
 {
     return swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-static swLock * swoole_lock_get_and_check_ptr(zval *zobject)
+static swLock * php_swoole_lock_get_and_check_ptr(zval *zobject)
 {
-    swLock *lock = swoole_lock_get_ptr(zobject);
+    swLock *lock = php_swoole_lock_get_ptr(zobject);
     if (!lock)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Lock constructor first");
@@ -45,7 +45,7 @@ static swLock * swoole_lock_get_and_check_ptr(zval *zobject)
     return lock;
 }
 
-void swoole_lock_set_ptr(zval *zobject, swLock *ptr)
+void php_swoole_lock_set_ptr(zval *zobject, swLock *ptr)
 {
     swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -132,7 +132,7 @@ void php_swoole_lock_minit(int module_number)
 
 static PHP_METHOD(swoole_lock, __construct)
 {
-    swLock *lock = swoole_lock_get_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_ptr(ZEND_THIS);
 
     if (lock != NULL)
     {
@@ -198,7 +198,7 @@ static PHP_METHOD(swoole_lock, __construct)
         RETURN_FALSE;
     }
 
-    swoole_lock_set_ptr(ZEND_THIS, lock);
+    php_swoole_lock_set_ptr(ZEND_THIS, lock);
     RETURN_TRUE;
 }
 
@@ -206,7 +206,7 @@ static PHP_METHOD(swoole_lock, __destruct) { }
 
 static PHP_METHOD(swoole_lock, lock)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     SW_LOCK_CHECK_RETURN(lock->lock(lock));
 }
 
@@ -218,7 +218,7 @@ static PHP_METHOD(swoole_lock, lockwait)
     {
         RETURN_FALSE;
     }
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->type != SW_MUTEX)
     {
         zend_throw_exception(swoole_exception_ce, "only mutex supports lockwait", -2);
@@ -229,13 +229,13 @@ static PHP_METHOD(swoole_lock, lockwait)
 
 static PHP_METHOD(swoole_lock, unlock)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     SW_LOCK_CHECK_RETURN(lock->unlock(lock));
 }
 
 static PHP_METHOD(swoole_lock, trylock)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->trylock == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use trylock", lock->type);
@@ -246,7 +246,7 @@ static PHP_METHOD(swoole_lock, trylock)
 
 static PHP_METHOD(swoole_lock, trylock_read)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->trylock_rd == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use trylock_read", lock->type);
@@ -257,7 +257,7 @@ static PHP_METHOD(swoole_lock, trylock_read)
 
 static PHP_METHOD(swoole_lock, lock_read)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->lock_rd == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use lock_read", lock->type);
@@ -268,6 +268,6 @@ static PHP_METHOD(swoole_lock, lock_read)
 
 static PHP_METHOD(swoole_lock, destroy)
 {
-    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
+    swLock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
     lock->free(lock);
 }

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -25,14 +25,14 @@ typedef struct
     zend_object std;
 } lock_t;
 
-static sw_inline lock_t* swoole_lock_fetch_object(zend_object *obj)
+static sw_inline lock_t* php_swoole_lock_fetch_object(zend_object *obj)
 {
     return (lock_t *) ((char *) obj - swoole_lock_handlers.offset);
 }
 
 static swLock * php_swoole_lock_get_ptr(zval *zobject)
 {
-    return swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 static swLock * php_swoole_lock_get_and_check_ptr(zval *zobject)
@@ -47,15 +47,15 @@ static swLock * php_swoole_lock_get_and_check_ptr(zval *zobject)
 
 void php_swoole_lock_set_ptr(zval *zobject, swLock *ptr)
 {
-    swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_lock_free_object(zend_object *object)
+static void php_swoole_lock_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_lock_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_lock_create_object(zend_class_entry *ce)
 {
     lock_t *lock = (lock_t *) ecalloc(1, sizeof(lock_t) + zend_object_properties_size(ce));
     zend_object_std_init(&lock->std, ce);
@@ -106,7 +106,7 @@ void php_swoole_lock_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_lock, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_lock, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_lock, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_lock, swoole_lock_create_object, swoole_lock_free_object, lock_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_lock, php_swoole_lock_create_object, php_swoole_lock_free_object, lock_t, std);
 
     zend_declare_class_constant_long(swoole_lock_ce, ZEND_STRL("FILELOCK"), SW_FILELOCK);
     zend_declare_class_constant_long(swoole_lock_ce, ZEND_STRL("MUTEX"), SW_MUTEX);

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -136,7 +136,7 @@ static PHP_METHOD(swoole_lock, __construct)
 
     if (lock != NULL)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     lock = (swLock *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swLock));

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -16,6 +16,54 @@
 
 #include "php_swoole.h"
 
+static zend_class_entry *swoole_lock_ce;
+static zend_object_handlers swoole_lock_handlers;
+
+typedef struct
+{
+    swLock *ptr;
+    zend_object std;
+} lock_t;
+
+static sw_inline lock_t* swoole_lock_fetch_object(zend_object *obj)
+{
+    return (lock_t *) ((char *) obj - swoole_lock_handlers.offset);
+}
+
+swLock * swoole_lock_get_ptr(zval *zobject)
+{
+    return swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+swLock * swoole_lock_get_and_check_ptr(zval *zobject)
+{
+    swLock *lock = swoole_lock_get_ptr(zobject);
+    if (!lock)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Lock constructor first");
+    }
+    return lock;
+}
+
+void swoole_lock_set_ptr(zval *zobject, swLock *ptr)
+{
+    swoole_lock_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_lock_free_object(zend_object *object)
+{
+    zend_object_std_dtor(&swoole_lock_fetch_object(object)->std);
+}
+
+static zend_object *swoole_lock_create_object(zend_class_entry *ce)
+{
+    lock_t *lock = (lock_t *) ecalloc(1, sizeof(lock_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&lock->std, ce);
+    object_properties_init(&lock->std, ce);
+    lock->std.handlers = &swoole_lock_handlers;
+    return &lock->std;
+}
+
 static PHP_METHOD(swoole_lock, __construct);
 static PHP_METHOD(swoole_lock, __destruct);
 static PHP_METHOD(swoole_lock, lock);
@@ -25,9 +73,6 @@ static PHP_METHOD(swoole_lock, lock_read);
 static PHP_METHOD(swoole_lock, trylock_read);
 static PHP_METHOD(swoole_lock, unlock);
 static PHP_METHOD(swoole_lock, destroy);
-
-static zend_class_entry *swoole_lock_ce;
-static zend_object_handlers swoole_lock_handlers;
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -61,7 +106,7 @@ void php_swoole_lock_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_lock, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_lock, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_lock, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_lock);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_lock, swoole_lock_create_object, swoole_lock_free_object, lock_t, std);
 
     zend_declare_class_constant_long(swoole_lock_ce, ZEND_STRL("FILELOCK"), SW_FILELOCK);
     zend_declare_class_constant_long(swoole_lock_ce, ZEND_STRL("MUTEX"), SW_MUTEX);
@@ -87,20 +132,27 @@ void php_swoole_lock_minit(int module_number)
 
 static PHP_METHOD(swoole_lock, __construct)
 {
-    long type = SW_MUTEX;
+    swLock *lock = swoole_lock_get_ptr(ZEND_THIS);
+
+    if (lock != NULL)
+    {
+        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+    }
+
+    lock = (swLock *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swLock));
+    if (lock == NULL)
+    {
+        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
+        RETURN_FALSE;
+    }
+
+    zend_long type = SW_MUTEX;
     char *filelock;
     size_t filelock_len = 0;
     int ret;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ls", &type, &filelock, &filelock_len) == FAILURE)
     {
-        RETURN_FALSE;
-    }
-
-    swLock *lock = (swLock *) SwooleG.memory_pool->alloc(SwooleG.memory_pool, sizeof(swLock));
-    if (lock == NULL)
-    {
-        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
 
@@ -145,24 +197,16 @@ static PHP_METHOD(swoole_lock, __construct)
         zend_throw_exception(swoole_exception_ce, "failed to create lock", errno);
         RETURN_FALSE;
     }
-    swoole_set_object(ZEND_THIS, lock);
+
+    swoole_lock_set_ptr(ZEND_THIS, lock);
     RETURN_TRUE;
 }
 
-static PHP_METHOD(swoole_lock, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
-    if (lock)
-    {
-        swoole_set_object(ZEND_THIS, NULL);
-    }
-}
+static PHP_METHOD(swoole_lock, __destruct) { }
 
 static PHP_METHOD(swoole_lock, lock)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     SW_LOCK_CHECK_RETURN(lock->lock(lock));
 }
 
@@ -174,7 +218,7 @@ static PHP_METHOD(swoole_lock, lockwait)
     {
         RETURN_FALSE;
     }
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->type != SW_MUTEX)
     {
         zend_throw_exception(swoole_exception_ce, "only mutex supports lockwait", -2);
@@ -185,13 +229,13 @@ static PHP_METHOD(swoole_lock, lockwait)
 
 static PHP_METHOD(swoole_lock, unlock)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     SW_LOCK_CHECK_RETURN(lock->unlock(lock));
 }
 
 static PHP_METHOD(swoole_lock, trylock)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->trylock == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use trylock", lock->type);
@@ -202,7 +246,7 @@ static PHP_METHOD(swoole_lock, trylock)
 
 static PHP_METHOD(swoole_lock, trylock_read)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->trylock_rd == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use trylock_read", lock->type);
@@ -213,7 +257,7 @@ static PHP_METHOD(swoole_lock, trylock_read)
 
 static PHP_METHOD(swoole_lock, lock_read)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     if (lock->lock_rd == NULL)
     {
         php_swoole_error(E_WARNING, "lock[type=%d] can't use lock_read", lock->type);
@@ -224,6 +268,6 @@ static PHP_METHOD(swoole_lock, lock_read)
 
 static PHP_METHOD(swoole_lock, destroy)
 {
-    swLock *lock = (swLock *) swoole_get_object(ZEND_THIS);
+    swLock *lock = swoole_lock_get_and_check_ptr(ZEND_THIS);
     lock->free(lock);
 }

--- a/swoole_lock.cc
+++ b/swoole_lock.cc
@@ -52,7 +52,7 @@ void swoole_lock_set_ptr(zval *zobject, swLock *ptr)
 
 static void swoole_lock_free_object(zend_object *object)
 {
-    zend_object_std_dtor(&swoole_lock_fetch_object(object)->std);
+    zend_object_std_dtor(object);
 }
 
 static zend_object *swoole_lock_create_object(zend_class_entry *ce)

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -1810,7 +1810,7 @@ static sw_inline mysql_coro_t* swoole_mysql_coro_fetch_object(zend_object *obj)
     return (mysql_coro_t *) ((char *) obj - swoole_mysql_coro_handlers.offset);
 }
 
-static sw_inline mysql_client* swoole_get_mysql_client(zval *zobject)
+static sw_inline mysql_client* php_swoole_get_mysql_client(zval *zobject)
 {
     return swoole_mysql_coro_fetch_object(Z_OBJ_P(zobject))->client;
 }
@@ -1837,7 +1837,7 @@ static sw_inline mysql_coro_statement_t* swoole_mysql_coro_statement_fetch_objec
     return (mysql_coro_statement_t *) ((char *) obj - swoole_mysql_coro_statement_handlers.offset);
 }
 
-static sw_inline mysql_statement* swoole_get_mysql_statement(zval *zobject)
+static sw_inline mysql_statement* php_swoole_get_mysql_statement(zval *zobject)
 {
     return swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject))->statement;
 }
@@ -2004,7 +2004,7 @@ static PHP_METHOD(swoole_mysql_coro, __destruct) { }
 
 static PHP_METHOD(swoole_mysql_coro, connect)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     zval *zserver_info = nullptr;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2119,13 +2119,13 @@ static PHP_METHOD(swoole_mysql_coro, connect)
 
 static PHP_METHOD(swoole_mysql_coro, getDefer)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     RETURN_BOOL(mc->get_defer());
 }
 
 static PHP_METHOD(swoole_mysql_coro, setDefer)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     zend_bool defer = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2143,7 +2143,7 @@ static PHP_METHOD(swoole_mysql_coro, setDefer)
 
 static PHP_METHOD(swoole_mysql_coro, query)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     char *sql;
     size_t sql_length;
     double timeout = 0;
@@ -2162,7 +2162,7 @@ static PHP_METHOD(swoole_mysql_coro, query)
 
 static PHP_METHOD(swoole_mysql_coro, fetch)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2181,7 +2181,7 @@ static PHP_METHOD(swoole_mysql_coro, fetch)
 
 static PHP_METHOD(swoole_mysql_coro, fetchAll)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2200,7 +2200,7 @@ static PHP_METHOD(swoole_mysql_coro, fetchAll)
 
 static PHP_METHOD(swoole_mysql_coro, nextResult)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2224,7 +2224,7 @@ static PHP_METHOD(swoole_mysql_coro, nextResult)
 
 static PHP_METHOD(swoole_mysql_coro, prepare)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     char *statement;
     size_t statement_length;
     double timeout = 0;
@@ -2260,7 +2260,7 @@ static PHP_METHOD(swoole_mysql_coro, prepare)
 
 static PHP_METHOD(swoole_mysql_coro, recv)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2312,7 +2312,7 @@ static PHP_METHOD(swoole_mysql_coro, recv)
 
 static void swoole_mysql_coro_query_transcation(INTERNAL_FUNCTION_PARAMETERS, const char* command, size_t command_length)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2352,7 +2352,7 @@ static PHP_METHOD(swoole_mysql_coro, rollback)
 #ifdef SW_USE_MYSQLND
 static PHP_METHOD(swoole_mysql_coro, escape)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     char *str;
     size_t str_length;
     zend_long flags = 0;
@@ -2389,7 +2389,7 @@ static PHP_METHOD(swoole_mysql_coro, escape)
 
 static PHP_METHOD(swoole_mysql_coro, close)
 {
-    mysql_client *mc = swoole_get_mysql_client(ZEND_THIS);
+    mysql_client *mc = php_swoole_get_mysql_client(ZEND_THIS);
     mc->close();
     zend_update_property_bool(swoole_mysql_coro_ce, ZEND_THIS, ZEND_STRL("connected"), 0);
     RETURN_TRUE;
@@ -2397,7 +2397,7 @@ static PHP_METHOD(swoole_mysql_coro, close)
 
 static PHP_METHOD(swoole_mysql_coro_statement, execute)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     zval *params = nullptr;
     double timeout = 0;
 
@@ -2415,7 +2415,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, execute)
 
 static PHP_METHOD(swoole_mysql_coro_statement, fetch)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2434,7 +2434,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetch)
 
 static PHP_METHOD(swoole_mysql_coro_statement, fetchAll)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2453,7 +2453,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetchAll)
 
 static PHP_METHOD(swoole_mysql_coro_statement, nextResult)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     double timeout = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -2478,7 +2478,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, nextResult)
 
 static PHP_METHOD(swoole_mysql_coro_statement, recv)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     double timeout = 0;
     enum sw_mysql_state state;
 
@@ -2518,7 +2518,7 @@ static PHP_METHOD(swoole_mysql_coro_statement, recv)
 
 static PHP_METHOD(swoole_mysql_coro_statement, close)
 {
-    mysql_statement *ms = swoole_get_mysql_statement(ZEND_THIS);
+    mysql_statement *ms = php_swoole_get_mysql_statement(ZEND_THIS);
     ms->close();
     RETURN_TRUE;
 }

--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -1805,24 +1805,24 @@ void mysql_statement::next_result(zval *return_value)
     }
 }
 
-static sw_inline mysql_coro_t* swoole_mysql_coro_fetch_object(zend_object *obj)
+static sw_inline mysql_coro_t* php_swoole_mysql_coro_fetch_object(zend_object *obj)
 {
     return (mysql_coro_t *) ((char *) obj - swoole_mysql_coro_handlers.offset);
 }
 
 static sw_inline mysql_client* php_swoole_get_mysql_client(zval *zobject)
 {
-    return swoole_mysql_coro_fetch_object(Z_OBJ_P(zobject))->client;
+    return php_swoole_mysql_coro_fetch_object(Z_OBJ_P(zobject))->client;
 }
 
-static void swoole_mysql_coro_free_object(zend_object *object)
+static void php_swoole_mysql_coro_free_object(zend_object *object)
 {
-    mysql_coro_t *zmc = swoole_mysql_coro_fetch_object(object);
+    mysql_coro_t *zmc = php_swoole_mysql_coro_fetch_object(object);
     delete zmc->client;
     zend_object_std_dtor(&zmc->std);
 }
 
-static zend_object *swoole_mysql_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_mysql_coro_create_object(zend_class_entry *ce)
 {
     mysql_coro_t *zmc = (mysql_coro_t *) ecalloc(1, sizeof(mysql_coro_t) + zend_object_properties_size(ce));
     zend_object_std_init(&zmc->std, ce);
@@ -1832,25 +1832,25 @@ static zend_object *swoole_mysql_coro_create_object(zend_class_entry *ce)
     return &zmc->std;
 }
 
-static sw_inline mysql_coro_statement_t* swoole_mysql_coro_statement_fetch_object(zend_object *obj)
+static sw_inline mysql_coro_statement_t* php_swoole_mysql_coro_statement_fetch_object(zend_object *obj)
 {
     return (mysql_coro_statement_t *) ((char *) obj - swoole_mysql_coro_statement_handlers.offset);
 }
 
 static sw_inline mysql_statement* php_swoole_get_mysql_statement(zval *zobject)
 {
-    return swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject))->statement;
+    return php_swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject))->statement;
 }
 
-static void swoole_mysql_coro_statement_free_object(zend_object *object)
+static void php_swoole_mysql_coro_statement_free_object(zend_object *object)
 {
-    mysql_coro_statement_t *zms = swoole_mysql_coro_statement_fetch_object(object);
+    mysql_coro_statement_t *zms = php_swoole_mysql_coro_statement_fetch_object(object);
     delete zms->statement;
     OBJ_RELEASE(zms->zclient);
     zend_object_std_dtor(&zms->std);
 }
 
-static sw_inline zend_object* swoole_mysql_coro_statement_create_object(zend_class_entry *ce, mysql_statement *statement, zend_object *client)
+static sw_inline zend_object* php_swoole_mysql_coro_statement_create_object(zend_class_entry *ce, mysql_statement *statement, zend_object *client)
 {
     zval zobject;
     mysql_coro_statement_t *zms = (mysql_coro_statement_t *) ecalloc(1, sizeof(mysql_coro_statement_t) + zend_object_properties_size(ce));
@@ -1865,12 +1865,12 @@ static sw_inline zend_object* swoole_mysql_coro_statement_create_object(zend_cla
     return &zms->std;
 }
 
-static sw_inline zend_object* swoole_mysql_coro_statement_create_object(mysql_statement *statement, zend_object *client)
+static sw_inline zend_object* php_swoole_mysql_coro_statement_create_object(mysql_statement *statement, zend_object *client)
 {
-    return swoole_mysql_coro_statement_create_object(swoole_mysql_coro_statement_ce, statement, client);
+    return php_swoole_mysql_coro_statement_create_object(swoole_mysql_coro_statement_ce, statement, client);
 }
 
-static zend_object* swoole_mysql_coro_statement_create_object(zend_class_entry *ce)
+static zend_object* php_swoole_mysql_coro_statement_create_object(zend_class_entry *ce)
 {
     php_swoole_fatal_error(E_ERROR, "you must create mysql statement object by prepare method");
     return nullptr;
@@ -1914,13 +1914,13 @@ static sw_inline void swoole_mysql_coro_sync_execute_error_properties(zval *zobj
 
     /* backward compatibility (sync error info to client) */
     zval zclient;
-    ZVAL_OBJ(&zclient, swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject))->zclient);
+    ZVAL_OBJ(&zclient, php_swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject))->zclient);
     swoole_mysql_coro_sync_error_properties(&zclient, error_code, error_msg, connected);
 }
 
 static sw_inline void swoole_mysql_coro_sync_execute_result_properties(zval *zobject, zval *return_value)
 {
-    mysql_coro_statement_t *zms = swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject));
+    mysql_coro_statement_t *zms = php_swoole_mysql_coro_statement_fetch_object(Z_OBJ_P(zobject));
     mysql_statement *ms = zms->statement;
 
     switch (Z_TYPE_P(return_value))
@@ -1954,13 +1954,13 @@ void php_swoole_mysql_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_mysql_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_mysql_coro, swoole_mysql_coro_create_object, swoole_mysql_coro_free_object, mysql_coro_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_mysql_coro, php_swoole_mysql_coro_create_object, php_swoole_mysql_coro_free_object, mysql_coro_t, std);
 
     SW_INIT_CLASS_ENTRY(swoole_mysql_coro_statement, "Swoole\\Coroutine\\MySQL\\Statement", NULL, "Co\\MySQL\\Statement", swoole_mysql_coro_statement_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro_statement, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_mysql_coro_statement, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro_statement, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_mysql_coro_statement, swoole_mysql_coro_statement_create_object, swoole_mysql_coro_statement_free_object, mysql_coro_statement_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_mysql_coro_statement, php_swoole_mysql_coro_statement_create_object, php_swoole_mysql_coro_statement_free_object, mysql_coro_statement_t, std);
 
     SW_INIT_CLASS_ENTRY_EX(swoole_mysql_coro_exception, "Swoole\\Coroutine\\MySQL\\Exception", NULL, "Co\\MySQL\\Exception", NULL, swoole_exception);
     SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro_exception, zend_class_serialize_deny, zend_class_unserialize_deny);
@@ -2253,7 +2253,7 @@ static PHP_METHOD(swoole_mysql_coro, prepare)
         {
             goto _failed;
         }
-        RETVAL_OBJ(swoole_mysql_coro_statement_create_object(statement, Z_OBJ_P(ZEND_THIS)));
+        RETVAL_OBJ(php_swoole_mysql_coro_statement_create_object(statement, Z_OBJ_P(ZEND_THIS)));
     }
     mc->del_timeout_controller();
 }
@@ -2292,7 +2292,7 @@ static PHP_METHOD(swoole_mysql_coro, recv)
         }
         else
         {
-            RETVAL_OBJ(swoole_mysql_coro_statement_create_object(statement, Z_OBJ_P(ZEND_THIS)));
+            RETVAL_OBJ(php_swoole_mysql_coro_statement_create_object(statement, Z_OBJ_P(ZEND_THIS)));
         }
         break;
     }

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -349,7 +349,7 @@ static PHP_METHOD(swoole_process, __construct)
         Z_PARAM_BOOL(enable_coroutine)
     ZEND_PARSE_PARAMETERS_END_EX(efree(func); RETURN_FALSE);
 
-    swWorker *process = (swWorker *) ecalloc(1, sizeof(swWorker));
+    process = (swWorker *) ecalloc(1, sizeof(swWorker));
 
     uint32_t base = 1;
     if (SwooleG.serv && SwooleG.serv->gs->start)

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -52,7 +52,7 @@ swWorker* swoole_process_get_and_check_worker(zval *zobject)
     return worker;
 }
 
-static void swoole_process_set_ptr(zval *zobject, swWorker *worker)
+void swoole_process_set_worker(zval *zobject, swWorker *worker)
 {
     swoole_process_fetch_object(Z_OBJ_P(zobject))->worker = worker;
 }
@@ -399,7 +399,7 @@ static PHP_METHOD(swoole_process, __construct)
     proc->enable_coroutine = enable_coroutine;
     process->ptr2 = proc;
 
-    swoole_process_set_ptr(ZEND_THIS, process);
+    swoole_process_set_worker(ZEND_THIS, process);
 }
 
 static PHP_METHOD(swoole_process, __destruct) { }

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -314,7 +314,7 @@ static PHP_METHOD(swoole_process, __construct)
 
     if (process)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     //only cli env

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -37,14 +37,14 @@ static sw_inline process_t* swoole_process_fetch_object(zend_object *obj)
     return (process_t *) ((char *) obj - swoole_process_handlers.offset);
 }
 
-static swWorker* swoole_process_get_worker(zval *zobject)
+static swWorker* php_swoole_process_get_worker(zval *zobject)
 {
     return swoole_process_fetch_object(Z_OBJ_P(zobject))->worker;
 }
 
-swWorker* swoole_process_get_and_check_worker(zval *zobject)
+swWorker* php_swoole_process_get_and_check_worker(zval *zobject)
 {
-    swWorker *worker = swoole_process_get_worker(zobject);
+    swWorker *worker = php_swoole_process_get_worker(zobject);
     if (!worker)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Process constructor first");
@@ -52,7 +52,7 @@ swWorker* swoole_process_get_and_check_worker(zval *zobject)
     return worker;
 }
 
-void swoole_process_set_worker(zval *zobject, swWorker *worker)
+void php_swoole_process_set_worker(zval *zobject, swWorker *worker)
 {
     swoole_process_fetch_object(Z_OBJ_P(zobject))->worker = worker;
 }
@@ -310,7 +310,7 @@ void php_swoole_process_minit(int module_number)
 
 static PHP_METHOD(swoole_process, __construct)
 {
-    swWorker *process = swoole_process_get_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_worker(ZEND_THIS);
 
     if (process)
     {
@@ -399,7 +399,7 @@ static PHP_METHOD(swoole_process, __construct)
     proc->enable_coroutine = enable_coroutine;
     process->ptr2 = proc;
 
-    swoole_process_set_worker(ZEND_THIS, process);
+    php_swoole_process_set_worker(ZEND_THIS, process);
 }
 
 static PHP_METHOD(swoole_process, __destruct) { }
@@ -445,7 +445,7 @@ static PHP_METHOD(swoole_process, useQueue)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
     if (msgkey <= 0)
     {
@@ -475,7 +475,7 @@ static PHP_METHOD(swoole_process, useQueue)
 
 static PHP_METHOD(swoole_process, statQueue)
 {
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (!process->queue)
     {
         php_swoole_fatal_error(E_WARNING, "no queue, can't get stats of the queue");
@@ -498,7 +498,7 @@ static PHP_METHOD(swoole_process, statQueue)
 
 static PHP_METHOD(swoole_process, freeQueue)
 {
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->queue && swMsgQueue_free(process->queue) == SW_OK)
     {
         efree(process->queue);
@@ -787,7 +787,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
 
 static PHP_METHOD(swoole_process, start)
 {
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
     if (process->pid && swoole_kill(process->pid, 0) == 0)
     {
@@ -830,7 +830,7 @@ static PHP_METHOD(swoole_process, read)
         buf_size = 65536;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
     if (process->pipe == 0)
     {
@@ -870,7 +870,7 @@ static PHP_METHOD(swoole_process, write)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot write into pipe");
@@ -911,7 +911,7 @@ static PHP_METHOD(swoole_process, write)
  */
 static PHP_METHOD(swoole_process, exportSocket)
 {
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot export stream");
@@ -957,7 +957,7 @@ static PHP_METHOD(swoole_process, push)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
     if (!process->queue)
     {
@@ -989,7 +989,7 @@ static PHP_METHOD(swoole_process, pop)
         maxsize = SW_MSGMAX;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (!process->queue)
     {
         php_swoole_fatal_error(E_WARNING, "no msgqueue, cannot use pop()");
@@ -1158,7 +1158,7 @@ static PHP_METHOD(swoole_process, exit)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
     if (getpid() != process->pid)
     {
@@ -1194,7 +1194,7 @@ static PHP_METHOD(swoole_process, close)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot close the pipe");
@@ -1246,7 +1246,7 @@ static PHP_METHOD(swoole_process, set)
 
     vht = Z_ARRVAL_P(zset);
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     zend::process *proc = (zend::process *) process->ptr2;
 
     if (php_swoole_array_get_value(vht, "enable_coroutine", ztmp))
@@ -1263,7 +1263,7 @@ static PHP_METHOD(swoole_process, setTimeout)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot setTimeout the pipe");
@@ -1280,7 +1280,7 @@ static PHP_METHOD(swoole_process, setBlocking)
         RETURN_FALSE;
     }
 
-    swWorker *process = swoole_process_get_and_check_worker(ZEND_THIS);
+    swWorker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot setBlocking the pipe");

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -32,14 +32,14 @@ typedef struct
     zend_object std;
 } process_t;
 
-static sw_inline process_t* swoole_process_fetch_object(zend_object *obj)
+static sw_inline process_t* php_swoole_process_fetch_object(zend_object *obj)
 {
     return (process_t *) ((char *) obj - swoole_process_handlers.offset);
 }
 
 static swWorker* php_swoole_process_get_worker(zval *zobject)
 {
-    return swoole_process_fetch_object(Z_OBJ_P(zobject))->worker;
+    return php_swoole_process_fetch_object(Z_OBJ_P(zobject))->worker;
 }
 
 swWorker* php_swoole_process_get_and_check_worker(zval *zobject)
@@ -54,12 +54,12 @@ swWorker* php_swoole_process_get_and_check_worker(zval *zobject)
 
 void php_swoole_process_set_worker(zval *zobject, swWorker *worker)
 {
-    swoole_process_fetch_object(Z_OBJ_P(zobject))->worker = worker;
+    php_swoole_process_fetch_object(Z_OBJ_P(zobject))->worker = worker;
 }
 
-static void swoole_process_free_object(zend_object *object)
+static void php_swoole_process_free_object(zend_object *object)
 {
-    swWorker *worker = swoole_process_fetch_object(object)->worker;
+    swWorker *worker = php_swoole_process_fetch_object(object)->worker;
 
     swPipe *_pipe = worker->pipe_object;
     if (_pipe)
@@ -83,7 +83,7 @@ static void swoole_process_free_object(zend_object *object)
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_process_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_process_create_object(zend_class_entry *ce)
 {
     process_t *process = (process_t *) ecalloc(1, sizeof(process_t) + zend_object_properties_size(ce));
     zend_object_std_init(&process->std, ce);
@@ -247,7 +247,7 @@ void php_swoole_process_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_process, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_process, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process, swoole_process_create_object, swoole_process_free_object, process_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process, php_swoole_process_create_object, php_swoole_process_free_object, process_t, std);
 
     zend_declare_class_constant_long(swoole_process_ce, ZEND_STRL("IPC_NOWAIT"), MSGQUEUE_NOWAIT);
     zend_declare_class_constant_long(swoole_process_ce, ZEND_STRL("PIPE_MASTER"), SW_PIPE_CLOSE_MASTER);

--- a/swoole_process.cc
+++ b/swoole_process.cc
@@ -20,6 +20,78 @@
 
 using namespace swoole;
 
+zend_class_entry *swoole_process_ce;
+static zend_object_handlers swoole_process_handlers;
+
+static uint32_t php_swoole_worker_round_id = 0;
+static zend_fcall_info_cache *signal_fci_caches[SW_SIGNO_MAX] = {0};
+
+typedef struct
+{
+    swWorker *worker;
+    zend_object std;
+} process_t;
+
+static sw_inline process_t* swoole_process_fetch_object(zend_object *obj)
+{
+    return (process_t *) ((char *) obj - swoole_process_handlers.offset);
+}
+
+swWorker* swoole_process_get_ptr(zval *zobject)
+{
+    return swoole_process_fetch_object(Z_OBJ_P(zobject))->worker;
+}
+
+swWorker* swoole_process_get_and_check_ptr(zval *zobject)
+{
+    swWorker *worker = swoole_process_get_ptr(zobject);
+    if (!worker)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Process constructor first");
+    }
+    return worker;
+}
+
+void swoole_process_set_ptr(zval *zobject, swWorker *worker)
+{
+    swoole_process_fetch_object(Z_OBJ_P(zobject))->worker = worker;
+}
+
+static void swoole_process_free_object(zend_object *object)
+{
+    swWorker *worker = swoole_process_fetch_object(object)->worker;
+
+    swPipe *_pipe = worker->pipe_object;
+    if (_pipe)
+    {
+        _pipe->close(_pipe);
+        efree(_pipe);
+    }
+
+    if (worker->queue)
+    {
+        efree(worker->queue);
+    }
+
+    zend::process *proc = (zend::process *) worker->ptr2;
+    if (proc)
+    {
+        delete proc;
+    }
+    efree(worker);
+
+    zend_object_std_dtor(object);
+}
+
+static zend_object *swoole_process_create_object(zend_class_entry *ce)
+{
+    process_t *process = (process_t *) ecalloc(1, sizeof(process_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&process->std, ce);
+    object_properties_init(&process->std, ce);
+    process->std.handlers = &swoole_process_handlers;
+    return &process->std;
+}
+
 static PHP_METHOD(swoole_process, __construct);
 static PHP_METHOD(swoole_process, __destruct);
 static PHP_METHOD(swoole_process, useQueue);
@@ -47,12 +119,6 @@ static PHP_METHOD(swoole_process, exec);
 static PHP_METHOD(swoole_process, exportSocket);
 
 static void php_swoole_onSignal(int signo);
-
-static uint32_t php_swoole_worker_round_id = 0;
-static zend_fcall_info_cache *signal_fci_caches[SW_SIGNO_MAX] = {0};
-
-zend_class_entry *swoole_process_ce;
-static zend_object_handlers swoole_process_handlers;
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_process_construct, 0, 0, 1)
     ZEND_ARG_CALLABLE_INFO(0, callback, 0)
@@ -142,7 +208,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_process_name, 0, 0, 1)
     ZEND_ARG_INFO(0, process_name)
 ZEND_END_ARG_INFO()
 
-#define MSGQUEUE_NOWAIT    (1 << 8)
+#define MSGQUEUE_NOWAIT (1 << 8)
 
 static const zend_function_entry swoole_process_methods[] =
 {
@@ -181,7 +247,7 @@ void php_swoole_process_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_process, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_process, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_process);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process, swoole_process_create_object, swoole_process_free_object, process_t, std);
 
     zend_declare_class_constant_long(swoole_process_ce, ZEND_STRL("IPC_NOWAIT"), MSGQUEUE_NOWAIT);
     zend_declare_class_constant_long(swoole_process_ce, ZEND_STRL("PIPE_MASTER"), SW_PIPE_CLOSE_MASTER);
@@ -201,52 +267,55 @@ void php_swoole_process_minit(int module_number)
      */
     if (!zend_hash_str_find(&module_registry, ZEND_STRL("pcntl")))
     {
-        REGISTER_LONG_CONSTANT("SIGHUP", (long) SIGHUP, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGINT", (long) SIGINT, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGQUIT", (long) SIGQUIT, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGILL", (long) SIGILL, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGTRAP", (long) SIGTRAP, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGABRT", (long) SIGABRT, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGBUS", (long) SIGBUS, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGFPE", (long) SIGFPE, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGKILL", (long) SIGKILL, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGUSR1", (long) SIGUSR1, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGSEGV", (long) SIGSEGV, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGUSR2", (long) SIGUSR2, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGPIPE", (long) SIGPIPE, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGALRM", (long) SIGALRM, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGTERM", (long) SIGTERM, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGHUP", (zend_long) SIGHUP, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGINT", (zend_long) SIGINT, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGQUIT", (zend_long) SIGQUIT, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGILL", (zend_long) SIGILL, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGTRAP", (zend_long) SIGTRAP, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGABRT", (zend_long) SIGABRT, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGBUS", (zend_long) SIGBUS, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGFPE", (zend_long) SIGFPE, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGKILL", (zend_long) SIGKILL, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGUSR1", (zend_long) SIGUSR1, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGSEGV", (zend_long) SIGSEGV, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGUSR2", (zend_long) SIGUSR2, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGPIPE", (zend_long) SIGPIPE, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGALRM", (zend_long) SIGALRM, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGTERM", (zend_long) SIGTERM, CONST_CS | CONST_PERSISTENT);
 #ifdef SIGSTKFLT
-        REGISTER_LONG_CONSTANT("SIGSTKFLT", (long) SIGSTKFLT, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGSTKFLT", (zend_long) SIGSTKFLT, CONST_CS | CONST_PERSISTENT);
 #endif
-        REGISTER_LONG_CONSTANT("SIGCHLD", (long) SIGCHLD, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGCONT", (long) SIGCONT, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGSTOP", (long) SIGSTOP, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGTSTP", (long) SIGTSTP, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGTTIN", (long) SIGTTIN, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGTTOU", (long) SIGTTOU, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGURG", (long) SIGURG, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGXCPU", (long) SIGXCPU, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGXFSZ", (long) SIGXFSZ, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGVTALRM", (long) SIGVTALRM, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGPROF", (long) SIGPROF, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGWINCH", (long) SIGWINCH, CONST_CS | CONST_PERSISTENT);
-        REGISTER_LONG_CONSTANT("SIGIO", (long) SIGIO, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGCHLD", (zend_long) SIGCHLD, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGCONT", (zend_long) SIGCONT, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGSTOP", (zend_long) SIGSTOP, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGTSTP", (zend_long) SIGTSTP, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGTTIN", (zend_long) SIGTTIN, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGTTOU", (zend_long) SIGTTOU, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGURG", (zend_long) SIGURG, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGXCPU", (zend_long) SIGXCPU, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGXFSZ", (zend_long) SIGXFSZ, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGVTALRM", (zend_long) SIGVTALRM, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGPROF", (zend_long) SIGPROF, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGWINCH", (zend_long) SIGWINCH, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGIO", (zend_long) SIGIO, CONST_CS | CONST_PERSISTENT);
 #ifdef SIGPWR
-        REGISTER_LONG_CONSTANT("SIGPWR", (long) SIGPWR, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGPWR", (zend_long) SIGPWR, CONST_CS | CONST_PERSISTENT);
 #endif
 #ifdef SIGSYS
-        REGISTER_LONG_CONSTANT("SIGSYS", (long) SIGSYS, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIGSYS", (zend_long) SIGSYS, CONST_CS | CONST_PERSISTENT);
 #endif
-        REGISTER_LONG_CONSTANT("SIG_IGN", (long) SIG_IGN, CONST_CS | CONST_PERSISTENT);
+        REGISTER_LONG_CONSTANT("SIG_IGN", (zend_long) SIG_IGN, CONST_CS | CONST_PERSISTENT);
     }
 }
 
 static PHP_METHOD(swoole_process, __construct)
 {
-    zend_bool redirect_stdin_and_stdout = 0;
-    zend_long pipe_type = 2;
-    zend_bool enable_coroutine = SW_FALSE;
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
+
+    if (process)
+    {
+        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+    }
 
     //only cli env
     if (!SWOOLE_G(cli))
@@ -267,8 +336,10 @@ static PHP_METHOD(swoole_process, __construct)
         RETURN_FALSE;
     }
 
-
     php_swoole_fci *func = (php_swoole_fci*) emalloc(sizeof(php_swoole_fci));
+    zend_bool redirect_stdin_and_stdout = 0;
+    zend_long pipe_type = 2;
+    zend_bool enable_coroutine = SW_FALSE;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 4)
         Z_PARAM_FUNC(func->fci, func->fci_cache);
@@ -328,32 +399,10 @@ static PHP_METHOD(swoole_process, __construct)
     proc->enable_coroutine = enable_coroutine;
     process->ptr2 = proc;
 
-    swoole_set_object(ZEND_THIS, process);
+    swoole_process_set_ptr(ZEND_THIS, process);
 }
 
-static PHP_METHOD(swoole_process, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
-    swoole_set_object(ZEND_THIS, NULL);
-    swPipe *_pipe = process->pipe_object;
-    if (_pipe)
-    {
-        _pipe->close(_pipe);
-        efree(_pipe);
-    }
-    if (process->queue)
-    {
-        efree(process->queue);
-    }
-    zend::process *proc = (zend::process *) process->ptr2;
-    if (proc)
-    {
-        delete proc;
-    }
-    efree(process);
-}
+static PHP_METHOD(swoole_process, __destruct) { }
 
 static PHP_METHOD(swoole_process, wait)
 {
@@ -396,7 +445,7 @@ static PHP_METHOD(swoole_process, useQueue)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
 
     if (msgkey <= 0)
     {
@@ -426,7 +475,7 @@ static PHP_METHOD(swoole_process, useQueue)
 
 static PHP_METHOD(swoole_process, statQueue)
 {
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (!process->queue)
     {
         php_swoole_fatal_error(E_WARNING, "no queue, can't get stats of the queue");
@@ -449,7 +498,7 @@ static PHP_METHOD(swoole_process, statQueue)
 
 static PHP_METHOD(swoole_process, freeQueue)
 {
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->queue && swMsgQueue_free(process->queue) == SW_OK)
     {
         efree(process->queue);
@@ -738,7 +787,7 @@ int php_swoole_process_start(swWorker *process, zval *zobject)
 
 static PHP_METHOD(swoole_process, start)
 {
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
 
     if (process->pid && swoole_kill(process->pid, 0) == 0)
     {
@@ -781,7 +830,7 @@ static PHP_METHOD(swoole_process, read)
         buf_size = 65536;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
 
     if (process->pipe == 0)
     {
@@ -821,7 +870,7 @@ static PHP_METHOD(swoole_process, write)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot write into pipe");
@@ -862,7 +911,7 @@ static PHP_METHOD(swoole_process, write)
  */
 static PHP_METHOD(swoole_process, exportSocket)
 {
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot export stream");
@@ -908,7 +957,7 @@ static PHP_METHOD(swoole_process, push)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
 
     if (!process->queue)
     {
@@ -940,7 +989,7 @@ static PHP_METHOD(swoole_process, pop)
         maxsize = SW_MSGMAX;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (!process->queue)
     {
         php_swoole_fatal_error(E_WARNING, "no msgqueue, cannot use pop()");
@@ -1109,7 +1158,7 @@ static PHP_METHOD(swoole_process, exit)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
 
     if (getpid() != process->pid)
     {
@@ -1145,7 +1194,7 @@ static PHP_METHOD(swoole_process, close)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot close the pipe");
@@ -1197,7 +1246,7 @@ static PHP_METHOD(swoole_process, set)
 
     vht = Z_ARRVAL_P(zset);
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     zend::process *proc = (zend::process *) process->ptr2;
 
     if (php_swoole_array_get_value(vht, "enable_coroutine", ztmp))
@@ -1214,7 +1263,7 @@ static PHP_METHOD(swoole_process, setTimeout)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot setTimeout the pipe");
@@ -1231,7 +1280,7 @@ static PHP_METHOD(swoole_process, setBlocking)
         RETURN_FALSE;
     }
 
-    swWorker *process = (swWorker *) swoole_get_object(ZEND_THIS);
+    swWorker *process = swoole_process_get_ptr(ZEND_THIS);
     if (process->pipe == 0)
     {
         php_swoole_fatal_error(E_WARNING, "no pipe, cannot setBlocking the pipe");

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -43,14 +43,14 @@ static sw_inline process_pool_t* swoole_process_pool_fetch_object(zend_object *o
     return (process_pool_t *) ((char *) obj - swoole_process_pool_handlers.offset);
 }
 
-static sw_inline swProcessPool * swoole_process_pool_get_pool(zval *zobject)
+static sw_inline swProcessPool * php_swoole_process_pool_get_pool(zval *zobject)
 {
     return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool;
 }
 
-static sw_inline swProcessPool * swoole_process_pool_get_and_check_pool(zval *zobject)
+static sw_inline swProcessPool * php_swoole_process_pool_get_and_check_pool(zval *zobject)
 {
-    swProcessPool *pool = swoole_process_pool_get_pool(zobject);
+    swProcessPool *pool = php_swoole_process_pool_get_pool(zobject);
     if (!pool)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Process\\Pool constructor first");
@@ -58,19 +58,19 @@ static sw_inline swProcessPool * swoole_process_pool_get_and_check_pool(zval *zo
     return pool;
 }
 
-static sw_inline void swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
+static sw_inline void php_swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
 {
     swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool = pool;
 }
 
-static sw_inline process_pool_property * swoole_process_pool_get_pp(zval *zobject)
+static sw_inline process_pool_property * php_swoole_process_pool_get_pp(zval *zobject)
 {
     return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp;
 }
 
-static sw_inline process_pool_property * swoole_process_pool_get_and_check_pp(zval *zobject)
+static sw_inline process_pool_property * php_swoole_process_pool_get_and_check_pp(zval *zobject)
 {
-    process_pool_property *pp = swoole_process_pool_get_pp(zobject);
+    process_pool_property *pp = php_swoole_process_pool_get_pp(zobject);
     if (!pp)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Process\\Pool constructor first");
@@ -78,7 +78,7 @@ static sw_inline process_pool_property * swoole_process_pool_get_and_check_pp(zv
     return pp;
 }
 
-static sw_inline void swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
+static sw_inline void php_swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
 {
     swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp = pp;
 }
@@ -204,7 +204,7 @@ void php_swoole_process_pool_minit(int module_number)
 static void pool_onWorkerStart(swProcessPool *pool, int worker_id)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(zobject);
 
     php_swoole_process_clean();
     SwooleWG.id = worker_id;
@@ -237,7 +237,7 @@ static void pool_onWorkerStart(swProcessPool *pool, int worker_id)
 static void pool_onMessage(swProcessPool *pool, char *data, uint32_t length)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(zobject);
     zval args[2];
 
     args[0] = *zobject;
@@ -254,7 +254,7 @@ static void pool_onMessage(swProcessPool *pool, char *data, uint32_t length)
 static void pool_onWorkerStop(swProcessPool *pool, int worker_id)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(zobject);
     zval args[2];
 
     if (pp->onWorkerStop == NULL)
@@ -357,8 +357,8 @@ static PHP_METHOD(swoole_process_pool, __construct)
 
     process_pool_property *pp = (process_pool_property *) ecalloc(1, sizeof(process_pool_property));
     pp->enable_coroutine = enable_coroutine;
-    swoole_process_pool_set_pp(zobject, pp);
-    swoole_process_pool_set_pool(zobject, pool);
+    php_swoole_process_pool_set_pp(zobject, pp);
+    php_swoole_process_pool_set_pool(zobject, pool);
 }
 
 static PHP_METHOD(swoole_process_pool, set)
@@ -373,7 +373,7 @@ static PHP_METHOD(swoole_process_pool, set)
 
     vht = Z_ARRVAL_P(zset);
 
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     if (php_swoole_array_get_value(vht, "enable_coroutine", ztmp))
     {
@@ -389,7 +389,7 @@ static PHP_METHOD(swoole_process_pool, on)
     zend_fcall_info fci;
     zend_fcall_info_cache fci_cache;
 
-    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
+    swProcessPool *pool = php_swoole_process_pool_get_and_check_pool(ZEND_THIS);
 
     if (pool->started > 0)
     {
@@ -402,7 +402,7 @@ static PHP_METHOD(swoole_process_pool, on)
         Z_PARAM_FUNC(fci, fci_cache);
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     if (strncasecmp("WorkerStart", name, l_name) == 0)
     {
@@ -488,7 +488,7 @@ static PHP_METHOD(swoole_process_pool, listen)
     zend_long port = 0;
     zend_long backlog = 2048;
 
-    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
+    swProcessPool *pool = php_swoole_process_pool_get_and_check_pool(ZEND_THIS);
 
     if (pool->started > 0)
     {
@@ -531,7 +531,7 @@ static PHP_METHOD(swoole_process_pool, write)
         RETURN_FALSE;
     }
 
-    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
+    swProcessPool *pool = php_swoole_process_pool_get_and_check_pool(ZEND_THIS);
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
         php_swoole_fatal_error(E_WARNING, "unsupported ipc type[%d]", pool->ipc_mode);
@@ -546,7 +546,7 @@ static PHP_METHOD(swoole_process_pool, write)
 
 static PHP_METHOD(swoole_process_pool, start)
 {
-    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
+    swProcessPool *pool = php_swoole_process_pool_get_and_check_pool(ZEND_THIS);
     if (pool->started)
     {
         php_swoole_fatal_error(E_WARNING, "process pool is started. unable to execute swoole_process_pool->start");
@@ -558,7 +558,7 @@ static PHP_METHOD(swoole_process_pool, start)
         swoole_event_free();
     }
 
-    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
+    process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     SwooleG.use_signalfd = 0;
 
@@ -610,7 +610,7 @@ static PHP_METHOD(swoole_process_pool, start)
     swProcessPool_shutdown(pool);
 }
 
-extern void swoole_process_set_worker(zval *zobject, swWorker *worker);
+extern void php_swoole_process_set_worker(zval *zobject, swWorker *worker);
 
 static PHP_METHOD(swoole_process_pool, getProcess)
 {
@@ -669,8 +669,8 @@ static PHP_METHOD(swoole_process_pool, getProcess)
             worker->pipe_object = nullptr;
             zend_update_property_long(swoole_process_ce, zprocess, ZEND_STRL("pipe"), worker->pipe);
         }
-        swoole_process_set_worker(zprocess, worker);
-        process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
+        php_swoole_process_set_worker(zprocess, worker);
+        process_pool_property *pp = php_swoole_process_pool_get_and_check_pp(ZEND_THIS);
         zend::process *proc = new zend::process;
         proc->pipe_type = zend::PIPE_TYPE_STREAM;
         proc->enable_coroutine = pp->enable_coroutine;

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -509,6 +509,8 @@ static PHP_METHOD(swoole_process_pool, start)
     swProcessPool_shutdown(pool);
 }
 
+extern void swoole_process_set_worker(zval *zobject, swWorker *worker);
+
 static PHP_METHOD(swoole_process_pool, getProcess)
 {
     long worker_id = -1;
@@ -566,7 +568,7 @@ static PHP_METHOD(swoole_process_pool, getProcess)
             worker->pipe_object = nullptr;
             zend_update_property_long(swoole_process_ce, zprocess, ZEND_STRL("pipe"), worker->pipe);
         }
-        swoole_set_object(zprocess, worker);
+        swoole_process_set_worker(zprocess, worker);
         process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
         zend::process *proc = new zend::process;
         proc->pipe_type = zend::PIPE_TYPE_STREAM;

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -43,12 +43,12 @@ static sw_inline process_pool_t* swoole_process_pool_fetch_object(zend_object *o
     return (process_pool_t *) ((char *) obj - swoole_process_pool_handlers.offset);
 }
 
-static swProcessPool * swoole_process_pool_get_pool(zval *zobject)
+static sw_inline swProcessPool * swoole_process_pool_get_pool(zval *zobject)
 {
     return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool;
 }
 
-static swProcessPool * swoole_process_pool_get_and_check_pool(zval *zobject)
+static sw_inline swProcessPool * swoole_process_pool_get_and_check_pool(zval *zobject)
 {
     swProcessPool *pool = swoole_process_pool_get_pool(zobject);
     if (!pool)
@@ -58,17 +58,17 @@ static swProcessPool * swoole_process_pool_get_and_check_pool(zval *zobject)
     return pool;
 }
 
-void swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
+static sw_inline void swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
 {
     swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool = pool;
 }
 
-static process_pool_property * swoole_process_pool_get_pp(zval *zobject)
+static sw_inline process_pool_property * swoole_process_pool_get_pp(zval *zobject)
 {
     return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp;
 }
 
-static process_pool_property * swoole_process_pool_get_and_check_pp(zval *zobject)
+static sw_inline process_pool_property * swoole_process_pool_get_and_check_pp(zval *zobject)
 {
     process_pool_property *pp = swoole_process_pool_get_pp(zobject);
     if (!pp)
@@ -78,7 +78,7 @@ static process_pool_property * swoole_process_pool_get_and_check_pp(zval *zobjec
     return pp;
 }
 
-void swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
+static sw_inline void swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
 {
     swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp = pp;
 }

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -18,6 +18,120 @@
 
 using namespace swoole;
 
+typedef struct
+{
+    zend_fcall_info_cache *onStart;
+    zend_fcall_info_cache *onWorkerStart;
+    zend_fcall_info_cache *onWorkerStop;
+    zend_fcall_info_cache *onMessage;
+    bool enable_coroutine;
+} process_pool_property;
+
+static zend_class_entry *swoole_process_pool_ce;
+static zend_object_handlers swoole_process_pool_handlers;
+static swProcessPool *current_pool;
+
+typedef struct
+{
+    swProcessPool *pool;
+    process_pool_property *pp;
+    zend_object std;
+} process_pool_t;
+
+static sw_inline process_pool_t* swoole_process_pool_fetch_object(zend_object *obj)
+{
+    return (process_pool_t *) ((char *) obj - swoole_process_pool_handlers.offset);
+}
+
+static swProcessPool * swoole_process_pool_get_pool(zval *zobject)
+{
+    return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool;
+}
+
+static swProcessPool * swoole_process_pool_get_and_check_pool(zval *zobject)
+{
+    swProcessPool *pool = swoole_process_pool_get_pool(zobject);
+    if (!pool)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Process\\Pool constructor first");
+    }
+    return pool;
+}
+
+void swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
+{
+    swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool = pool;
+}
+
+static process_pool_property * swoole_process_pool_get_pp(zval *zobject)
+{
+    return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp;
+}
+
+static process_pool_property * swoole_process_pool_get_and_check_pp(zval *zobject)
+{
+    process_pool_property *pp = swoole_process_pool_get_pp(zobject);
+    if (!pp)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Process\\Pool constructor first");
+    }
+    return pp;
+}
+
+void swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
+{
+    swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp = pp;
+}
+
+static void swoole_process_pool_free_object(zend_object *object)
+{
+    process_pool_t *process_pool = swoole_process_pool_fetch_object(object);
+
+    swProcessPool *pool = process_pool->pool;
+    if (pool)
+    {
+        efree(pool->ptr);
+        efree(pool);
+    }
+
+    process_pool_property *pp = process_pool->pp;
+    if (pp)
+    {
+        if (pp->onWorkerStart)
+        {
+            sw_zend_fci_cache_discard(pp->onWorkerStart);
+            efree(pp->onWorkerStart);
+        }
+        if (pp->onMessage)
+        {
+            sw_zend_fci_cache_discard(pp->onMessage);
+            efree(pp->onMessage);
+        }
+        if (pp->onWorkerStop)
+        {
+            sw_zend_fci_cache_discard(pp->onWorkerStop);
+            efree(pp->onWorkerStop);
+        }
+        if (pp->onStart)
+        {
+            sw_zend_fci_cache_discard(pp->onStart);
+            efree(pp->onStart);
+        }
+        efree(pp);
+    }
+
+    zend_object_std_dtor(object);
+}
+
+static zend_object *swoole_process_pool_create_object(zend_class_entry *ce)
+{
+    process_pool_t *process_pool = (process_pool_t *) ecalloc(1, sizeof(process_pool_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&process_pool->std, ce);
+    object_properties_init(&process_pool->std, ce);
+    process_pool->std.handlers = &swoole_process_pool_handlers;
+    return &process_pool->std;
+}
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_process_pool_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -75,26 +189,13 @@ static const zend_function_entry swoole_process_pool_methods[] =
     PHP_FE_END
 };
 
-typedef struct
-{
-    zend_fcall_info_cache *onStart;
-    zend_fcall_info_cache *onWorkerStart;
-    zend_fcall_info_cache *onWorkerStop;
-    zend_fcall_info_cache *onMessage;
-    bool enable_coroutine;
-} process_pool_property;
-
-static zend_class_entry *swoole_process_pool_ce;
-static zend_object_handlers swoole_process_pool_handlers;
-static swProcessPool *current_pool;
-
 void php_swoole_process_pool_minit(int module_number)
 {
     SW_INIT_CLASS_ENTRY(swoole_process_pool, "Swoole\\Process\\Pool", "swoole_process_pool", NULL, swoole_process_pool_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_process_pool, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_process_pool, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process_pool, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_process_pool);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process_pool, swoole_process_pool_create_object, swoole_process_pool_free_object, process_pool_t, std);
 
     zend_declare_property_long(swoole_process_pool_ce, ZEND_STRL("master_pid"), -1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_process_pool_ce, ZEND_STRL("workers"), ZEND_ACC_PUBLIC);
@@ -103,7 +204,7 @@ void php_swoole_process_pool_minit(int module_number)
 static void pool_onWorkerStart(swProcessPool *pool, int worker_id)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(zobject, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
 
     php_swoole_process_clean();
     SwooleWG.id = worker_id;
@@ -136,7 +237,7 @@ static void pool_onWorkerStart(swProcessPool *pool, int worker_id)
 static void pool_onMessage(swProcessPool *pool, char *data, uint32_t length)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(zobject, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
     zval args[2];
 
     args[0] = *zobject;
@@ -153,7 +254,7 @@ static void pool_onMessage(swProcessPool *pool, char *data, uint32_t length)
 static void pool_onWorkerStop(swProcessPool *pool, int worker_id)
 {
     zval *zobject = (zval *) pool->ptr;
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(zobject, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(zobject);
     zval args[2];
 
     if (pp->onWorkerStop == NULL)
@@ -256,8 +357,8 @@ static PHP_METHOD(swoole_process_pool, __construct)
 
     process_pool_property *pp = (process_pool_property *) ecalloc(1, sizeof(process_pool_property));
     pp->enable_coroutine = enable_coroutine;
-    swoole_set_property(zobject, 0, pp);
-    swoole_set_object(zobject, pool);
+    swoole_process_pool_set_pp(zobject, pp);
+    swoole_process_pool_set_pool(zobject, pool);
 }
 
 static PHP_METHOD(swoole_process_pool, set)
@@ -272,7 +373,7 @@ static PHP_METHOD(swoole_process_pool, set)
 
     vht = Z_ARRVAL_P(zset);
 
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     if (php_swoole_array_get_value(vht, "enable_coroutine", ztmp))
     {
@@ -288,7 +389,7 @@ static PHP_METHOD(swoole_process_pool, on)
     zend_fcall_info fci;
     zend_fcall_info_cache fci_cache;
 
-    swProcessPool *pool = (swProcessPool *) swoole_get_object(ZEND_THIS);
+    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
 
     if (pool->started > 0)
     {
@@ -301,7 +402,7 @@ static PHP_METHOD(swoole_process_pool, on)
         Z_PARAM_FUNC(fci, fci_cache);
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     if (strncasecmp("WorkerStart", name, l_name) == 0)
     {
@@ -387,7 +488,7 @@ static PHP_METHOD(swoole_process_pool, listen)
     zend_long port = 0;
     zend_long backlog = 2048;
 
-    swProcessPool *pool = (swProcessPool *) swoole_get_object(ZEND_THIS);
+    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
 
     if (pool->started > 0)
     {
@@ -430,7 +531,7 @@ static PHP_METHOD(swoole_process_pool, write)
         RETURN_FALSE;
     }
 
-    swProcessPool *pool = (swProcessPool *) swoole_get_object(ZEND_THIS);
+    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
     if (pool->ipc_mode != SW_IPC_SOCKET)
     {
         php_swoole_fatal_error(E_WARNING, "unsupported ipc type[%d]", pool->ipc_mode);
@@ -445,7 +546,7 @@ static PHP_METHOD(swoole_process_pool, write)
 
 static PHP_METHOD(swoole_process_pool, start)
 {
-    swProcessPool *pool = (swProcessPool *) swoole_get_object(ZEND_THIS);
+    swProcessPool *pool = swoole_process_pool_get_and_check_pool(ZEND_THIS);
     if (pool->started)
     {
         php_swoole_fatal_error(E_WARNING, "process pool is started. unable to execute swoole_process_pool->start");
@@ -457,7 +558,7 @@ static PHP_METHOD(swoole_process_pool, start)
         swoole_event_free();
     }
 
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
+    process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
 
     SwooleG.use_signalfd = 0;
 
@@ -569,7 +670,7 @@ static PHP_METHOD(swoole_process_pool, getProcess)
             zend_update_property_long(swoole_process_ce, zprocess, ZEND_STRL("pipe"), worker->pipe);
         }
         swoole_process_set_worker(zprocess, worker);
-        process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
+        process_pool_property *pp = swoole_process_pool_get_and_check_pp(ZEND_THIS);
         zend::process *proc = new zend::process;
         proc->pipe_type = zend::PIPE_TYPE_STREAM;
         proc->enable_coroutine = pp->enable_coroutine;
@@ -587,36 +688,4 @@ static PHP_METHOD(swoole_process_pool, shutdown)
     RETURN_BOOL(swoole_kill(pid, SIGTERM) == 0);
 }
 
-static PHP_METHOD(swoole_process_pool, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    swProcessPool *pool = (swProcessPool *) swoole_get_object(ZEND_THIS);
-    efree(pool->ptr);
-    efree(pool);
-    swoole_set_object(ZEND_THIS, NULL);
-
-    process_pool_property *pp = (process_pool_property *) swoole_get_property(ZEND_THIS, 0);
-    if (pp->onWorkerStart)
-    {
-        sw_zend_fci_cache_discard(pp->onWorkerStart);
-        efree(pp->onWorkerStart);
-    }
-    if (pp->onMessage)
-    {
-        sw_zend_fci_cache_discard(pp->onMessage);
-        efree(pp->onMessage);
-    }
-    if (pp->onWorkerStop)
-    {
-        sw_zend_fci_cache_discard(pp->onWorkerStop);
-        efree(pp->onWorkerStop);
-    }
-    if (pp->onStart)
-    {
-        sw_zend_fci_cache_discard(pp->onStart);
-        efree(pp->onStart);
-    }
-    efree(pp);
-    swoole_set_property(ZEND_THIS, 0, NULL);
-}
+static PHP_METHOD(swoole_process_pool, __destruct) { }

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -38,14 +38,14 @@ typedef struct
     zend_object std;
 } process_pool_t;
 
-static sw_inline process_pool_t* swoole_process_pool_fetch_object(zend_object *obj)
+static sw_inline process_pool_t* php_swoole_process_pool_fetch_object(zend_object *obj)
 {
     return (process_pool_t *) ((char *) obj - swoole_process_pool_handlers.offset);
 }
 
 static sw_inline swProcessPool * php_swoole_process_pool_get_pool(zval *zobject)
 {
-    return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool;
+    return php_swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool;
 }
 
 static sw_inline swProcessPool * php_swoole_process_pool_get_and_check_pool(zval *zobject)
@@ -60,12 +60,12 @@ static sw_inline swProcessPool * php_swoole_process_pool_get_and_check_pool(zval
 
 static sw_inline void php_swoole_process_pool_set_pool(zval *zobject, swProcessPool *pool)
 {
-    swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool = pool;
+    php_swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pool = pool;
 }
 
 static sw_inline process_pool_property * php_swoole_process_pool_get_pp(zval *zobject)
 {
-    return swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp;
+    return php_swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp;
 }
 
 static sw_inline process_pool_property * php_swoole_process_pool_get_and_check_pp(zval *zobject)
@@ -80,12 +80,12 @@ static sw_inline process_pool_property * php_swoole_process_pool_get_and_check_p
 
 static sw_inline void php_swoole_process_pool_set_pp(zval *zobject, process_pool_property *pp)
 {
-    swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp = pp;
+    php_swoole_process_pool_fetch_object(Z_OBJ_P(zobject))->pp = pp;
 }
 
-static void swoole_process_pool_free_object(zend_object *object)
+static void php_swoole_process_pool_free_object(zend_object *object)
 {
-    process_pool_t *process_pool = swoole_process_pool_fetch_object(object);
+    process_pool_t *process_pool = php_swoole_process_pool_fetch_object(object);
 
     swProcessPool *pool = process_pool->pool;
     if (pool)
@@ -123,7 +123,7 @@ static void swoole_process_pool_free_object(zend_object *object)
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_process_pool_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_process_pool_create_object(zend_class_entry *ce)
 {
     process_pool_t *process_pool = (process_pool_t *) ecalloc(1, sizeof(process_pool_t) + zend_object_properties_size(ce));
     zend_object_std_init(&process_pool->std, ce);
@@ -195,7 +195,7 @@ void php_swoole_process_pool_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_process_pool, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_process_pool, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process_pool, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process_pool, swoole_process_pool_create_object, swoole_process_pool_free_object, process_pool_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_process_pool, php_swoole_process_pool_create_object, php_swoole_process_pool_free_object, process_pool_t, std);
 
     zend_declare_property_long(swoole_process_pool_ce, ZEND_STRL("master_pid"), -1, ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_process_pool_ce, ZEND_STRL("workers"), ZEND_ACC_PUBLIC);

--- a/swoole_redis_coro.cc
+++ b/swoole_redis_coro.cc
@@ -2087,7 +2087,7 @@ static PHP_METHOD(swoole_redis_coro, __construct)
 
     if (redis->zobject)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
         RETURN_FALSE;
     }
 

--- a/swoole_redis_coro.cc
+++ b/swoole_redis_coro.cc
@@ -849,7 +849,7 @@ ZEND_END_ARG_INFO()
 
 #define SW_REDIS_COMMAND_CHECK \
     Coroutine::get_current_safe(); \
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
 
 #define SW_REDIS_COMMAND_ARGV_FILL(str, str_len) \
     argvlen[i] = str_len; \
@@ -935,7 +935,7 @@ static sw_inline swRedisClient* swoole_redis_coro_fetch_object(zend_object *obj)
     return (swRedisClient *) ((char *) obj - swoole_redis_coro_handlers.offset);
 }
 
-static sw_inline swRedisClient* swoole_get_redis_client(zval *zobject)
+static sw_inline swRedisClient* php_swoole_get_redis_client(zval *zobject)
 {
     swRedisClient *redis = (swRedisClient *) swoole_redis_coro_fetch_object(Z_OBJ_P(zobject));
     if (UNEXPECTED(!redis))
@@ -2076,7 +2076,7 @@ static void swoole_redis_coro_set_options(swRedisClient *redis, zval* zoptions, 
 
 static PHP_METHOD(swoole_redis_coro, __construct)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     zval *zsettings = sw_zend_read_and_convert_property_array(swoole_redis_coro_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
     zval *zset = NULL;
 
@@ -2149,7 +2149,7 @@ static PHP_METHOD(swoole_redis_coro, connect)
 
 static PHP_METHOD(swoole_redis_coro, getAuth)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     if (redis->session.auth)
     {
         zval *ztmp = sw_zend_read_and_convert_property_array(swoole_redis_coro_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
@@ -2164,7 +2164,7 @@ static PHP_METHOD(swoole_redis_coro, getAuth)
 
 static PHP_METHOD(swoole_redis_coro, getDBNum)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     if (!redis->context)
     {
         RETURN_FALSE;
@@ -2179,7 +2179,7 @@ static PHP_METHOD(swoole_redis_coro, getOptions)
 
 static PHP_METHOD(swoole_redis_coro, setOptions)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     zval *zoptions;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -2193,14 +2193,14 @@ static PHP_METHOD(swoole_redis_coro, setOptions)
 
 static PHP_METHOD(swoole_redis_coro, getDefer)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
 
     RETURN_BOOL(redis->defer);
 }
 
 static PHP_METHOD(swoole_redis_coro, setDefer)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     zend_bool defer = 1;
 
     if (redis->session.subscribe)
@@ -2288,7 +2288,7 @@ static PHP_METHOD(swoole_redis_coro, recv)
 
 static PHP_METHOD(swoole_redis_coro, close)
 {
-    swRedisClient *redis = swoole_get_redis_client(ZEND_THIS);
+    swRedisClient *redis = php_swoole_get_redis_client(ZEND_THIS);
     RETURN_BOOL(swoole_redis_coro_close(redis));
 }
 

--- a/swoole_redis_coro.cc
+++ b/swoole_redis_coro.cc
@@ -930,14 +930,14 @@ enum {SW_REDIS_MODE_MULTI, SW_REDIS_MODE_PIPELINE};
 
 static void swoole_redis_coro_parse_result(swRedisClient *redis, zval* return_value, redisReply* reply);
 
-static sw_inline swRedisClient* swoole_redis_coro_fetch_object(zend_object *obj)
+static sw_inline swRedisClient* php_swoole_redis_coro_fetch_object(zend_object *obj)
 {
     return (swRedisClient *) ((char *) obj - swoole_redis_coro_handlers.offset);
 }
 
 static sw_inline swRedisClient* php_swoole_get_redis_client(zval *zobject)
 {
-    swRedisClient *redis = (swRedisClient *) swoole_redis_coro_fetch_object(Z_OBJ_P(zobject));
+    swRedisClient *redis = (swRedisClient *) php_swoole_redis_coro_fetch_object(Z_OBJ_P(zobject));
     if (UNEXPECTED(!redis))
     {
         php_swoole_fatal_error(E_ERROR, "you must call Redis constructor first");
@@ -977,9 +977,9 @@ static sw_inline bool swoole_redis_coro_close(swRedisClient *redis)
     return false;
 }
 
-static void swoole_redis_coro_free_object(zend_object *object)
+static void php_swoole_redis_coro_free_object(zend_object *object)
 {
-    swRedisClient *redis = swoole_redis_coro_fetch_object(object);
+    swRedisClient *redis = php_swoole_redis_coro_fetch_object(object);
 
     if (redis && redis->context)
     {
@@ -989,7 +989,7 @@ static void swoole_redis_coro_free_object(zend_object *object)
     zend_object_std_dtor(&redis->std);
 }
 
-static zend_object *swoole_redis_coro_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_redis_coro_create_object(zend_class_entry *ce)
 {
     swRedisClient *redis = (swRedisClient *) ecalloc(1, sizeof(swRedisClient) + zend_object_properties_size(ce));
     zend_object_std_init(&redis->std, ce);
@@ -1993,7 +1993,7 @@ void php_swoole_redis_coro_minit(int module_number)
     SW_SET_CLASS_CLONEABLE(swoole_redis_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_redis_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_redis_coro);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_redis_coro, swoole_redis_coro_create_object, swoole_redis_coro_free_object, swRedisClient, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_redis_coro, php_swoole_redis_coro_create_object, php_swoole_redis_coro_free_object, swRedisClient, std);
 
     zend_declare_property_string(swoole_redis_coro_ce, ZEND_STRL("host"), "", ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_redis_coro_ce, ZEND_STRL("port"), 0, ZEND_ACC_PUBLIC);

--- a/swoole_redis_server.cc
+++ b/swoole_redis_server.cc
@@ -217,11 +217,11 @@ static int redis_onReceive(swServer *serv, swEventData *req)
     return SW_OK;
 }
 
-extern swServer* swoole_server_get_and_check_server(zval *zobject);
+extern swServer* php_swoole_server_get_and_check_server(zval *zobject);
 
 static PHP_METHOD(swoole_redis_server, start)
 {
-    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
+    swServer *serv = php_swoole_server_get_and_check_server(ZEND_THIS);
     zval *zserv = ZEND_THIS;
 
     if (serv->gs->start > 0)

--- a/swoole_redis_server.cc
+++ b/swoole_redis_server.cc
@@ -218,11 +218,13 @@ static int redis_onReceive(swServer *serv, swEventData *req)
     return SW_OK;
 }
 
+extern swServer* swoole_server_get_and_check_server(zval *zobject);
+
 static PHP_METHOD(swoole_redis_server, start)
 {
+    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
     zval *zserv = ZEND_THIS;
 
-    swServer *serv = (swServer *) swoole_get_object(zserv);
     if (serv->gs->start > 0)
     {
         php_swoole_error(E_WARNING, "server is running, unable to execute %s->start", SW_Z_OBJCE_NAME_VAL_P(zserv));

--- a/swoole_redis_server.cc
+++ b/swoole_redis_server.cc
@@ -70,7 +70,6 @@ void php_swoole_redis_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_redis_server, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_redis_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_redis_server, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_redis_server);
 
     zend_declare_class_constant_long(swoole_redis_server_ce, ZEND_STRL("NIL"), SW_REDIS_REPLY_NIL);
     zend_declare_class_constant_long(swoole_redis_server_ce, ZEND_STRL("ERROR"), SW_REDIS_REPLY_ERROR);

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -2684,6 +2684,8 @@ static PHP_METHOD(swoole_server, listen)
     RETURN_ZVAL(port_object, 1, NULL);
 }
 
+extern swWorker* swoole_process_get_and_check_worker(zval *zobject);
+
 static PHP_METHOD(swoole_server, addProcess)
 {
     swServer *serv = (swServer *) swoole_get_object(ZEND_THIS);
@@ -2724,7 +2726,7 @@ static PHP_METHOD(swoole_server, addProcess)
 
     Z_TRY_ADDREF_P(process);
 
-    swWorker *worker = (swWorker *) swoole_get_object(process);
+    swWorker *worker = swoole_process_get_and_check_worker(process);
     worker->ptr = process;
 
     int id = swServer_add_worker(serv, worker);

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -182,14 +182,14 @@ typedef struct
     zend_object std;
 } server_t;
 
-static sw_inline server_t* swoole_server_fetch_object(zend_object *obj)
+static sw_inline server_t* php_swoole_server_fetch_object(zend_object *obj)
 {
     return (server_t *) ((char *) obj - swoole_server_handlers.offset);
 }
 
 static sw_inline swServer* php_swoole_server_get_server(zval *zobject)
 {
-    return swoole_server_fetch_object(Z_OBJ_P(zobject))->serv;
+    return php_swoole_server_fetch_object(Z_OBJ_P(zobject))->serv;
 }
 
 swServer* php_swoole_server_get_and_check_server(zval *zobject)
@@ -204,12 +204,12 @@ swServer* php_swoole_server_get_and_check_server(zval *zobject)
 
 static sw_inline void php_swoole_server_set_server(zval *zobject, swServer *serv)
 {
-    swoole_server_fetch_object(Z_OBJ_P(zobject))->serv = serv;
+    php_swoole_server_fetch_object(Z_OBJ_P(zobject))->serv = serv;
 }
 
-static void swoole_server_free_object(zend_object *object)
+static void php_swoole_server_free_object(zend_object *object)
 {
-    server_t *server = swoole_server_fetch_object(object);
+    server_t *server = php_swoole_server_fetch_object(object);
     swServer *serv = server->serv;
 
     if (serv)
@@ -249,7 +249,7 @@ static void swoole_server_free_object(zend_object *object)
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_server_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_server_create_object(zend_class_entry *ce)
 {
     server_t *server = (server_t *) ecalloc(1, sizeof(server_t) + zend_object_properties_size(ce));
     zend_object_std_init(&server->std, ce);
@@ -264,14 +264,14 @@ typedef struct
     zend_object std;
 } connection_iterator_t;
 
-static sw_inline connection_iterator_t* swoole_connection_iterator_fetch_object(zend_object *obj)
+static sw_inline connection_iterator_t* php_swoole_connection_iterator_fetch_object(zend_object *obj)
 {
     return (connection_iterator_t *) ((char *) obj - swoole_connection_iterator_handlers.offset);
 }
 
 static sw_inline swConnectionIterator* php_swoole_connection_iterator_get_ptr(zval *zobject)
 {
-    return &swoole_connection_iterator_fetch_object(Z_OBJ_P(zobject))->iterator;
+    return &php_swoole_connection_iterator_fetch_object(Z_OBJ_P(zobject))->iterator;
 }
 
 swConnectionIterator* php_swoole_connection_iterator_get_and_check_ptr(zval *zobject)
@@ -284,12 +284,12 @@ swConnectionIterator* php_swoole_connection_iterator_get_and_check_ptr(zval *zob
     return iterator;
 }
 
-static void swoole_connection_iterator_free_object(zend_object *object)
+static void php_swoole_connection_iterator_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_connection_iterator_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_connection_iterator_create_object(zend_class_entry *ce)
 {
     connection_iterator_t *connection = (connection_iterator_t *) ecalloc(1, sizeof(connection_iterator_t) + zend_object_properties_size(ce));
     zend_object_std_init(&connection->std, ce);
@@ -305,14 +305,14 @@ typedef struct
     zend_object std;
 } server_task_t;
 
-static sw_inline server_task_t* swoole_server_task_fetch_object(zend_object *obj)
+static sw_inline server_task_t* php_swoole_server_task_fetch_object(zend_object *obj)
 {
     return (server_task_t *) ((char *) obj - swoole_server_task_handlers.offset);
 }
 
 static sw_inline swServer* php_swoole_server_task_get_server(zval *zobject)
 {
-    swServer* serv = swoole_server_task_fetch_object(Z_OBJ_P(zobject))->serv;
+    swServer* serv = php_swoole_server_task_fetch_object(Z_OBJ_P(zobject))->serv;
     if (!serv)
     {
         php_swoole_fatal_error(E_ERROR, "Invaild instance of %s", SW_Z_OBJCE_NAME_VAL_P(zobject));
@@ -322,12 +322,12 @@ static sw_inline swServer* php_swoole_server_task_get_server(zval *zobject)
 
 static sw_inline void php_swoole_server_task_set_server(zval *zobject, swServer *serv)
 {
-    swoole_server_task_fetch_object(Z_OBJ_P(zobject))->serv = serv;
+    php_swoole_server_task_fetch_object(Z_OBJ_P(zobject))->serv = serv;
 }
 
 static sw_inline swDataHead* php_swoole_server_task_get_info(zval *zobject)
 {
-    server_task_t *task = swoole_server_task_fetch_object(Z_OBJ_P(zobject));
+    server_task_t *task = php_swoole_server_task_fetch_object(Z_OBJ_P(zobject));
     if (!task->serv)
     {
         php_swoole_fatal_error(E_ERROR, "Invaild instance of %s", SW_Z_OBJCE_NAME_VAL_P(zobject));
@@ -337,15 +337,15 @@ static sw_inline swDataHead* php_swoole_server_task_get_info(zval *zobject)
 
 static sw_inline void php_swoole_server_task_set_info(zval *zobject, swDataHead *info)
 {
-    swoole_server_task_fetch_object(Z_OBJ_P(zobject))->info = *info;
+    php_swoole_server_task_fetch_object(Z_OBJ_P(zobject))->info = *info;
 }
 
-static void swoole_server_task_free_object(zend_object *object)
+static void php_swoole_server_task_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_server_task_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_server_task_create_object(zend_class_entry *ce)
 {
     server_task_t *server_task = (server_task_t *) ecalloc(1, sizeof(server_task_t) + zend_object_properties_size(ce));
     zend_object_std_init(&server_task->std, ce);
@@ -666,7 +666,7 @@ void php_swoole_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_server, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_server, swoole_server_create_object, swoole_server_free_object, server_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_server, php_swoole_server_create_object, php_swoole_server_free_object, server_t, std);
 
     SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "after", &swoole_server_ce->function_table, "after");
     SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "tick", &swoole_server_ce->function_table, "tick");
@@ -679,13 +679,13 @@ void php_swoole_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_server_task, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_server_task, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server_task, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_AND_FREE(swoole_server_task, swoole_server_task_create_object, swoole_server_task_free_object);
+    SW_SET_CLASS_CREATE_AND_FREE(swoole_server_task, php_swoole_server_task_create_object, php_swoole_server_task_free_object);
 
     SW_INIT_CLASS_ENTRY(swoole_connection_iterator, "Swoole\\Connection\\Iterator", "swoole_connection_iterator", NULL, swoole_connection_iterator_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_connection_iterator, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_connection_iterator, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_connection_iterator, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_connection_iterator, swoole_connection_iterator_create_object, swoole_connection_iterator_free_object, connection_iterator_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_connection_iterator, php_swoole_connection_iterator_create_object, php_swoole_connection_iterator_free_object, connection_iterator_t, std);
     zend_class_implements(swoole_connection_iterator_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #ifdef SW_HAVE_COUNTABLE
     zend_class_implements(swoole_connection_iterator_ce, 1, zend_ce_countable);

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -740,22 +740,9 @@ void php_swoole_get_recv_data(swServer *serv, zval *zdata, swEventData *req, cha
 
 size_t php_swoole_get_send_data(zval *zdata, char **str)
 {
-    size_t length;
-
-    if (Z_TYPE_P(zdata) == IS_OBJECT && instanceof_function(Z_OBJCE_P(zdata), swoole_buffer_ce))
-    {
-        swString *str_buffer = (swString *) swoole_get_object(zdata);
-        length = str_buffer->length - str_buffer->offset;
-        *str = str_buffer->str + str_buffer->offset;
-    }
-    else
-    {
-        convert_to_string(zdata);
-        length = Z_STRLEN_P(zdata);
-        *str = Z_STRVAL_P(zdata);
-    }
-
-    return length;
+    convert_to_string(zdata);
+    *str = Z_STRVAL_P(zdata);
+    return Z_STRLEN_P(zdata);
 }
 
 static sw_inline int php_swoole_check_task_param(swServer *serv, zend_long dst_worker_id)

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -438,9 +438,6 @@ static inline zend_bool php_swoole_server_isset_callback(swListenPort *port, int
 static void swoole_server_task_free_object(zend_object *object)
 {
     uint32_t handle = object->handle;
-    zval _zobject, *zobject = &_zobject;
-    ZVAL_OBJ(zobject, object);
-
     swDataHead *info = (swDataHead *) swoole_get_property_by_handle(handle, 0);
     efree(info);
     swoole_set_property_by_handle(handle, 0, NULL);

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -3360,6 +3360,8 @@ static PHP_METHOD(swoole_server, taskwait)
     }
 
     swEventData buf;
+    memset(&buf.info, 0, sizeof(buf.info));
+
     zval *zdata;
     double timeout = SW_TASKWAIT_TIMEOUT;
     zend_long dst_worker_id = -1;
@@ -3455,6 +3457,8 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
     }
 
     swEventData buf;
+    memset(&buf.info, 0, sizeof(buf.info));
+
     zval *ztasks;
     zval *ztask;
     double timeout = SW_TASKWAIT_TIMEOUT;
@@ -3618,6 +3622,7 @@ static PHP_METHOD(swoole_server, taskCo)
     int task_id;
     int i = 0;
     uint32_t n_task = php_swoole_array_length(ztasks);
+
     swEventData buf;
     memset(&buf.info, 0, sizeof(buf.info));
 
@@ -3763,9 +3768,14 @@ static PHP_METHOD(swoole_server, sendMessage)
         php_swoole_fatal_error(E_WARNING, "server is not running");
         RETURN_FALSE;
     }
+    if (!serv->onPipeMessage)
+    {
+        php_swoole_fatal_error(E_WARNING, "onPipeMessage is null, can't use sendMessage");
+        RETURN_FALSE;
+    }
 
     zval *zmessage;
-    long worker_id = -1;
+    zend_long worker_id = -1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "zl", &zmessage, &worker_id) == FAILURE)
     {
@@ -3777,16 +3787,9 @@ static PHP_METHOD(swoole_server, sendMessage)
         php_swoole_fatal_error(E_WARNING, "can't send messages to self");
         RETURN_FALSE;
     }
-
     if (worker_id >= serv->worker_num + serv->task_worker_num)
     {
         php_swoole_fatal_error(E_WARNING, "worker_id[%d] is invalid", (int) worker_id);
-        RETURN_FALSE;
-    }
-
-    if (!serv->onPipeMessage)
-    {
-        php_swoole_fatal_error(E_WARNING, "onPipeMessage is null, can't use sendMessage");
         RETURN_FALSE;
     }
 
@@ -3849,7 +3852,9 @@ static PHP_METHOD(swoole_server_task, finish)
 
 static PHP_METHOD(swoole_server_task, pack)
 {
-    swEventData buf = {{0}};
+    swEventData buf;
+    memset(&buf.info, 0, sizeof(buf.info));
+
     zval *zdata;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -4364,12 +4369,3 @@ static PHP_METHOD(swoole_connection_iterator, offsetGet)
 static PHP_METHOD(swoole_connection_iterator, offsetSet) { }
 static PHP_METHOD(swoole_connection_iterator, offsetUnset) { }
 static PHP_METHOD(swoole_connection_iterator, __destruct) { }
-
-/*
- * Local variables:
- * tab-width: 4
- * c-basic-offset: 4
- * End:
- * vim600: noet sw=4 ts=4 fdm=marker
- * vim<600: noet sw=4 ts=4
- */

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -2061,7 +2061,7 @@ static PHP_METHOD(swoole_server, __construct)
     swServer *serv = swoole_server_get_server(ZEND_THIS);
     if (serv)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     zval *zserv = ZEND_THIS;

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -679,7 +679,7 @@ void php_swoole_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_server_task, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_server_task, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server_task, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_AND_FREE(swoole_server_task, php_swoole_server_task_create_object, php_swoole_server_task_free_object);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_server_task, php_swoole_server_task_create_object, php_swoole_server_task_free_object, server_task_t, std);
 
     SW_INIT_CLASS_ENTRY(swoole_connection_iterator, "Swoole\\Connection\\Iterator", "swoole_connection_iterator", NULL, swoole_connection_iterator_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_connection_iterator, zend_class_serialize_deny, zend_class_unserialize_deny);
@@ -3753,11 +3753,9 @@ static PHP_METHOD(swoole_server, task)
     {
         RETURN_LONG(buf.info.fd);
     }
-    else
-    {
-        sw_atomic_fetch_sub(&serv->stats->tasking_num, 1);
-        RETURN_FALSE;
-    }
+
+    sw_atomic_fetch_sub(&serv->stats->tasking_num, 1);
+    RETURN_FALSE;
 }
 
 static PHP_METHOD(swoole_server, sendMessage)

--- a/swoole_server_port.cc
+++ b/swoole_server_port.cc
@@ -43,7 +43,7 @@ static zend_object_handlers swoole_server_port_handlers;
 typedef struct
 {
     swListenPort *port;
-    swoole_server_port_property property;
+    php_swoole_server_port_property property;
     zend_object std;
 } server_port_t;
 
@@ -52,14 +52,14 @@ static sw_inline server_port_t* swoole_server_port_fetch_object(zend_object *obj
     return (server_port_t *) ((char *) obj - swoole_server_port_handlers.offset);
 }
 
-static sw_inline swListenPort* swoole_server_port_get_ptr(zval *zobject)
+static sw_inline swListenPort* php_swoole_server_port_get_ptr(zval *zobject)
 {
     return swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port;
 }
 
-swListenPort* swoole_server_port_get_and_check_ptr(zval *zobject)
+swListenPort* php_swoole_server_port_get_and_check_ptr(zval *zobject)
 {
-    swListenPort* port = swoole_server_port_get_ptr(zobject);
+    swListenPort* port = php_swoole_server_port_get_ptr(zobject);
     if (UNEXPECTED(!port))
     {
         php_swoole_fatal_error(E_ERROR, "Invaild instance of %s", SW_Z_OBJCE_NAME_VAL_P(zobject));
@@ -67,19 +67,19 @@ swListenPort* swoole_server_port_get_and_check_ptr(zval *zobject)
     return port;
 }
 
-void swoole_server_port_set_ptr(zval *zobject, swListenPort *port)
+void php_swoole_server_port_set_ptr(zval *zobject, swListenPort *port)
 {
     swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port = port;
 }
 
-swoole_server_port_property* swoole_server_port_get_property(zval *zobject)
+php_swoole_server_port_property* php_swoole_server_port_get_property(zval *zobject)
 {
     return &swoole_server_port_fetch_object(Z_OBJ_P(zobject))->property;
 }
 
-static swoole_server_port_property* swoole_server_port_get_and_check_property(zval *zobject)
+static php_swoole_server_port_property* php_swoole_server_port_get_and_check_property(zval *zobject)
 {
-    swoole_server_port_property* property = swoole_server_port_get_property(zobject);
+    php_swoole_server_port_property* property = php_swoole_server_port_get_property(zobject);
     if (UNEXPECTED(!property->serv))
     {
         php_swoole_fatal_error(E_ERROR, "Invaild instance of %s", SW_Z_OBJCE_NAME_VAL_P(zobject));
@@ -91,7 +91,7 @@ static void swoole_server_port_free_object(zend_object *object)
 {
     server_port_t *server_port = swoole_server_port_fetch_object(object);
 
-    swoole_server_port_property *property = &server_port->property;
+    php_swoole_server_port_property *property = &server_port->property;
     if (property->serv)
     {
         for (int j = 0; j < PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM; j++)
@@ -251,8 +251,8 @@ static PHP_METHOD(swoole_server_port, set)
 
     vht = Z_ARRVAL_P(zset);
 
-    swListenPort *port = swoole_server_port_get_and_check_ptr(ZEND_THIS);
-    swoole_server_port_property *property = swoole_server_port_get_and_check_property(ZEND_THIS);
+    swListenPort *port = php_swoole_server_port_get_and_check_ptr(ZEND_THIS);
+    php_swoole_server_port_property *property = php_swoole_server_port_get_and_check_property(ZEND_THIS);
 
     if (port == NULL || property == NULL)
     {
@@ -661,7 +661,7 @@ static PHP_METHOD(swoole_server_port, on)
     size_t len, i;
     zval *cb;
 
-    swoole_server_port_property *property = swoole_server_port_get_and_check_property(ZEND_THIS);
+    php_swoole_server_port_property *property = php_swoole_server_port_get_and_check_property(ZEND_THIS);
     swServer *serv = property->serv;
     if (serv->gs->start > 0)
     {
@@ -781,7 +781,7 @@ static PHP_METHOD(swoole_server_port, getCallback)
 #ifdef SWOOLE_SOCKETS_SUPPORT
 static PHP_METHOD(swoole_server_port, getSocket)
 {
-    swListenPort *port = swoole_server_port_get_and_check_ptr(ZEND_THIS);
+    swListenPort *port = php_swoole_server_port_get_and_check_ptr(ZEND_THIS);
     php_socket *socket_object = swoole_convert_to_socket(port->sock);
     if (!socket_object)
     {

--- a/swoole_server_port.cc
+++ b/swoole_server_port.cc
@@ -47,14 +47,14 @@ typedef struct
     zend_object std;
 } server_port_t;
 
-static sw_inline server_port_t* swoole_server_port_fetch_object(zend_object *obj)
+static sw_inline server_port_t* php_swoole_server_port_fetch_object(zend_object *obj)
 {
     return (server_port_t *) ((char *) obj - swoole_server_port_handlers.offset);
 }
 
 static sw_inline swListenPort* php_swoole_server_port_get_ptr(zval *zobject)
 {
-    return swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port;
+    return php_swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port;
 }
 
 swListenPort* php_swoole_server_port_get_and_check_ptr(zval *zobject)
@@ -69,12 +69,12 @@ swListenPort* php_swoole_server_port_get_and_check_ptr(zval *zobject)
 
 void php_swoole_server_port_set_ptr(zval *zobject, swListenPort *port)
 {
-    swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port = port;
+    php_swoole_server_port_fetch_object(Z_OBJ_P(zobject))->port = port;
 }
 
 php_swoole_server_port_property* php_swoole_server_port_get_property(zval *zobject)
 {
-    return &swoole_server_port_fetch_object(Z_OBJ_P(zobject))->property;
+    return &php_swoole_server_port_fetch_object(Z_OBJ_P(zobject))->property;
 }
 
 static php_swoole_server_port_property* php_swoole_server_port_get_and_check_property(zval *zobject)
@@ -87,9 +87,9 @@ static php_swoole_server_port_property* php_swoole_server_port_get_and_check_pro
     return property;
 }
 
-static void swoole_server_port_free_object(zend_object *object)
+static void php_swoole_server_port_free_object(zend_object *object)
 {
-    server_port_t *server_port = swoole_server_port_fetch_object(object);
+    server_port_t *server_port = php_swoole_server_port_fetch_object(object);
 
     php_swoole_server_port_property *property = &server_port->property;
     if (property->serv)
@@ -118,7 +118,7 @@ static void swoole_server_port_free_object(zend_object *object)
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_server_port_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_server_port_create_object(zend_class_entry *ce)
 {
     server_port_t *server_port = (server_port_t *) ecalloc(1, sizeof(server_port_t) + zend_object_properties_size(ce));
     zend_object_std_init(&server_port->std, ce);
@@ -172,7 +172,7 @@ void php_swoole_server_port_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_server_port, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_server_port, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server_port, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_server_port, swoole_server_port_create_object, swoole_server_port_free_object, server_port_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_server_port, php_swoole_server_port_create_object, php_swoole_server_port_free_object, server_port_t, std);
 
     zend_declare_property_null(swoole_server_port_ce, ZEND_STRL("onConnect"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(swoole_server_port_ce, ZEND_STRL("onReceive"), ZEND_ACC_PRIVATE);

--- a/swoole_socket_coro.cc
+++ b/swoole_socket_coro.cc
@@ -170,7 +170,7 @@ static const zend_function_entry swoole_socket_coro_methods[] =
 
 #define SW_BAD_SOCKET ((Socket *)-1)
 #define swoole_get_socket_coro(_sock, _zobject) \
-        socket_coro* _sock = swoole_socket_coro_fetch_object(Z_OBJ_P(_zobject)); \
+        socket_coro* _sock = php_swoole_socket_coro_fetch_object(Z_OBJ_P(_zobject)); \
         if (UNEXPECTED(!sock->socket)) \
         { \
             php_swoole_fatal_error(E_ERROR, "you must call Socket constructor first"); \
@@ -181,14 +181,14 @@ static const zend_function_entry swoole_socket_coro_methods[] =
             RETURN_FALSE; \
         }
 
-static sw_inline socket_coro* swoole_socket_coro_fetch_object(zend_object *obj)
+static sw_inline socket_coro* php_swoole_socket_coro_fetch_object(zend_object *obj)
 {
     return (socket_coro *) ((char *) obj - swoole_socket_coro_handlers.offset);
 }
 
-static void swoole_socket_coro_free_object(zend_object *object)
+static void php_swoole_socket_coro_free_object(zend_object *object)
 {
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(object);
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(object);
     if (!sock->reference && sock->socket && sock->socket != SW_BAD_SOCKET)
     {
         sock->socket->close();
@@ -197,7 +197,7 @@ static void swoole_socket_coro_free_object(zend_object *object)
     zend_object_std_dtor(&sock->std);
 }
 
-static zend_object* swoole_socket_coro_create_object(zend_class_entry *ce)
+static zend_object* php_swoole_socket_coro_create_object(zend_class_entry *ce)
 {
     socket_coro *sock = (socket_coro *) ecalloc(1, sizeof(socket_coro) + zend_object_properties_size(ce));
     zend_object_std_init(&sock->std, ce);
@@ -752,7 +752,7 @@ void php_swoole_socket_coro_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_socket_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_socket_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_socket_coro, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_socket_coro, swoole_socket_coro_create_object, swoole_socket_coro_free_object, socket_coro, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_socket_coro, php_swoole_socket_coro_create_object, php_swoole_socket_coro_free_object, socket_coro, std);
 
     zend_declare_property_long(swoole_socket_coro_ce, ZEND_STRL("fd"), -1, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_socket_coro_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);
@@ -782,13 +782,13 @@ static void sw_inline php_swoole_init_socket(zval *zobject, socket_coro *sock)
 
 SW_API bool php_swoole_export_socket(zval *zobject, Socket *_socket)
 {
-    zend_object *object = swoole_socket_coro_create_object(swoole_socket_coro_ce);
+    zend_object *object = php_swoole_socket_coro_create_object(swoole_socket_coro_ce);
     if (!object)
     {
         return false;
     }
 
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(object);
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(object);
     sock->reference = 1;
     sock->socket = _socket;
 
@@ -799,8 +799,8 @@ SW_API bool php_swoole_export_socket(zval *zobject, Socket *_socket)
 
 SW_API zend_object* php_swoole_dup_socket(int fd, enum swSocket_type type)
 {
-    zend_object *object = swoole_socket_coro_create_object(swoole_socket_coro_ce);
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(object);
+    zend_object *object = php_swoole_socket_coro_create_object(swoole_socket_coro_ce);
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(object);
 
     php_swoole_check_reactor();
     int new_fd = dup(fd);
@@ -824,14 +824,14 @@ SW_API zend_object* php_swoole_dup_socket(int fd, enum swSocket_type type)
 SW_API Socket* php_swoole_get_socket(zval *zobject)
 {
     SW_ASSERT(Z_OBJCE_P(zobject) == swoole_socket_coro_ce);
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(Z_OBJ_P(zobject));
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(Z_OBJ_P(zobject));
     return sock->socket;
 }
 
 SW_API void php_swoole_init_socket_object(zval *zobject, Socket *socket)
 {
-    zend_object *object = swoole_socket_coro_create_object(swoole_socket_coro_ce);
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(object);
+    zend_object *object = php_swoole_socket_coro_create_object(swoole_socket_coro_ce);
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(object);
     sock->socket = socket;
     ZVAL_OBJ(zobject, object);
     php_swoole_init_socket(zobject, sock);
@@ -1000,7 +1000,7 @@ static PHP_METHOD(swoole_socket_coro, __construct)
         Z_PARAM_LONG(protocol)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    socket_coro *sock = (socket_coro *) swoole_socket_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
+    socket_coro *sock = (socket_coro *) php_swoole_socket_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
 
     if (EXPECTED(!sock->socket))
     {
@@ -1075,8 +1075,8 @@ static PHP_METHOD(swoole_socket_coro, accept)
     Socket *conn = sock->socket->accept(timeout);
     if (conn)
     {
-        zend_object *client = swoole_socket_coro_create_object(swoole_socket_coro_ce);
-        socket_coro *client_sock = (socket_coro *) swoole_socket_coro_fetch_object(client);
+        zend_object *client = php_swoole_socket_coro_create_object(swoole_socket_coro_ce);
+        socket_coro *client_sock = (socket_coro *) php_swoole_socket_coro_fetch_object(client);
         client_sock->socket = conn;
         ZVAL_OBJ(return_value, &client_sock->std);
         php_swoole_init_socket(return_value, client_sock);

--- a/swoole_table.cc
+++ b/swoole_table.cc
@@ -388,7 +388,7 @@ PHP_METHOD(swoole_table, __construct)
     swTable *table = swoole_table_get_ptr(ZEND_THIS);
     if (table)
     {
-        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+        php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
     }
 
     zend_long table_size;

--- a/swoole_table.cc
+++ b/swoole_table.cc
@@ -18,11 +18,210 @@
 
 #include "table.h"
 
+static inline void php_swoole_table_row2array(swTable *table, swTableRow *row, zval *return_value)
+{
+    array_init(return_value);
+
+    swTableColumn *col = NULL;
+    swTable_string_length_t vlen = 0;
+    double dval = 0;
+    int64_t lval = 0;
+    char *k;
+
+    swHashMap_rewind(table->columns);
+    while(1)
+    {
+        col = (swTableColumn *) swHashMap_each(table->columns, &k);
+        if (col == NULL)
+        {
+            break;
+        }
+        if (col->type == SW_TABLE_STRING)
+        {
+            memcpy(&vlen, row->data + col->index, sizeof(swTable_string_length_t));
+            add_assoc_stringl_ex(return_value, col->name->str, col->name->length, row->data + col->index + sizeof(swTable_string_length_t), vlen);
+        }
+        else if (col->type == SW_TABLE_FLOAT)
+        {
+            memcpy(&dval, row->data + col->index, sizeof(dval));
+            add_assoc_double_ex(return_value, col->name->str, col->name->length, dval);
+        }
+        else
+        {
+            switch (col->type)
+            {
+            case SW_TABLE_INT8:
+                memcpy(&lval, row->data + col->index, 1);
+                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int8_t) lval);
+                break;
+            case SW_TABLE_INT16:
+                memcpy(&lval, row->data + col->index, 2);
+                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int16_t) lval);
+                break;
+            case SW_TABLE_INT32:
+                memcpy(&lval, row->data + col->index, 4);
+                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int32_t) lval);
+                break;
+            default:
+                memcpy(&lval, row->data + col->index, 8);
+                add_assoc_long_ex(return_value, col->name->str, col->name->length, lval);
+                break;
+            }
+        }
+    }
+}
+
+static inline void php_swoole_table_get_field_value(swTable *table, swTableRow *row, zval *return_value, char *field, uint16_t field_len)
+{
+    swTable_string_length_t vlen = 0;
+    double dval = 0;
+    int64_t lval = 0;
+
+    swTableColumn *col = (swTableColumn *) swHashMap_find(table->columns, field, field_len);
+    if (!col)
+    {
+        ZVAL_FALSE(return_value);
+        return;
+    }
+    if (col->type == SW_TABLE_STRING)
+    {
+        memcpy(&vlen, row->data + col->index, sizeof(swTable_string_length_t));
+        ZVAL_STRINGL(return_value, row->data + col->index + sizeof(swTable_string_length_t), vlen);
+    }
+    else if (col->type == SW_TABLE_FLOAT)
+    {
+        memcpy(&dval, row->data + col->index, sizeof(dval));
+        ZVAL_DOUBLE(return_value, dval);
+    }
+    else
+    {
+        switch (col->type)
+        {
+        case SW_TABLE_INT8:
+            memcpy(&lval, row->data + col->index, 1);
+            ZVAL_LONG(return_value, (int8_t) lval);
+            break;
+        case SW_TABLE_INT16:
+            memcpy(&lval, row->data + col->index, 2);
+            ZVAL_LONG(return_value, (int16_t) lval);
+            break;
+        case SW_TABLE_INT32:
+            memcpy(&lval, row->data + col->index, 4);
+            ZVAL_LONG(return_value, (int32_t) lval);
+            break;
+        default:
+            memcpy(&lval, row->data + col->index, 8);
+            ZVAL_LONG(return_value, lval);
+            break;
+        }
+    }
+}
+
 static zend_class_entry *swoole_table_ce;
 static zend_object_handlers swoole_table_handlers;
 
 static zend_class_entry *swoole_table_row_ce;
 static zend_object_handlers swoole_table_row_handlers;
+
+typedef struct
+{
+    swTable *ptr;
+    zend_object std;
+} table_t;
+
+static sw_inline table_t* swoole_table_fetch_object(zend_object *obj)
+{
+    return (table_t *) ((char *) obj - swoole_table_handlers.offset);
+}
+
+static swTable * swoole_table_get_ptr(zval *zobject)
+{
+    return swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+static swTable * swoole_table_get_and_check_ptr(zval *zobject)
+{
+    swTable *table = swoole_table_get_ptr(zobject);
+    if (!table)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Table constructor first");
+    }
+    return table;
+}
+
+static swTable * swoole_table_get_and_check_ptr2(zval *zobject)
+{
+    swTable *table = swoole_table_get_and_check_ptr(zobject);
+    if (!table->memory)
+    {
+        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
+    }
+    return table;
+}
+
+void swoole_table_set_ptr(zval *zobject, swTable *ptr)
+{
+    swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_table_free_object(zend_object *object)
+{
+    zend_object_std_dtor(object);
+}
+
+static zend_object *swoole_table_create_object(zend_class_entry *ce)
+{
+    table_t *table = (table_t *) ecalloc(1, sizeof(table_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&table->std, ce);
+    object_properties_init(&table->std, ce);
+    table->std.handlers = &swoole_table_handlers;
+    return &table->std;
+}
+
+typedef struct
+{
+    swTable *ptr;
+    zend_object std;
+} table_row_t;
+
+static sw_inline table_row_t* swoole_table_row_fetch_object(zend_object *obj)
+{
+    return (table_row_t *) ((char *) obj - swoole_table_row_handlers.offset);
+}
+
+static swTable * swoole_table_row_get_ptr(zval *zobject)
+{
+    return swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr;
+}
+
+static swTable * swoole_table_row_get_and_check_ptr(zval *zobject)
+{
+    swTable *table_row = swoole_table_row_get_ptr(zobject);
+    if (!table_row)
+    {
+        php_swoole_fatal_error(E_ERROR, "you must call Lock constructor first");
+    }
+    return table_row;
+}
+
+void swoole_table_row_set_ptr(zval *zobject, swTable *ptr)
+{
+    swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+}
+
+static void swoole_table_row_free_object(zend_object *object)
+{
+    zend_object_std_dtor(object);
+}
+
+static zend_object *swoole_table_row_create_object(zend_class_entry *ce)
+{
+    table_row_t *table_row = (table_row_t *) ecalloc(1, sizeof(table_row_t) + zend_object_properties_size(ce));
+    zend_object_std_init(&table_row->std, ce);
+    object_properties_init(&table_row->std, ce);
+    table_row->std.handlers = &swoole_table_row_handlers;
+    return &table_row->std;
+}
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_table_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -152,112 +351,13 @@ static const zend_function_entry swoole_table_row_methods[] =
     PHP_FE_END
 };
 
-static inline void php_swoole_table_row2array(swTable *table, swTableRow *row, zval *return_value)
-{
-    array_init(return_value);
-
-    swTableColumn *col = NULL;
-    swTable_string_length_t vlen = 0;
-    double dval = 0;
-    int64_t lval = 0;
-    char *k;
-
-    swHashMap_rewind(table->columns);
-    while(1)
-    {
-        col = (swTableColumn *) swHashMap_each(table->columns, &k);
-        if (col == NULL)
-        {
-            break;
-        }
-        if (col->type == SW_TABLE_STRING)
-        {
-            memcpy(&vlen, row->data + col->index, sizeof(swTable_string_length_t));
-            add_assoc_stringl_ex(return_value, col->name->str, col->name->length, row->data + col->index + sizeof(swTable_string_length_t), vlen);
-        }
-        else if (col->type == SW_TABLE_FLOAT)
-        {
-            memcpy(&dval, row->data + col->index, sizeof(dval));
-            add_assoc_double_ex(return_value, col->name->str, col->name->length, dval);
-        }
-        else
-        {
-            switch (col->type)
-            {
-            case SW_TABLE_INT8:
-                memcpy(&lval, row->data + col->index, 1);
-                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int8_t) lval);
-                break;
-            case SW_TABLE_INT16:
-                memcpy(&lval, row->data + col->index, 2);
-                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int16_t) lval);
-                break;
-            case SW_TABLE_INT32:
-                memcpy(&lval, row->data + col->index, 4);
-                add_assoc_long_ex(return_value, col->name->str, col->name->length, (int32_t) lval);
-                break;
-            default:
-                memcpy(&lval, row->data + col->index, 8);
-                add_assoc_long_ex(return_value, col->name->str, col->name->length, lval);
-                break;
-            }
-        }
-    }
-}
-
-static inline void php_swoole_table_get_field_value(swTable *table, swTableRow *row, zval *return_value, char *field, uint16_t field_len)
-{
-    swTable_string_length_t vlen = 0;
-    double dval = 0;
-    int64_t lval = 0;
-
-    swTableColumn *col = (swTableColumn *) swHashMap_find(table->columns, field, field_len);
-    if (!col)
-    {
-        ZVAL_FALSE(return_value);
-        return;
-    }
-    if (col->type == SW_TABLE_STRING)
-    {
-        memcpy(&vlen, row->data + col->index, sizeof(swTable_string_length_t));
-        ZVAL_STRINGL(return_value, row->data + col->index + sizeof(swTable_string_length_t), vlen);
-    }
-    else if (col->type == SW_TABLE_FLOAT)
-    {
-        memcpy(&dval, row->data + col->index, sizeof(dval));
-        ZVAL_DOUBLE(return_value, dval);
-    }
-    else
-    {
-        switch (col->type)
-        {
-        case SW_TABLE_INT8:
-            memcpy(&lval, row->data + col->index, 1);
-            ZVAL_LONG(return_value, (int8_t) lval);
-            break;
-        case SW_TABLE_INT16:
-            memcpy(&lval, row->data + col->index, 2);
-            ZVAL_LONG(return_value, (int16_t) lval);
-            break;
-        case SW_TABLE_INT32:
-            memcpy(&lval, row->data + col->index, 4);
-            ZVAL_LONG(return_value, (int32_t) lval);
-            break;
-        default:
-            memcpy(&lval, row->data + col->index, 8);
-            ZVAL_LONG(return_value, lval);
-            break;
-        }
-    }
-}
-
 void php_swoole_table_minit(int module_number)
 {
     SW_INIT_CLASS_ENTRY(swoole_table, "Swoole\\Table", "swoole_table", NULL, swoole_table_methods);
     SW_SET_CLASS_SERIALIZABLE(swoole_table, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_table, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_table, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_table);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table, swoole_table_create_object, swoole_table_free_object, table_t, std);
     zend_class_implements(swoole_table_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #ifdef SW_HAVE_COUNTABLE
     zend_class_implements(swoole_table_ce, 1, zend_ce_countable);
@@ -271,7 +371,7 @@ void php_swoole_table_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_table_row, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_table_row, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_table_row, sw_zend_class_unset_property_deny);
-    // SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_table_row);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table_row, swoole_table_row_create_object, swoole_table_row_free_object, table_row_t, std);
     zend_class_implements(swoole_table_row_ce, 1, zend_ce_arrayaccess);
 
     zend_declare_property_null(swoole_table_row_ce, ZEND_STRL("key"), ZEND_ACC_PUBLIC);
@@ -285,6 +385,12 @@ void swoole_table_column_free(swTableColumn *col)
 
 PHP_METHOD(swoole_table, __construct)
 {
+    swTable *table = swoole_table_get_ptr(ZEND_THIS);
+    if (table)
+    {
+        php_swoole_fatal_error(E_ERROR, "constructor can only be called once");
+    }
+
     zend_long table_size;
     double conflict_proportion = SW_TABLE_CONFLICT_PROPORTION;
 
@@ -294,17 +400,18 @@ PHP_METHOD(swoole_table, __construct)
         Z_PARAM_DOUBLE(conflict_proportion)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    swTable *table = swTable_new(table_size, conflict_proportion);
+    table = swTable_new(table_size, conflict_proportion);
     if (table == NULL)
     {
         zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
-    swoole_set_object(ZEND_THIS, table);
+    swoole_table_set_ptr(ZEND_THIS, table);
 }
 
 PHP_METHOD(swoole_table, column)
 {
+    swTable *table = swoole_table_get_and_check_ptr(ZEND_THIS);
     char *name;
     size_t len;
     long type;
@@ -328,10 +435,9 @@ PHP_METHOD(swoole_table, column)
     {
         size = 4;
     }
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
     if (table->memory)
     {
-        php_swoole_fatal_error(E_WARNING, "can't add column after the creation of swoole table");
+        php_swoole_fatal_error(E_WARNING, "unable to add column after table has been created");
         RETURN_FALSE;
     }
     swTableColumn_add(table, name, len, type, size);
@@ -340,12 +446,8 @@ PHP_METHOD(swoole_table, column)
 
 static PHP_METHOD(swoole_table, create)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (table->memory)
-    {
-        php_swoole_fatal_error(E_WARNING, "the swoole table has been created already");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr(ZEND_THIS);
+
     if (swTable_create(table) < 0)
     {
         php_swoole_fatal_error(E_ERROR, "unable to allocate memory");
@@ -358,12 +460,7 @@ static PHP_METHOD(swoole_table, create)
 
 static PHP_METHOD(swoole_table, destroy)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
 
     swTable_free(table);
     RETURN_TRUE;
@@ -371,6 +468,7 @@ static PHP_METHOD(swoole_table, destroy)
 
 static PHP_METHOD(swoole_table, set)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     zval *array;
     char *key;
     size_t keylen;
@@ -380,7 +478,6 @@ static PHP_METHOD(swoole_table, set)
         RETURN_FALSE;
     }
 
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
     if (!table->memory)
     {
         php_swoole_fatal_error(E_ERROR, "the table object does not exist");
@@ -445,6 +542,7 @@ static PHP_METHOD(swoole_table, offsetSet)
 
 static PHP_METHOD(swoole_table, incr)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -457,13 +555,6 @@ static PHP_METHOD(swoole_table, incr)
     }
 
     swTableRow *_rowlock = NULL;
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
-
     swTableRow *row = swTableRow_set(table, key, key_len, &_rowlock);
     if (!row)
     {
@@ -521,6 +612,7 @@ static PHP_METHOD(swoole_table, incr)
 
 static PHP_METHOD(swoole_table, decr)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -533,13 +625,6 @@ static PHP_METHOD(swoole_table, decr)
     }
 
     swTableRow *_rowlock = NULL;
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
-
     swTableRow *row = swTableRow_set(table, key, key_len, &_rowlock);
     if (!row)
     {
@@ -597,6 +682,7 @@ static PHP_METHOD(swoole_table, decr)
 
 static PHP_METHOD(swoole_table, get)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
     char *field = NULL;
@@ -608,13 +694,6 @@ static PHP_METHOD(swoole_table, get)
     }
 
     swTableRow *_rowlock = NULL;
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
-
     swTableRow *row = swTableRow_get(table, key, keylen, &_rowlock);
     if (!row)
     {
@@ -633,6 +712,7 @@ static PHP_METHOD(swoole_table, get)
 
 static PHP_METHOD(swoole_table, offsetGet)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
     char *field = NULL;
@@ -643,16 +723,8 @@ static PHP_METHOD(swoole_table, offsetGet)
         RETURN_FALSE;
     }
 
-    swTableRow *_rowlock = NULL;
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "Must create table first");
-        RETURN_FALSE;
-    }
-
     zval value;
-
+    swTableRow *_rowlock = NULL;
     swTableRow *row = swTableRow_get(table, key, keylen, &_rowlock);
     if (!row)
     {
@@ -668,11 +740,12 @@ static PHP_METHOD(swoole_table, offsetGet)
     zend_update_property(swoole_table_row_ce, return_value, ZEND_STRL("value"), &value);
     zend_update_property_stringl(swoole_table_row_ce, return_value, ZEND_STRL("key"), key, keylen);
     zval_ptr_dtor(&value);
-    swoole_set_object(return_value, table);
+    swoole_table_row_set_ptr(return_value, table);
 }
 
 static PHP_METHOD(swoole_table, exists)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
@@ -681,12 +754,6 @@ static PHP_METHOD(swoole_table, exists)
         RETURN_FALSE;
     }
 
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
 
     swTableRow *_rowlock = NULL;
     swTableRow *row = swTableRow_get(table, key, keylen, &_rowlock);
@@ -708,6 +775,7 @@ static PHP_METHOD(swoole_table, offsetExists)
 
 static PHP_METHOD(swoole_table, del)
 {
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
@@ -716,12 +784,6 @@ static PHP_METHOD(swoole_table, del)
         RETURN_FALSE;
     }
 
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
     SW_CHECK_RETURN(swTableRow_del(table, key, keylen));
 }
 
@@ -735,17 +797,11 @@ static PHP_METHOD(swoole_table, count)
     #define COUNT_NORMAL            0
     #define COUNT_RECURSIVE         1
 
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     long mode = COUNT_NORMAL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &mode) == FAILURE)
     {
-        RETURN_FALSE;
-    }
-
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
         RETURN_FALSE;
     }
 
@@ -761,8 +817,13 @@ static PHP_METHOD(swoole_table, count)
 
 static PHP_METHOD(swoole_table, getMemorySize)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
+    swTable *table = swoole_table_get_ptr(ZEND_THIS);
+
+    if (!table)
+    {
+        RETURN_LONG(0);
+    }
+    else if (!table->memory)
     {
         RETURN_LONG(swTable_get_memory_size(table));
     }
@@ -774,24 +835,14 @@ static PHP_METHOD(swoole_table, getMemorySize)
 
 static PHP_METHOD(swoole_table, rewind)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTable_iterator_rewind(table);
     swTable_iterator_forward(table);
 }
 
 static PHP_METHOD(swoole_table, current)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     if (row)
     {
@@ -807,12 +858,7 @@ static PHP_METHOD(swoole_table, current)
 
 static PHP_METHOD(swoole_table, key)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     if (row)
     {
@@ -828,23 +874,13 @@ static PHP_METHOD(swoole_table, key)
 
 static PHP_METHOD(swoole_table, next)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTable_iterator_forward(table);
 }
 
 static PHP_METHOD(swoole_table, valid)
 {
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (!table->memory)
-    {
-        php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
-        RETURN_FALSE;
-    }
+    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     RETURN_BOOL(row != NULL);
 }
@@ -884,19 +920,13 @@ static PHP_METHOD(swoole_table_row, offsetGet)
 
 static PHP_METHOD(swoole_table_row, offsetSet)
 {
+    swTable *table = swoole_table_row_get_and_check_ptr(ZEND_THIS);
     zval *value;
     char *key;
     size_t keylen;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz", &key, &keylen, &value) == FAILURE)
     {
-        RETURN_FALSE;
-    }
-
-    swTable *table = (swTable *) swoole_get_object(ZEND_THIS);
-    if (table == NULL || table->memory == NULL)
-    {
-        php_swoole_fatal_error(E_ERROR, "Must create table first");
         RETURN_FALSE;
     }
 
@@ -950,9 +980,4 @@ static PHP_METHOD(swoole_table_row, offsetUnset)
     RETURN_FALSE;
 }
 
-static PHP_METHOD(swoole_table_row, __destruct)
-{
-    SW_PREVENT_USER_DESTRUCT();
-
-    swoole_set_object(ZEND_THIS, NULL);
-}
+static PHP_METHOD(swoole_table_row, __destruct) { }

--- a/swoole_table.cc
+++ b/swoole_table.cc
@@ -199,7 +199,7 @@ static swTable * swoole_table_row_get_and_check_ptr(zval *zobject)
     swTable *table_row = swoole_table_row_get_ptr(zobject);
     if (!table_row)
     {
-        php_swoole_fatal_error(E_ERROR, "you must call Lock constructor first");
+        php_swoole_fatal_error(E_ERROR, "you can only get Table\\Row from Table");
     }
     return table_row;
 }

--- a/swoole_table.cc
+++ b/swoole_table.cc
@@ -134,14 +134,14 @@ static sw_inline table_t* swoole_table_fetch_object(zend_object *obj)
     return (table_t *) ((char *) obj - swoole_table_handlers.offset);
 }
 
-static swTable * swoole_table_get_ptr(zval *zobject)
+static swTable * php_swoole_table_get_ptr(zval *zobject)
 {
     return swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-static swTable * swoole_table_get_and_check_ptr(zval *zobject)
+static swTable * php_swoole_table_get_and_check_ptr(zval *zobject)
 {
-    swTable *table = swoole_table_get_ptr(zobject);
+    swTable *table = php_swoole_table_get_ptr(zobject);
     if (!table)
     {
         php_swoole_fatal_error(E_ERROR, "you must call Table constructor first");
@@ -149,9 +149,9 @@ static swTable * swoole_table_get_and_check_ptr(zval *zobject)
     return table;
 }
 
-static swTable * swoole_table_get_and_check_ptr2(zval *zobject)
+static swTable * php_swoole_table_get_and_check_ptr2(zval *zobject)
 {
-    swTable *table = swoole_table_get_and_check_ptr(zobject);
+    swTable *table = php_swoole_table_get_and_check_ptr(zobject);
     if (!table->memory)
     {
         php_swoole_fatal_error(E_ERROR, "the swoole table does not exist");
@@ -159,7 +159,7 @@ static swTable * swoole_table_get_and_check_ptr2(zval *zobject)
     return table;
 }
 
-void swoole_table_set_ptr(zval *zobject, swTable *ptr)
+void php_swoole_table_set_ptr(zval *zobject, swTable *ptr)
 {
     swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -189,14 +189,14 @@ static sw_inline table_row_t* swoole_table_row_fetch_object(zend_object *obj)
     return (table_row_t *) ((char *) obj - swoole_table_row_handlers.offset);
 }
 
-static swTable * swoole_table_row_get_ptr(zval *zobject)
+static swTable * php_swoole_table_row_get_ptr(zval *zobject)
 {
     return swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
-static swTable * swoole_table_row_get_and_check_ptr(zval *zobject)
+static swTable * php_swoole_table_row_get_and_check_ptr(zval *zobject)
 {
-    swTable *table_row = swoole_table_row_get_ptr(zobject);
+    swTable *table_row = php_swoole_table_row_get_ptr(zobject);
     if (!table_row)
     {
         php_swoole_fatal_error(E_ERROR, "you can only get Table\\Row from Table");
@@ -204,7 +204,7 @@ static swTable * swoole_table_row_get_and_check_ptr(zval *zobject)
     return table_row;
 }
 
-void swoole_table_row_set_ptr(zval *zobject, swTable *ptr)
+void php_swoole_table_row_set_ptr(zval *zobject, swTable *ptr)
 {
     swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -385,7 +385,7 @@ void swoole_table_column_free(swTableColumn *col)
 
 PHP_METHOD(swoole_table, __construct)
 {
-    swTable *table = swoole_table_get_ptr(ZEND_THIS);
+    swTable *table = php_swoole_table_get_ptr(ZEND_THIS);
     if (table)
     {
         php_swoole_fatal_error(E_ERROR, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
@@ -406,12 +406,12 @@ PHP_METHOD(swoole_table, __construct)
         zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
         RETURN_FALSE;
     }
-    swoole_table_set_ptr(ZEND_THIS, table);
+    php_swoole_table_set_ptr(ZEND_THIS, table);
 }
 
 PHP_METHOD(swoole_table, column)
 {
-    swTable *table = swoole_table_get_and_check_ptr(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr(ZEND_THIS);
     char *name;
     size_t len;
     long type;
@@ -446,7 +446,7 @@ PHP_METHOD(swoole_table, column)
 
 static PHP_METHOD(swoole_table, create)
 {
-    swTable *table = swoole_table_get_and_check_ptr(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr(ZEND_THIS);
 
     if (swTable_create(table) < 0)
     {
@@ -460,7 +460,7 @@ static PHP_METHOD(swoole_table, create)
 
 static PHP_METHOD(swoole_table, destroy)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
 
     swTable_free(table);
     RETURN_TRUE;
@@ -468,7 +468,7 @@ static PHP_METHOD(swoole_table, destroy)
 
 static PHP_METHOD(swoole_table, set)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     zval *array;
     char *key;
     size_t keylen;
@@ -542,7 +542,7 @@ static PHP_METHOD(swoole_table, offsetSet)
 
 static PHP_METHOD(swoole_table, incr)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -612,7 +612,7 @@ static PHP_METHOD(swoole_table, incr)
 
 static PHP_METHOD(swoole_table, decr)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -682,7 +682,7 @@ static PHP_METHOD(swoole_table, decr)
 
 static PHP_METHOD(swoole_table, get)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
     char *field = NULL;
@@ -712,7 +712,7 @@ static PHP_METHOD(swoole_table, get)
 
 static PHP_METHOD(swoole_table, offsetGet)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
     char *field = NULL;
@@ -740,12 +740,12 @@ static PHP_METHOD(swoole_table, offsetGet)
     zend_update_property(swoole_table_row_ce, return_value, ZEND_STRL("value"), &value);
     zend_update_property_stringl(swoole_table_row_ce, return_value, ZEND_STRL("key"), key, keylen);
     zval_ptr_dtor(&value);
-    swoole_table_row_set_ptr(return_value, table);
+    php_swoole_table_row_set_ptr(return_value, table);
 }
 
 static PHP_METHOD(swoole_table, exists)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
@@ -775,7 +775,7 @@ static PHP_METHOD(swoole_table, offsetExists)
 
 static PHP_METHOD(swoole_table, del)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
@@ -797,7 +797,7 @@ static PHP_METHOD(swoole_table, count)
     #define COUNT_NORMAL            0
     #define COUNT_RECURSIVE         1
 
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     long mode = COUNT_NORMAL;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &mode) == FAILURE)
@@ -817,7 +817,7 @@ static PHP_METHOD(swoole_table, count)
 
 static PHP_METHOD(swoole_table, getMemorySize)
 {
-    swTable *table = swoole_table_get_ptr(ZEND_THIS);
+    swTable *table = php_swoole_table_get_ptr(ZEND_THIS);
 
     if (!table)
     {
@@ -835,14 +835,14 @@ static PHP_METHOD(swoole_table, getMemorySize)
 
 static PHP_METHOD(swoole_table, rewind)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTable_iterator_rewind(table);
     swTable_iterator_forward(table);
 }
 
 static PHP_METHOD(swoole_table, current)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     if (row)
     {
@@ -858,7 +858,7 @@ static PHP_METHOD(swoole_table, current)
 
 static PHP_METHOD(swoole_table, key)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     if (row)
     {
@@ -874,13 +874,13 @@ static PHP_METHOD(swoole_table, key)
 
 static PHP_METHOD(swoole_table, next)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTable_iterator_forward(table);
 }
 
 static PHP_METHOD(swoole_table, valid)
 {
-    swTable *table = swoole_table_get_and_check_ptr2(ZEND_THIS);
+    swTable *table = php_swoole_table_get_and_check_ptr2(ZEND_THIS);
     swTableRow *row = swTable_iterator_current(table);
     RETURN_BOOL(row != NULL);
 }
@@ -920,7 +920,7 @@ static PHP_METHOD(swoole_table_row, offsetGet)
 
 static PHP_METHOD(swoole_table_row, offsetSet)
 {
-    swTable *table = swoole_table_row_get_and_check_ptr(ZEND_THIS);
+    swTable *table = php_swoole_table_row_get_and_check_ptr(ZEND_THIS);
     zval *value;
     char *key;
     size_t keylen;

--- a/swoole_table.cc
+++ b/swoole_table.cc
@@ -129,14 +129,14 @@ typedef struct
     zend_object std;
 } table_t;
 
-static sw_inline table_t* swoole_table_fetch_object(zend_object *obj)
+static sw_inline table_t* php_swoole_table_fetch_object(zend_object *obj)
 {
     return (table_t *) ((char *) obj - swoole_table_handlers.offset);
 }
 
 static swTable * php_swoole_table_get_ptr(zval *zobject)
 {
-    return swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 static swTable * php_swoole_table_get_and_check_ptr(zval *zobject)
@@ -161,15 +161,15 @@ static swTable * php_swoole_table_get_and_check_ptr2(zval *zobject)
 
 void php_swoole_table_set_ptr(zval *zobject, swTable *ptr)
 {
-    swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_table_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_table_free_object(zend_object *object)
+static void php_swoole_table_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_table_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_table_create_object(zend_class_entry *ce)
 {
     table_t *table = (table_t *) ecalloc(1, sizeof(table_t) + zend_object_properties_size(ce));
     zend_object_std_init(&table->std, ce);
@@ -184,14 +184,14 @@ typedef struct
     zend_object std;
 } table_row_t;
 
-static sw_inline table_row_t* swoole_table_row_fetch_object(zend_object *obj)
+static sw_inline table_row_t* php_swoole_table_row_fetch_object(zend_object *obj)
 {
     return (table_row_t *) ((char *) obj - swoole_table_row_handlers.offset);
 }
 
 static swTable * php_swoole_table_row_get_ptr(zval *zobject)
 {
-    return swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr;
+    return php_swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
 static swTable * php_swoole_table_row_get_and_check_ptr(zval *zobject)
@@ -206,15 +206,15 @@ static swTable * php_swoole_table_row_get_and_check_ptr(zval *zobject)
 
 void php_swoole_table_row_set_ptr(zval *zobject, swTable *ptr)
 {
-    swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
+    php_swoole_table_row_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
 
-static void swoole_table_row_free_object(zend_object *object)
+static void php_swoole_table_row_free_object(zend_object *object)
 {
     zend_object_std_dtor(object);
 }
 
-static zend_object *swoole_table_row_create_object(zend_class_entry *ce)
+static zend_object *php_swoole_table_row_create_object(zend_class_entry *ce)
 {
     table_row_t *table_row = (table_row_t *) ecalloc(1, sizeof(table_row_t) + zend_object_properties_size(ce));
     zend_object_std_init(&table_row->std, ce);
@@ -357,7 +357,7 @@ void php_swoole_table_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_table, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_table, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_table, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table, swoole_table_create_object, swoole_table_free_object, table_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table, php_swoole_table_create_object, php_swoole_table_free_object, table_t, std);
     zend_class_implements(swoole_table_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #ifdef SW_HAVE_COUNTABLE
     zend_class_implements(swoole_table_ce, 1, zend_ce_countable);
@@ -371,7 +371,7 @@ void php_swoole_table_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_table_row, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_table_row, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_table_row, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table_row, swoole_table_row_create_object, swoole_table_row_free_object, table_row_t, std);
+    SW_SET_CLASS_CUSTOM_OBJECT(swoole_table_row, php_swoole_table_row_create_object, php_swoole_table_row_free_object, table_row_t, std);
     zend_class_implements(swoole_table_row_ce, 1, zend_ce_arrayaccess);
 
     zend_declare_property_null(swoole_table_row_ce, ZEND_STRL("key"), ZEND_ACC_PUBLIC);

--- a/swoole_websocket_server.cc
+++ b/swoole_websocket_server.cc
@@ -652,7 +652,6 @@ void php_swoole_websocket_server_minit(int module_number)
     SW_SET_CLASS_SERIALIZABLE(swoole_websocket_server, zend_class_serialize_deny, zend_class_unserialize_deny);
     SW_SET_CLASS_CLONEABLE(swoole_websocket_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_websocket_server, sw_zend_class_unset_property_deny);
-    SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_websocket_server);
     zend_declare_property_null(swoole_websocket_server_ce, ZEND_STRL("onHandshake"), ZEND_ACC_PRIVATE);
 
     SW_INIT_CLASS_ENTRY(swoole_websocket_frame, "Swoole\\WebSocket\\Frame", "swoole_websocket_frame", NULL, swoole_websocket_frame_methods);

--- a/swoole_websocket_server.cc
+++ b/swoole_websocket_server.cc
@@ -782,6 +782,8 @@ static sw_inline int swoole_websocket_server_close(swServer *serv, int fd, swStr
     }
 }
 
+extern swServer* swoole_server_get_and_check_server(zval *zobject);
+
 static PHP_METHOD(swoole_websocket_server, disconnect)
 {
     zend_long fd = 0;
@@ -798,12 +800,16 @@ static PHP_METHOD(swoole_websocket_server, disconnect)
     {
         RETURN_FALSE;
     }
-    swServer *serv = (swServer *) swoole_get_object(ZEND_THIS);
-    SW_CHECK_RETURN(swoole_websocket_server_close(serv, fd, swoole_http_buffer, 1));
+    SW_CHECK_RETURN(
+        swoole_websocket_server_close(
+            swoole_server_get_and_check_server(ZEND_THIS), fd, swoole_http_buffer, 1
+        )
+    );
 }
 
 static PHP_METHOD(swoole_websocket_server, push)
 {
+    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
     zend_long fd = 0;
     zval *zdata = NULL;
     zend_long opcode = WEBSOCKET_OPCODE_TEXT;
@@ -822,8 +828,6 @@ static PHP_METHOD(swoole_websocket_server, push)
     {
         flags = zval_get_long(zflags);
     }
-
-    swServer *serv = (swServer *) swoole_get_object(ZEND_THIS);
 
 #ifdef SW_HAVE_ZLIB
     if (flags & SW_WEBSOCKET_FLAG_COMPRESS)
@@ -917,9 +921,9 @@ static PHP_METHOD(swoole_websocket_server, unpack)
 
 static PHP_METHOD(swoole_websocket_server, isEstablished)
 {
+    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
     zend_long fd;
 
-    swServer *serv = (swServer *) swoole_get_object(ZEND_THIS);
     if (sw_unlikely(!serv->gs->start))
     {
         php_error_docref(NULL, E_WARNING, "the server is not running");

--- a/swoole_websocket_server.cc
+++ b/swoole_websocket_server.cc
@@ -781,7 +781,7 @@ static sw_inline int swoole_websocket_server_close(swServer *serv, int fd, swStr
     }
 }
 
-extern swServer* swoole_server_get_and_check_server(zval *zobject);
+extern swServer* php_swoole_server_get_and_check_server(zval *zobject);
 
 static PHP_METHOD(swoole_websocket_server, disconnect)
 {
@@ -801,14 +801,14 @@ static PHP_METHOD(swoole_websocket_server, disconnect)
     }
     SW_CHECK_RETURN(
         swoole_websocket_server_close(
-            swoole_server_get_and_check_server(ZEND_THIS), fd, swoole_http_buffer, 1
+            php_swoole_server_get_and_check_server(ZEND_THIS), fd, swoole_http_buffer, 1
         )
     );
 }
 
 static PHP_METHOD(swoole_websocket_server, push)
 {
-    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
+    swServer *serv = php_swoole_server_get_and_check_server(ZEND_THIS);
     zend_long fd = 0;
     zval *zdata = NULL;
     zend_long opcode = WEBSOCKET_OPCODE_TEXT;
@@ -920,7 +920,7 @@ static PHP_METHOD(swoole_websocket_server, unpack)
 
 static PHP_METHOD(swoole_websocket_server, isEstablished)
 {
-    swServer *serv = swoole_server_get_and_check_server(ZEND_THIS);
+    swServer *serv = php_swoole_server_get_and_check_server(ZEND_THIS);
     zend_long fd;
 
     if (sw_unlikely(!serv->gs->start))


### PR DESCRIPTION
历史遗留问题：Swoole底层C/C++对象和Zend对象的绑定使用了静态数组的方式，而`object->handle`的废除会导致该方式不可用，此外`handle`的值过大（创建了大量对象）也会导致一些问题，现对其进行全面重构，改为使用标准的zend_object扩写的方式。

- [x] swoole_atomic[_long]
- [x] ~~swoole_buffer~~
- [x] swoole_client
- [x] swoole_client_coro
- [x] swoole_http_request
- [x] swoole_http_response
- [x] swoole_http2_client_coro
- [x] swoole_lock
- [x] swoole_process
- [x] swoole_process_pool
- [x] swoole_server
- [x] swoole_server_port
- [x] swoole_redis_server
- [x] swoole_websocket_server
- [x] swoole_table

