### PR TITLE
Added new method get the coroutine elapsed time: co::getElapsed.

### DIFF
--- a/include/coroutine.h
+++ b/include/coroutine.h
@@ -82,6 +82,11 @@ public:
         return state;
     }
 
+    inline long get_init_msec()
+    {
+        return init_msec;
+    }
+
     inline long get_cid()
     {
         return cid;
@@ -185,6 +190,12 @@ public:
         return peak_num;
     }
 
+    static inline long get_elapsed(long cid)
+    {
+        Coroutine *co = cid == 0 ? get_current() : get_by_cid(cid);
+        return sw_likely(co) ? swTimer_get_absolute_msec() - co->get_init_msec() : -1;
+    }
+
     static void print_list();
 
 protected:
@@ -199,6 +210,7 @@ protected:
 
     sw_coro_state state = SW_CORO_INIT;
     long cid;
+    long init_msec = swTimer_get_absolute_msec();
     void *task = nullptr;
     Context ctx;
     Coroutine *origin;

--- a/swoole_coroutine.cc
+++ b/swoole_coroutine.cc
@@ -79,6 +79,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_coroutine_getPcid, 0, 0, 0)
     ZEND_ARG_INFO(0, cid)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_coroutine_getElapsed, 0, 0, 0)
+    ZEND_ARG_INFO(0, cid)
+ZEND_END_ARG_INFO()
+
 bool PHPCoroutine::active = false;
 
 swoole::coroutine::Config PHPCoroutine::config =
@@ -117,6 +121,7 @@ static PHP_METHOD(swoole_coroutine, getCid);
 static PHP_METHOD(swoole_coroutine, getPcid);
 static PHP_METHOD(swoole_coroutine, getContext);
 static PHP_METHOD(swoole_coroutine, getBackTrace);
+static PHP_METHOD(swoole_coroutine, getElapsed);
 static PHP_METHOD(swoole_coroutine, list);
 static PHP_METHOD(swoole_coroutine, enableScheduler);
 static PHP_METHOD(swoole_coroutine, disableScheduler);
@@ -139,6 +144,7 @@ static const zend_function_entry swoole_coroutine_util_methods[] =
     PHP_ME(swoole_coroutine, getPcid, arginfo_swoole_coroutine_getPcid, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, getContext, arginfo_swoole_coroutine_getContext, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, getBackTrace, arginfo_swoole_coroutine_getBackTrace, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_coroutine, getElapsed, arginfo_swoole_coroutine_getElapsed, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, list, arginfo_swoole_coroutine_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_MALIAS(swoole_coroutine, listCoroutines, list, arginfo_swoole_coroutine_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, enableScheduler, arginfo_swoole_coroutine_void, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
@@ -989,6 +995,20 @@ PHP_METHOD(swoole_coroutine, getContext)
     }
     GC_ADDREF(task->context);
     RETURN_OBJ(task->context);
+}
+
+PHP_METHOD(swoole_coroutine, getElapsed)
+{
+    zend_long cid = 0;
+    zend_long ret;
+
+    ZEND_PARSE_PARAMETERS_START(0, 1)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(cid)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    ret = PHPCoroutine::get_elapsed(cid);
+    RETURN_LONG(ret);
 }
 
 PHP_METHOD(swoole_coroutine, exists)

--- a/swoole_coroutine.h
+++ b/swoole_coroutine.h
@@ -138,6 +138,11 @@ public:
         return sw_likely(task) ? task->pcid : 0;
     }
 
+    static inline long get_elapsed(long cid = 0)
+    {
+        return sw_likely(active) ? Coroutine::get_elapsed(cid) : -1;
+    }
+
     static inline php_coro_task* get_task()
     {
         php_coro_task *task = (php_coro_task *) Coroutine::get_current_task();

--- a/tests/swoole_coroutine/getElasped.phpt
+++ b/tests/swoole_coroutine/getElasped.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_coroutine: getElapsed
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+Co\run(function () {
+    var_dump(Co::getElapsed(1000));
+    var_dump(Co::getElapsed(-1));
+    co::sleep(.001);
+    var_dump(Co::getElapsed() === Co::getElapsed(Co::getCid()));
+});
+
+?>
+--EXPECT--
+int(-1)
+int(-1)
+bool(true)


### PR DESCRIPTION
Related to #3078 and #2827

Allow users to get the elapsed time of a coroutine.

Terminate the coroutine based on elapsed time:

```php
<?php
while (true) {
    if(Co::getElapsed() > 3000) {
        return;
    }
    // ......
}
```

Get the running time of coroutines:

```php
<?php
$server->on('workerStart', function() {
    while (true) {
        co::sleep(1);
        foreach(Co::list() as $key => $cid){
            $elapsed = Co::getElapsed($cid);
            echo "cid : ". $cid . " - ". $elapsed ."ms\n";
        }
    }
});
```

Profiling the running time of a request:

```php
<?php
$server->on('request', function (Request $request, Response $response) {
    // ...
    $elapsed = Co::getElapsed();
    $response->end("Elapsed: $elapsed ms\n");
});
```

