### PR TITLE
Fix #3118

### DIFF
--- a/swoole_http_client_coro.cc
+++ b/swoole_http_client_coro.cc
@@ -429,12 +429,6 @@ static int http_parser_on_header_value(swoole_http_parser *parser, const char *a
 static int http_parser_on_headers_complete(swoole_http_parser *parser)
 {
     http_client* http = (http_client*) parser->data;
-    //no content-length
-    if (http->chunked == 0 && parser->content_length == -1)
-    {
-        enum flags { F_CONNECTION_CLOSE = 1 << 2 };
-        parser->flags |= F_CONNECTION_CLOSE;
-    }
     if (http->method == SW_HTTP_HEAD || parser->status_code == SW_HTTP_NO_CONTENT)
     {
         return 1;

--- a/tests/swoole_http_client_coro/bug_3118.phpt
+++ b/tests/swoole_http_client_coro/bug_3118.phpt
@@ -1,0 +1,28 @@
+--TEST--
+swoole_http_client_coro: Github #3118
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_offline();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+
+Coroutine\run(function () {
+    $client = new Coroutine\Http\Client(HTTPBIN_SERVER_HOST, HTTPBIN_SERVER_PORT);
+    $client->set(['timeout' => 10]);
+    $codes = [200, 201, 304, 301, 302, 303,];
+    foreach ($codes as $code) {
+        $client->get("/status/{$code}");
+        Assert::same($client->getStatusCode(), $code);
+    }
+});
+
+echo "DONE\n"
+
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
很久以前的一段hack代码 (在响应为非chunk且没有给出Content-Length的时候置Connection为close, 这样就能以没有body来处理)
但是现在看来好像没什么用了, 反而会造成BUG
