### PR TITLE
Blocking prediction

### DIFF
--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1042,7 +1042,7 @@ ssize_t Socket::recv_all(void *__buf, size_t __n)
         char *read_p = (char *) __buf + total_bytes;
         size_t read_n = __n - total_bytes;
         ssize_t retval = swConnection_recv(socket, read_p, read_n, 0);
-        if (retval >= 0)
+        if (retval > 0)
         {
             total_bytes += retval;
             if (retval < read_n)
@@ -1054,7 +1054,7 @@ ssize_t Socket::recv_all(void *__buf, size_t __n)
                 break;
             }
         }
-        else
+        else if (retval < 0)
         {
             if (swConnection_error(errno) == SW_WAIT)
             {
@@ -1070,8 +1070,12 @@ ssize_t Socket::recv_all(void *__buf, size_t __n)
             }
             break;
         }
+        else // if (retval == 0) /* connection closed */
+        {
+            break;
+        }
     }
-    set_err(total_bytes != __n ? errno : 0);
+    set_err((total_bytes != __n && total_bytes != 0) ? errno : 0);
     return total_bytes;
 }
 

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1048,14 +1048,12 @@ ssize_t Socket::recv_all(void *__buf, size_t __n)
             if (retval < read_n)
             {
                 _would_block:
-                if (!timer.start())
+                if (timer.start() && wait_event(SW_EVENT_READ))
                 {
-                    break;
+                    continue;
                 }
-                if (!wait_event(SW_EVENT_READ))
-                {
-                    break;
-                }
+                retval = -1;
+                break;
             }
             else if ((size_t) total_bytes == __n)
             {
@@ -1098,14 +1096,12 @@ ssize_t Socket::send_all(const void *__buf, size_t __n)
             if (retval < send_n)
             {
                 _would_block:
-                if (!timer.start())
+                if (timer.start() && wait_event(SW_EVENT_WRITE, &__buf, __n))
                 {
-                    break;
+                    continue;
                 }
-                if (!wait_event(SW_EVENT_WRITE, &__buf, __n))
-                {
-                    break;
-                }
+                retval = -1;
+                break;
             }
             else if ((size_t) total_bytes == __n)
             {


### PR DESCRIPTION
阻塞预测，当发送成功但发送的长度小于给出的数据长度时，不再进行下一次尝试，而是直接等待可写事件
