### PR TITLE
修复fd值变小时，minfd 不更新问题

### DIFF
--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -117,7 +117,7 @@ int swServer_master_onAccept(swReactor *reactor, swEvent *event)
             }
         }
 
-        swTrace("[Master] Accept new connection. maxfd=%d|reactor_id=%d|conn=%d", swServer_get_maxfd(serv), reactor->id, new_fd);
+        swTrace("[Master] Accept new connection. maxfd=%d|minfd=%d|reactor_id=%d|conn=%d", swServer_get_maxfd(serv), swServer_get_minfd(serv), reactor->id, new_fd);
 
         //too many connection
         if (new_fd >= (int) serv->max_connection)
@@ -1827,6 +1827,11 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     if (fd > swServer_get_maxfd(serv))
     {
         swServer_set_maxfd(serv, fd);
+    }
+
+    if (fd < swServer_get_minfd(serv))
+    {
+        swServer_set_minfd(serv, fd);
     }
 
     connection = &(serv->connection_list[fd]);

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -1828,8 +1828,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, i
     {
         swServer_set_maxfd(serv, fd);
     }
-
-    if (fd < swServer_get_minfd(serv))
+    else if (fd < swServer_get_minfd(serv))
     {
         swServer_set_minfd(serv, fd);
     }


### PR DESCRIPTION
我们线上使用 V4.4.12  版本 Http Server，当 Nginx 开启 keepalive 时，停止服务发现 Master 进程一直不能退出，必须先停止 nginx 让连接关闭，Master 才能退出。调试后发现新连接 fd 可能会比 minfd 值更小。当服务进行 shutdown 时，新连接的fd比minfd 更小时将导致该连接不能正常close，导致事件循环一直不能退出

![image](https://user-images.githubusercontent.com/6482528/69728407-5989f480-115f-11ea-881e-c178ac432ae4.png)
 