### PR TITLE
fix php7.3+ return code 1

### DIFF
--- a/swoole.cc
+++ b/swoole.cc
@@ -475,6 +475,7 @@ PHP_MINIT_FUNCTION(swoole)
     {
         zend_hash_str_del(CG(function_table), ZEND_STRL("go"));
         zend_hash_str_del(CG(function_table), ZEND_STRL("defer"));
+        zend_hash_rehash(CG(function_table));
     }
 
     swoole_init();


### PR DESCRIPTION
当PHP7.3+，且定义了过多的function。执行php脚本 returncode会永恒等于1

https://bugs.php.net/bug.php?id=79064
php官方也给了另外一种方法。。。
~~~
You need to set EG(full_table_cleanup) = 1 if you modify the function/class tables in a way that allows internal and user classes to be mixed.

Alternatively, doing a call to zend_hash_rehash() *might* also work. But in the general case, EG(full_table_cleanup) exists exactly for this kind of case (most commonly when "dl" is used.)
~~~
