### PR TITLE
Patch for #2918

### DIFF
--- a/include/swoole.h
+++ b/include/swoole.h
@@ -1710,6 +1710,7 @@ struct _swReactor
     void (*onBegin)(swReactor *);
 
     int (*is_empty)(swReactor *);
+    int (*can_exit)(swReactor *);
 
     int (*write)(swReactor *, int, const void *, int);
     int (*close)(swReactor *, int);
@@ -2421,6 +2422,7 @@ typedef struct
     swHashMap *functions;
     swLinkedList *hooks[SW_MAX_HOOK_TYPE];
 
+    int (*reactor_can_exit)(swReactor *);
 } swGlobal_t;
 
 extern swGlobal_t SwooleG;              //Local Global Variable

--- a/src/reactor/base.cc
+++ b/src/reactor/base.cc
@@ -61,6 +61,7 @@ int swReactor_create(swReactor *reactor, int max_event)
     reactor->onFinish = reactor_finish;
     reactor->onTimeout = reactor_timeout;
     reactor->is_empty = swReactor_empty;
+    reactor->can_exit = SwooleG.reactor_can_exit;
 
     reactor->write = swReactor_write;
     reactor->close = swReactor_close;
@@ -154,6 +155,11 @@ int swReactor_empty(swReactor *reactor)
     if (event_num == 0)
     {
         empty = SW_TRUE;
+    }
+    //custom
+    if (reactor->can_exit && !reactor->can_exit(reactor))
+    {
+        empty = SW_FALSE;
     }
     return empty;
 }

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -993,11 +993,8 @@ PHP_FUNCTION(swoole_coroutine_defer)
 PHP_METHOD(swoole_coroutine, stats)
 {
     array_init(return_value);
-    if (SwooleTG.reactor)
-    {
-        add_assoc_long_ex(return_value, ZEND_STRL("event_num"), SwooleTG.reactor->event_num);
-        add_assoc_long_ex(return_value, ZEND_STRL("signal_listener_num"), SwooleTG.reactor->signal_listener_num);
-    }
+    add_assoc_long_ex(return_value, ZEND_STRL("event_num"), SwooleTG.reactor ? SwooleTG.reactor->event_num : 0);
+    add_assoc_long_ex(return_value, ZEND_STRL("signal_listener_num"), SwooleTG.reactor ? SwooleTG.reactor->signal_listener_num : 0);
     add_assoc_long_ex(return_value, ZEND_STRL("aio_task_num"), SwooleTG.aio_task_num);
     add_assoc_long_ex(return_value, ZEND_STRL("aio_worker_num"), swAio_thread_count());
     add_assoc_long_ex(return_value, ZEND_STRL("c_stack_size"), Coroutine::get_stack_size());

--- a/swoole_coroutine_scheduler.cc
+++ b/swoole_coroutine_scheduler.cc
@@ -121,17 +121,17 @@ void php_swoole_coroutine_scheduler_minit(int module_number)
     zend_declare_property_null(swoole_coroutine_scheduler_ce, ZEND_STRL("_list"), ZEND_ACC_PRIVATE);
 }
 
-static zend_fcall_info_cache can_exit_fci_cache;
-static bool can_exit_cleaner;
+static zend_fcall_info_cache exit_condition_fci_cache;
+static bool exit_condition_cleaner;
 
 static int php_swoole_coroutine_reactor_can_exit(swReactor *reactor)
 {
     zval retval;
     int success;
 
-    SW_ASSERT(can_exit_fci_cache.function_handler);
+    SW_ASSERT(exit_condition_fci_cache.function_handler);
     ZVAL_NULL(&retval);
-    success = sw_zend_call_function_ex(NULL, &can_exit_fci_cache, 0, nullptr, &retval);
+    success = sw_zend_call_function_ex(NULL, &exit_condition_fci_cache, 0, nullptr, &retval);
     if (UNEXPECTED(success != SUCCESS))
     {
         php_swoole_fatal_error(E_ERROR, "Coroutine can_exit callback handler error");
@@ -238,35 +238,35 @@ PHP_METHOD(swoole_coroutine_scheduler, set)
         SwooleG.aio_max_idle_time = zval_get_double(ztmp);
     }
     /* Reactor can exit */
-    if ((ztmp = zend_hash_str_find(vht, ZEND_STRL("can_exit"))))
+    if ((ztmp = zend_hash_str_find(vht, ZEND_STRL("exit_condition"))))
     {
         char *func_name;
-        if (can_exit_fci_cache.function_handler)
+        if (exit_condition_fci_cache.function_handler)
         {
-            sw_zend_fci_cache_discard(&can_exit_fci_cache);
-            can_exit_fci_cache.function_handler = nullptr;
+            sw_zend_fci_cache_discard(&exit_condition_fci_cache);
+            exit_condition_fci_cache.function_handler = nullptr;
         }
         if (!ZVAL_IS_NULL(ztmp))
         {
-            if (!sw_zend_is_callable_ex(ztmp, NULL, 0, &func_name, NULL, &can_exit_fci_cache, NULL))
+            if (!sw_zend_is_callable_ex(ztmp, NULL, 0, &func_name, NULL, &exit_condition_fci_cache, NULL))
             {
-                php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
+                php_swoole_fatal_error(E_ERROR, "exit_condition '%s' is not callable", func_name);
             }
             else
             {
                 efree(func_name);
-                sw_zend_fci_cache_persist(&can_exit_fci_cache);
-                if (!can_exit_cleaner)
+                sw_zend_fci_cache_persist(&exit_condition_fci_cache);
+                if (!exit_condition_cleaner)
                 {
                     php_swoole_register_rshutdown_callback([](void *data)
                     {
-                        if (can_exit_fci_cache.function_handler)
+                        if (exit_condition_fci_cache.function_handler)
                         {
-                            sw_zend_fci_cache_discard(&can_exit_fci_cache);
-                            can_exit_fci_cache.function_handler = nullptr;
+                            sw_zend_fci_cache_discard(&exit_condition_fci_cache);
+                            exit_condition_fci_cache.function_handler = nullptr;
                         }
                     }, nullptr);
-                    can_exit_cleaner = true;
+                    exit_condition_cleaner = true;
                 }
                 SwooleG.reactor_can_exit = php_swoole_coroutine_reactor_can_exit;
                 if (SwooleTG.reactor)

--- a/swoole_coroutine_scheduler.cc
+++ b/swoole_coroutine_scheduler.cc
@@ -121,6 +121,28 @@ void php_swoole_coroutine_scheduler_minit(int module_number)
     zend_declare_property_null(swoole_coroutine_scheduler_ce, ZEND_STRL("_list"), ZEND_ACC_PRIVATE);
 }
 
+static zend_fcall_info_cache can_exit_fci_cache;
+static bool can_exit_cleaner;
+
+static int php_swoole_coroutine_reactor_can_exit(swReactor *reactor)
+{
+    zval retval;
+    int success;
+
+    SW_ASSERT(can_exit_fci_cache.function_handler);
+    ZVAL_NULL(&retval);
+    success = sw_zend_call_function_ex(NULL, &can_exit_fci_cache, 0, nullptr, &retval);
+    if (UNEXPECTED(success != SUCCESS))
+    {
+        php_swoole_fatal_error(E_ERROR, "Coroutine can_exit callback handler error");
+    }
+    if (UNEXPECTED(EG(exception)))
+    {
+        zend_exception_error(EG(exception), E_ERROR);
+    }
+    return !(Z_TYPE_P(&retval) == IS_FALSE);
+}
+
 PHP_METHOD(swoole_coroutine_scheduler, set)
 {
     zval *zset = NULL;
@@ -214,6 +236,53 @@ PHP_METHOD(swoole_coroutine_scheduler, set)
     if (php_swoole_array_get_value(vht, "aio_max_idle_time", ztmp))
     {
         SwooleG.aio_max_idle_time = zval_get_double(ztmp);
+    }
+    /* Reactor can exit */
+    if ((ztmp = zend_hash_str_find(vht, ZEND_STRL("can_exit"))))
+    {
+        char *func_name;
+        if (can_exit_fci_cache.function_handler)
+        {
+            sw_zend_fci_cache_discard(&can_exit_fci_cache);
+            can_exit_fci_cache.function_handler = nullptr;
+        }
+        if (!ZVAL_IS_NULL(ztmp))
+        {
+            if (!sw_zend_is_callable_ex(ztmp, NULL, 0, &func_name, NULL, &can_exit_fci_cache, NULL))
+            {
+                php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
+            }
+            else
+            {
+                efree(func_name);
+                sw_zend_fci_cache_persist(&can_exit_fci_cache);
+                if (!can_exit_cleaner)
+                {
+                    php_swoole_register_rshutdown_callback([](void *data)
+                    {
+                        if (can_exit_fci_cache.function_handler)
+                        {
+                            sw_zend_fci_cache_discard(&can_exit_fci_cache);
+                            can_exit_fci_cache.function_handler = nullptr;
+                        }
+                    }, nullptr);
+                    can_exit_cleaner = true;
+                }
+                SwooleG.reactor_can_exit = php_swoole_coroutine_reactor_can_exit;
+                if (SwooleTG.reactor)
+                {
+                    SwooleTG.reactor->can_exit = php_swoole_coroutine_reactor_can_exit;
+                }
+            }
+        }
+        else
+        {
+            SwooleG.reactor_can_exit = nullptr;
+            if (SwooleTG.reactor)
+            {
+                SwooleTG.reactor->can_exit = nullptr;
+            }
+        }
     }
 }
 

--- a/tests/swoole_coroutine/dead_lock.phpt
+++ b/tests/swoole_coroutine/dead_lock.phpt
@@ -1,0 +1,38 @@
+--TEST--
+swoole_coroutine: dead lock
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Process;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    for ($n = 3; $n--;) {
+        $ret = Process::wait(false);
+        Assert::isEmpty($ret);
+        switch_process();
+    }
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm) {
+    $pm->wakeup();
+    Coroutine::set([
+        'can_exit' => function () {
+            return Coroutine::stats()['coroutine_num'] === 0;
+        }
+    ]);
+    Coroutine::create(function () {
+        $channel = new Coroutine\Channel;
+        $channel->pop();
+    });
+};
+$pm->childFirst();
+$pm->run();
+
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/dead_lock.phpt
+++ b/tests/swoole_coroutine/dead_lock.phpt
@@ -17,6 +17,7 @@ $pm->parentFunc = function () use ($pm) {
         switch_process();
     }
     $pm->kill();
+    echo "DONE\n";
 };
 $pm->childFunc = function () use ($pm) {
     $pm->wakeup();

--- a/tests/swoole_coroutine/dead_lock.phpt
+++ b/tests/swoole_coroutine/dead_lock.phpt
@@ -22,7 +22,7 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $pm->wakeup();
     Coroutine::set([
-        'can_exit' => function () {
+        'exit_condition' => function () {
             return Coroutine::stats()['coroutine_num'] === 0;
         }
     ]);

--- a/tests/swoole_coroutine/signal_listener.phpt
+++ b/tests/swoole_coroutine/signal_listener.phpt
@@ -1,0 +1,43 @@
+--TEST--
+swoole_coroutine: dead lock
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Process;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    for ($n = 3; $n--;) {
+        $ret = Process::wait(false);
+        Assert::isEmpty($ret);
+        switch_process();
+    }
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm) {
+    $pm->wakeup();
+    Coroutine::set([
+        'can_exit' => function () {
+            return Coroutine::stats()['signal_listener_num'] === 0;
+        }
+    ]);
+    Process::signal(SIGINT, function () {
+        echo 'SIGINT' . PHP_EOL;
+        exit(123);
+    });
+    Process::signal(SIGTERM, function () {
+        echo 'SIGTERM' . PHP_EOL;
+        exit(123);
+    });
+};
+$pm->childFirst();
+$pm->run();
+$pm->expectExitCode(123);
+
+?>
+--EXPECT--
+SIGTERM

--- a/tests/swoole_coroutine/signal_listener.phpt
+++ b/tests/swoole_coroutine/signal_listener.phpt
@@ -21,7 +21,7 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $pm->wakeup();
     Coroutine::set([
-        'can_exit' => function () {
+        'exit_condition' => function () {
             return Coroutine::stats()['signal_listener_num'] === 0;
         }
     ]);


### PR DESCRIPTION
#2918

解决方案：支持注册自定义handler，改变reactor退出条件

返回值为`false`表示不退出，否则按照原有规则（是否有事件）决定是否退出

Examples
---

```php
<?php
declare(strict_types=1);

use Swoole\Coroutine;

Coroutine::set([
    'exit_condition' => function () {
        return Coroutine::stats()['coroutine_num'] === 0;
    }
]);

Coroutine::create(function () {
    $channel = new Coroutine\Channel;
    $channel->pop();
});
```

```php
<?php
declare(strict_types=1);

use Swoole\Coroutine;
use Swoole\Process;

Coroutine::set([
    'exit_condition' => function () {
        return Coroutine::stats()['signal_listener_num'] === 0;
    }
]);

Process::signal(SIGINT, function () {
    echo 'SIGINT' . PHP_EOL;
    exit;
});
Process::signal(SIGTERM, function () {
    echo 'SIGTERM' . PHP_EOL;
    exit;
});
```
