### PR TITLE
improve: set buffer NULL

### DIFF
--- a/src/reactor/base.cc
+++ b/src/reactor/base.cc
@@ -220,10 +220,12 @@ int swReactor_close(swReactor *reactor, swSocket *socket)
     if (socket->out_buffer)
     {
         swBuffer_free(socket->out_buffer);
+        socket->out_buffer = NULL;
     }
     if (socket->in_buffer)
     {
         swBuffer_free(socket->in_buffer);
+        socket->in_buffer = NULL;
     }
 
     swTraceLog(SW_TRACE_CLOSE, "fd=%d", socket->fd);


### PR DESCRIPTION
因为测试的时候，需要判断`buffer`是否释放了，所以这里置为空指针。