### PR TITLE
Fix static handler when the file content is empty return 404

### DIFF
--- a/src/server/static_handler.cc
+++ b/src/server/static_handler.cc
@@ -170,10 +170,6 @@ bool StaticHandler::hit()
             return false;
         }
     }
-    if (file_stat.st_size == 0)
-    {
-        return false;
-    }
     if ((file_stat.st_mode & S_IFMT) != S_IFREG)
     {
         return false;

--- a/tests/swoole_http_server/static_handler.phpt
+++ b/tests/swoole_http_server/static_handler.phpt
@@ -29,6 +29,10 @@ $pm->parentFunc = function () use ($pm) {
                 }
             }
             Assert::assert(md5($data) === md5_file(TEST_IMAGE));
+
+            $response = httpRequest("http://127.0.0.1:{$pm->getFreePort()}/http/empty.txt");
+            Assert::assert(200 === $response['statusCode']);
+            Assert::assert('' === $response['body']);
         });
     }
     echo "DONE\n";


### PR DESCRIPTION
修复当启用`enable_static_handler`时，文件存在，但内容为空（长度为0），会返回状态码 `404` 的问题

修复后，会返回状态码 `200`，内容为空，符合预期