### PR TITLE
fix: no peer address info in swSSL_accept

### DIFF
--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -142,7 +142,9 @@ int swServer_master_onAccept(swReactor *reactor, swEvent *event)
         }
 
         memcpy(&conn->info.addr, &event->socket->info, sizeof(event->socket->info));
+        memcpy(&sock->info.addr, &event->socket->info, sizeof(event->socket->info));
         conn->socket_type = listen_host->type;
+        sock->socket_type = listen_host->type;
 
 #ifdef SW_USE_OPENSSL
         if (listen_host->ssl)


### PR DESCRIPTION
1. set conn socket info and socket type in swServer_master_onAccept