### PR TITLE
fix: set ssl quiet shutdown when client close

### DIFF
--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -1079,6 +1079,10 @@ void swSSL_close(swSocket *conn)
         return;
     }
 
+    /**
+     * If the peer close first, local should be set to quiet mode and do not send any data, 
+     * otherwise the peer will send RST segment.
+     */
     if (conn->ssl_quiet_shutdown)
     {
         SSL_set_quiet_shutdown(conn->ssl, 1);

--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -1082,8 +1082,11 @@ void swSSL_close(swSocket *conn)
     if (conn->ssl_quiet_shutdown)
     {
         SSL_set_quiet_shutdown(conn->ssl, 1);
-        SSL_set_shutdown(conn->ssl, SSL_RECEIVED_SHUTDOWN | SSL_SENT_SHUTDOWN);
     }
+
+    int mode = SSL_get_shutdown(conn->ssl);
+
+    SSL_set_shutdown(conn->ssl, mode | SSL_RECEIVED_SHUTDOWN | SSL_SENT_SHUTDOWN);
 
     n = SSL_shutdown(conn->ssl);
 

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -272,10 +272,6 @@ int swReactorThread_close(swReactor *reactor, swSocket *socket)
 #ifdef SW_USE_OPENSSL
     if (socket->ssl)
     {
-        /**
-         * If it is peer close first, local should be set to silent mode and do not send any data, 
-         * otherwise the peer will send RST segment.
-         */
         conn->socket->ssl_quiet_shutdown = 1;
         swSSL_close(conn->socket);
     }
@@ -381,6 +377,10 @@ static int swReactorThread_onClose(swReactor *reactor, swEvent *event)
         }
         else
         {
+            /**
+             * peer_closed indicates that the client has closed the connection 
+             * and the connection is no longer available.
+             */
             conn->peer_closed = 1;
             return serv->factory.notify(&serv->factory, &notify_ev);
         }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -272,6 +272,10 @@ int swReactorThread_close(swReactor *reactor, swSocket *socket)
 #ifdef SW_USE_OPENSSL
     if (socket->ssl)
     {
+        /**
+         * If it is peer close first, local should be set to silent mode and do not send any data, 
+         * otherwise the peer will send RST segment.
+         */
         conn->socket->ssl_quiet_shutdown = 1;
         swSSL_close(conn->socket);
     }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -272,7 +272,7 @@ int swReactorThread_close(swReactor *reactor, swSocket *socket)
 #ifdef SW_USE_OPENSSL
     if (socket->ssl)
     {
-        conn->socket->ssl_quiet_shutdown = 1;
+        conn->socket->ssl_quiet_shutdown = conn->peer_closed;
         swSSL_close(conn->socket);
     }
 #ifdef SW_SUPPORT_DTLS

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -272,6 +272,7 @@ int swReactorThread_close(swReactor *reactor, swSocket *socket)
 #ifdef SW_USE_OPENSSL
     if (socket->ssl)
     {
+        conn->socket->ssl_quiet_shutdown = 1;
         swSSL_close(conn->socket);
     }
 #ifdef SW_SUPPORT_DTLS


### PR DESCRIPTION
If it is client close first, server should be set to silent mode and do not send any data, otherwise the client will send RST segment.