### PR TITLE
修复当php编译时，指定了参数--enable-sigchild，swoole接收不到退出进程的pid

### DIFF
--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -270,6 +270,7 @@ static int swManager_loop(swServer *serv)
 
     //for reload
     swSignal_add(SIGHUP, NULL);
+    swSignal_add(SIGCHLD, swManager_signal_handler);
     swSignal_add(SIGTERM, swManager_signal_handler);
     swSignal_add(SIGUSR1, swManager_signal_handler);
     swSignal_add(SIGUSR2, swManager_signal_handler);


### PR DESCRIPTION
当编译php时，指定了--enable-sigchild参数，php将会注册SIGCHLD信号处理函数，并且在里面调用waitpid回收进程，如果manager进程没有覆盖php的默认处理函数，那么manager进程调用wait的时候，有可能就不会收到退出进程的pid，所以task worker有时候就不会重启。
这是php的处理
![image](https://user-images.githubusercontent.com/12780455/70908074-52128880-2045-11ea-9359-8540ecd80cef.png)
