### PR TITLE
Add error info for bind error

### DIFF
--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1172,6 +1172,7 @@ bool Socket::bind(std::string address, int port)
 
         if (bind_address.size() >= sizeof(sa->sun_path))
         {
+            swSysWarn("unixSocket bind path(%s) is too long,the maxium limit of bytes number is 108", bind_address.c_str());
             return false;
         }
         memcpy(&sa->sun_path, bind_address.c_str(), bind_address.size());

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1172,7 +1172,8 @@ bool Socket::bind(std::string address, int port)
 
         if (bind_address.size() >= sizeof(sa->sun_path))
         {
-            swSysWarn("unixSocket bind path(%s) is too long,the maxium limit of bytes number is 108", bind_address.c_str());
+            set_err(EINVAL);
+            swWarn("UNIXSocket bind path(%s) is too long, the maxium limit of bytes number is %zu", bind_address.c_str(), sizeof(sa->sun_path));
             return false;
         }
         memcpy(&sa->sun_path, bind_address.c_str(), bind_address.size());
@@ -1189,6 +1190,7 @@ bool Socket::bind(std::string address, int port)
         sa->sin_port = htons((unsigned short) bind_port);
         if (!inet_aton(bind_address.c_str(), &sa->sin_addr))
         {
+            set_err(EINVAL);
             return false;
         }
         retval = ::bind(sock_fd, (struct sockaddr *) sa, sizeof(struct sockaddr_in));


### PR DESCRIPTION
当超过108个字节会出现失败提示，但是实际上执行会出现成功的情况 
```
#include <sys/un.h>
#include <sys/socket.h>
#include <unistd.h>

int main() {
    char *dir = "/home/zhanglei/data/www/pureliving/framework/Service/Factory/Process/Actor/Sock/ProcessServiceCenter28291.sock";

    int sockfd;
    socklen_t len;
    struct sockaddr_un addr1, addr2;
    unlink(dir);  //delete file
    sockfd = socket(AF_LOCAL, SOCK_STREAM, 0);
    bzero(&addr1, sizeof(addr1));
    addr1.sun_family = AF_LOCAL;
    strncpy(addr1.sun_path, dir, sizeof(addr1.sun_path) - 1);
    int res = bind(sockfd, (struct sockaddr *) &addr1, SUN_LEN(&addr1));
}
```
执行结果 绑定成功
"/home/zhanglei/data/www/pureliving/framework/Service/Factory/Process/Actor/Sock/ProcessServiceCenter28291.s"