### PR TITLE
Replace `bzero()` calls with `memset()`

### DIFF
--- a/core-tests/src/memory/ringbuffer.cpp
+++ b/core-tests/src/memory/ringbuffer.cpp
@@ -57,7 +57,7 @@ static void thread_write(void)
     uint32_t size, yield_count = 0, yield_total_count = 0;
     void *ptr;
     pkg send_pkg;
-    bzero(&send_pkg, sizeof(send_pkg));
+    sw_memset_zero(&send_pkg, sizeof(send_pkg));
 
     int i;
     for (i = 0; i < WRITE_N; i++)

--- a/core-tests/src/network/socket.cpp
+++ b/core-tests/src/network/socket.cpp
@@ -8,8 +8,8 @@ TEST(socket, swSocket_unix_sendto)
     char sock2_path[] = "/tmp/udp_unix2.sock";
     char test_data[] = "swoole";
 
-    bzero(&un1,sizeof(struct sockaddr_un));
-    bzero(&un2,sizeof(struct sockaddr_un));
+    sw_memset_zero(&un1,sizeof(struct sockaddr_un));
+    sw_memset_zero(&un2,sizeof(struct sockaddr_un));
 
     un1.sun_family = AF_UNIX;
     un2.sun_family = AF_UNIX;

--- a/core-tests/src/os/pipe.cpp
+++ b/core-tests/src/os/pipe.cpp
@@ -4,7 +4,7 @@ TEST(pipe, unixsock)
 {
     swPipe p;
     char buf[1024];
-    bzero(&p, sizeof(p));
+    sw_memset_zero(&p, sizeof(p));
     int ret = swPipeUnsock_create(&p, 1, SOCK_DGRAM);
     ASSERT_EQ(ret, 0);
 
@@ -46,7 +46,7 @@ TEST(pipe, base)
     ret = p.write(&p, (void *) SW_STRL("你好中国。\n"));
     ASSERT_GT(ret, 0);
 
-    bzero(data, 256);
+    sw_memset_zero(data, 256);
     ret = p.read(&p, data, 255);
     ASSERT_GT(ret, 0);
     ASSERT_EQ(strcmp("hello world\n你好中国。\n", data), 0);

--- a/examples/ssl/client.c
+++ b/examples/ssl/client.c
@@ -28,7 +28,7 @@ int OpenConnection(const char *hostname, int port)
     }
 
     sd = socket(PF_INET, SOCK_STREAM, 0);
-    bzero(&addr, sizeof(addr));
+    sw_memset_zero(&addr, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = *(long*) (host->h_addr);

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -246,6 +246,8 @@ typedef unsigned long ulong_t;
 #endif
 #endif
 
+#define sw_memset_zero(s, n)   memset(s, '\0', n)
+
 static sw_inline int sw_mem_equal(const void *v1, size_t s1, const void *v2, size_t s2)
 {
     return s1 == s2 && memcmp(v1, v2, s2) == 0;

--- a/src/core/base.cc
+++ b/src/core/base.cc
@@ -58,9 +58,9 @@ void swoole_init(void)
         return;
     }
 
-    bzero(&SwooleG, sizeof(SwooleG));
-    bzero(&SwooleWG, sizeof(SwooleWG));
-    bzero(sw_error, SW_ERROR_MSG_SIZE);
+    sw_memset_zero(&SwooleG, sizeof(SwooleG));
+    sw_memset_zero(&SwooleWG, sizeof(SwooleWG));
+    sw_memset_zero(sw_error, SW_ERROR_MSG_SIZE);
 
     SwooleG.running = 1;
     SwooleG.init = 1;
@@ -174,7 +174,7 @@ void swoole_clean(void)
     {
         SwooleG.memory_pool->destroy(SwooleG.memory_pool);
     }
-    bzero(&SwooleG, sizeof(SwooleG));
+    sw_memset_zero(&SwooleG, sizeof(SwooleG));
 }
 
 pid_t swoole_fork(int flags)
@@ -248,7 +248,7 @@ pid_t swoole_fork(int flags)
         /**
          * reset global struct
          */
-        bzero(&SwooleWG, sizeof(SwooleWG));
+        sw_memset_zero(&SwooleWG, sizeof(SwooleWG));
         SwooleG.pid = getpid();
     }
     return pid;
@@ -1262,7 +1262,7 @@ int swoole_getaddrinfo(swRequest_getaddrinfo *req)
     struct addrinfo *ptr = nullptr;
     struct addrinfo hints;
 
-    bzero(&hints, sizeof(hints));
+    sw_memset_zero(&hints, sizeof(hints));
     hints.ai_family = req->family;
     hints.ai_socktype = req->socktype;
     hints.ai_protocol = req->protocol;

--- a/src/core/channel.cc
+++ b/src/core/channel.cc
@@ -51,7 +51,7 @@ swChannel* swChannel_new(size_t size, size_t maxlen, int flags)
     swChannel *object = (swChannel *) mem;
     mem = (char*) mem + sizeof(swChannel);
 
-    bzero(object, sizeof(swChannel));
+    sw_memset_zero(object, sizeof(swChannel));
 
     //overflow space
     object->size = size;

--- a/src/core/hashmap.cc
+++ b/src/core/hashmap.cc
@@ -89,11 +89,11 @@ swHashMap* swHashMap_new(uint32_t bucket_num, swHashMap_dtor dtor)
         return nullptr;
     }
 
-    bzero(hmap, sizeof(swHashMap));
+    sw_memset_zero(hmap, sizeof(swHashMap));
     hmap->root = root;
     hmap->iterator = root;
 
-    bzero(root, sizeof(swHashMap_node));
+    sw_memset_zero(root, sizeof(swHashMap_node));
 
     root->hh.tbl = (UT_hash_table*) sw_malloc(sizeof(UT_hash_table));
     if (!(root->hh.tbl))
@@ -131,7 +131,7 @@ int swHashMap_add(swHashMap* hmap, const char *key, uint16_t key_len, void *data
         swWarn("malloc failed");
         return SW_ERR;
     }
-    bzero(node, sizeof(swHashMap_node));
+    sw_memset_zero(node, sizeof(swHashMap_node));
     swHashMap_node *root = hmap->root;
     node->key_str = sw_strndup(key, key_len);
     node->key_int = key_len;

--- a/src/core/timer.cc
+++ b/src/core/timer.cc
@@ -70,7 +70,7 @@ static int swReactorTimer_init(swReactor *reactor, swTimer *timer, long exec_mse
 
 int swTimer_init(swTimer *timer, long msec)
 {
-    bzero(timer, sizeof(swTimer));
+    sw_memset_zero(timer, sizeof(swTimer));
     if (swTimer_now(&timer->basetime) < 0)
     {
         return SW_ERR;

--- a/src/coroutine/hook.cc
+++ b/src/coroutine/hook.cc
@@ -302,7 +302,7 @@ int swoole_coroutine_open(const char *pathname, int flags, mode_t mode)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) pathname;
     ev.offset = mode;
     ev.flags = flags;
@@ -334,7 +334,7 @@ ssize_t swoole_coroutine_read(int sockfd, void *buf, size_t count)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.fd = sockfd;
     ev.buf = buf;
     ev.nbytes = count;
@@ -366,7 +366,7 @@ ssize_t swoole_coroutine_write(int sockfd, const void *buf, size_t count)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.fd = sockfd;
     ev.buf = (void*) buf;
     ev.nbytes = count;
@@ -392,7 +392,7 @@ off_t swoole_coroutine_lseek(int fd, off_t offset, int whence)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.fd = fd;
     ev.offset = offset;
     ev.flags = whence;
@@ -418,7 +418,7 @@ int swoole_coroutine_fstat(int fd, struct stat *statbuf)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.fd = fd;
     ev.buf = (void*) statbuf;
     ev.handler = handler_fstat;
@@ -443,7 +443,7 @@ int swoole_coroutine_unlink(const char *pathname)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) pathname;
     ev.handler = handler_unlink;
     ev.callback = aio_onCompleted;
@@ -467,7 +467,7 @@ int swoole_coroutine_statvfs(const char *path, struct statvfs *buf)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) path;
     ev.offset = (off_t) buf;
     ev.handler = handler_statvfs;
@@ -492,7 +492,7 @@ int swoole_coroutine_mkdir(const char *pathname, mode_t mode)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) pathname;
     ev.offset = mode;
     ev.handler = handler_mkdir;
@@ -517,7 +517,7 @@ int swoole_coroutine_rmdir(const char *pathname)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) pathname;
     ev.handler = handler_rmdir;
     ev.callback = aio_onCompleted;
@@ -541,7 +541,7 @@ int swoole_coroutine_rename(const char *oldpath, const char *newpath)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) oldpath;
     ev.offset = (off_t) newpath;
     ev.handler = handler_rename;
@@ -566,7 +566,7 @@ int swoole_coroutine_access(const char *pathname, int mode)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) pathname;
     ev.offset = mode;
     ev.handler = handler_access;
@@ -591,7 +591,7 @@ int swoole_coroutine_flock(int fd, int operation)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.fd = fd;
     ev.flags = operation;
     ev.handler = handler_flock;
@@ -631,7 +631,7 @@ DIR *swoole_coroutine_opendir(const char *name)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) name;
     ev.handler = handler_opendir;
     ev.callback = aio_onCompleted;
@@ -655,7 +655,7 @@ struct dirent *swoole_coroutine_readdir(DIR *dirp)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(ev));
+    sw_memset_zero(&ev, sizeof(ev));
     ev.buf = (void*) dirp;
     ev.handler = handler_readdir;
     ev.callback = aio_onCompleted;

--- a/src/coroutine/system.cc
+++ b/src/coroutine/system.cc
@@ -112,7 +112,7 @@ swString* System::read_file(const char *file, bool lock)
     AsyncTask task;
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     task.co = Coroutine::get_current_safe();
     task.original_event = &ev;
@@ -152,7 +152,7 @@ ssize_t System::write_file(const char *file, char *buf, size_t length, bool lock
     AsyncTask task;
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     task.co = Coroutine::get_current_safe();
     task.original_event = &ev;
@@ -202,7 +202,7 @@ string System::gethostbyname(const string &hostname, int domain, double timeout)
     swAio_event ev;
     AsyncTask task;
 
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
     if (hostname.size() < SW_IP_MAX_LENGTH)
     {
         ev.nbytes = SW_IP_MAX_LENGTH + 1;
@@ -278,10 +278,10 @@ vector<string> System::getaddrinfo(const string &hostname, int family, int sockt
     assert(family == AF_INET || family == AF_INET6);
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     swRequest_getaddrinfo req;
-    bzero(&req, sizeof(swRequest_getaddrinfo));
+    sw_memset_zero(&req, sizeof(swRequest_getaddrinfo));
 
     AsyncTask task;
 

--- a/src/lock/atomic.cc
+++ b/src/lock/atomic.cc
@@ -22,7 +22,7 @@ static int swAtomicLock_trylock(swLock *lock);
 
 int swAtomicLock_create(swLock *lock, int spin)
 {
-    bzero(lock, sizeof(swLock));
+    sw_memset_zero(lock, sizeof(swLock));
     lock->type = SW_ATOMLOCK;
     lock->object.atomlock.spin = spin;
     lock->lock = swAtomicLock_lock;

--- a/src/lock/file_lock.cc
+++ b/src/lock/file_lock.cc
@@ -27,7 +27,7 @@ static int swFileLock_free(swLock *lock);
 
 int swFileLock_create(swLock *lock, int fd)
 {
-    bzero(lock, sizeof(swLock));
+    sw_memset_zero(lock, sizeof(swLock));
     lock->type = SW_FILELOCK;
     lock->object.filelock.fd = fd;
     lock->lock_rd = swFileLock_lock_rd;

--- a/src/lock/mutex.cc
+++ b/src/lock/mutex.cc
@@ -24,7 +24,7 @@ static int swMutex_free(swLock *lock);
 int swMutex_create(swLock *lock, int use_in_process)
 {
     int ret;
-    bzero(lock, sizeof(swLock));
+    sw_memset_zero(lock, sizeof(swLock));
     lock->type = SW_MUTEX;
     pthread_mutexattr_init(&lock->object.mutex.attr);
     if (use_in_process == 1)

--- a/src/lock/rw_lock.cc
+++ b/src/lock/rw_lock.cc
@@ -28,7 +28,7 @@ static int swRWLock_free(swLock *lock);
 int swRWLock_create(swLock *lock, int use_in_process)
 {
     int ret;
-    bzero(lock, sizeof(swLock));
+    sw_memset_zero(lock, sizeof(swLock));
     lock->type = SW_RWLOCK;
     pthread_rwlockattr_init(&lock->object.rwlock.attr);
     if (use_in_process == 1)

--- a/src/lock/spin_lock.cc
+++ b/src/lock/spin_lock.cc
@@ -26,7 +26,7 @@ static int swSpinLock_free(swLock *lock);
 int swSpinLock_create(swLock *lock, int use_in_process)
 {
     int ret;
-    bzero(lock, sizeof(swLock));
+    sw_memset_zero(lock, sizeof(swLock));
     lock->type = SW_SPINLOCK;
     if ((ret = pthread_spin_init(&lock->object.spinlock.lock_t, use_in_process)) < 0)
     {

--- a/src/memory/buffer.cc
+++ b/src/memory/buffer.cc
@@ -29,7 +29,7 @@ swBuffer* swBuffer_new(uint32_t chunk_size)
         return nullptr;
     }
 
-    bzero(buffer, sizeof(swBuffer));
+    sw_memset_zero(buffer, sizeof(swBuffer));
     buffer->chunk_size = chunk_size == 0 ? INT_MAX : chunk_size;
 
     return buffer;
@@ -47,7 +47,7 @@ swBuffer_chunk *swBuffer_new_chunk(swBuffer *buffer, uint32_t type, uint32_t siz
         return nullptr;
     }
 
-    bzero(chunk, sizeof(swBuffer_chunk));
+    sw_memset_zero(chunk, sizeof(swBuffer_chunk));
 
     //require alloc memory
     if (type == SW_CHUNK_DATA && size > 0)

--- a/src/memory/fixed_pool.cc
+++ b/src/memory/fixed_pool.cc
@@ -40,7 +40,7 @@ swMemoryPool* swFixedPool_new(uint32_t slice_num, uint32_t slice_size, uint8_t s
 
     swFixedPool *object = (swFixedPool *) memory;
     memory = (char *) memory + sizeof(swFixedPool);
-    bzero(object, sizeof(swFixedPool));
+    sw_memset_zero(object, sizeof(swFixedPool));
 
     object->shared = shared;
     object->slice_num = slice_num;
@@ -71,7 +71,7 @@ swMemoryPool* swFixedPool_new2(uint32_t slice_size, void *memory, size_t size)
 {
     swFixedPool *object = (swFixedPool *) memory;
     memory = (char *) memory + sizeof(swFixedPool);
-    bzero(object, sizeof(swFixedPool));
+    sw_memset_zero(object, sizeof(swFixedPool));
 
     object->slice_size = slice_size;
     object->size = size - sizeof(swMemoryPool) - sizeof(swFixedPool);
@@ -79,7 +79,7 @@ swMemoryPool* swFixedPool_new2(uint32_t slice_size, void *memory, size_t size)
 
     swMemoryPool *pool = (swMemoryPool *) memory;
     memory = (char *) memory + sizeof(swMemoryPool);
-    bzero(pool, sizeof(swMemoryPool));
+    sw_memset_zero(pool, sizeof(swMemoryPool));
 
     pool->object = object;
     pool->alloc = swFixedPool_alloc;
@@ -107,7 +107,7 @@ static void swFixedPool_init(swFixedPool *object)
     do
     {
         slice = (swFixedPool_slice *) cur;
-        bzero(slice, sizeof(swFixedPool_slice));
+        sw_memset_zero(slice, sizeof(swFixedPool_slice));
 
         if (object->head != nullptr)
         {

--- a/src/memory/global_memory.cc
+++ b/src/memory/global_memory.cc
@@ -43,7 +43,7 @@ swMemoryPool* swMemoryGlobal_new(uint32_t pagesize, uint8_t shared)
 {
     swMemoryGlobal gm, *gm_ptr;
     assert(pagesize >= SW_MIN_PAGE_SIZE);
-    bzero(&gm, sizeof(swMemoryGlobal));
+    sw_memset_zero(&gm, sizeof(swMemoryGlobal));
 
     gm.shared = shared;
     gm.pagesize = pagesize;
@@ -82,7 +82,7 @@ static swMemoryGlobal_page* swMemoryGlobal_new_page(swMemoryGlobal *gm)
     {
         return nullptr;
     }
-    bzero(page, gm->pagesize);
+    sw_memset_zero(page, gm->pagesize);
     page->next = nullptr;
 
     if (gm->current_page != nullptr)

--- a/src/memory/ring_buffer.cc
+++ b/src/memory/ring_buffer.cc
@@ -62,7 +62,7 @@ swMemoryPool *swRingBuffer_new(uint32_t size, uint8_t shared)
 
     swRingBuffer *object = (swRingBuffer *) mem;
     mem = (char *) mem + sizeof(swRingBuffer);
-    bzero(object, sizeof(swRingBuffer));
+    sw_memset_zero(object, sizeof(swRingBuffer));
 
     object->size = (size - sizeof(swRingBuffer) - sizeof(swMemoryPool));
     object->shared = shared;

--- a/src/memory/shared_memory.cc
+++ b/src/memory/shared_memory.cc
@@ -52,7 +52,7 @@ void* sw_shm_calloc(size_t num, size_t _size)
     {
         memcpy(mem, &object, sizeof(swShareMemory));
         ret_mem = (char *) mem + sizeof(swShareMemory);
-        bzero(ret_mem, size - sizeof(swShareMemory));
+        sw_memset_zero(ret_mem, size - sizeof(swShareMemory));
         return ret_mem;
     }
 }
@@ -91,7 +91,7 @@ void *swShareMemory_mmap_create(swShareMemory *object, size_t size, const char *
     void *mem;
     int tmpfd = -1;
     int flag = MAP_SHARED;
-    bzero(object, sizeof(swShareMemory));
+    sw_memset_zero(object, sizeof(swShareMemory));
 
 #ifdef MAP_ANONYMOUS
     flag |= MAP_ANONYMOUS;
@@ -147,7 +147,7 @@ void *swShareMemory_sysv_create(swShareMemory *object, size_t size, int key)
 {
     int shmid;
     void *mem;
-    bzero(object, sizeof(swShareMemory));
+    sw_memset_zero(object, sizeof(swShareMemory));
 
     if (key == 0)
     {

--- a/src/memory/table.cc
+++ b/src/memory/table.cc
@@ -81,7 +81,7 @@ swTable* swTable_new(uint32_t rows_size, float conflict_proportion)
     table->hash_func = swoole_hash_austin;
 #endif
 
-    bzero(table->iterator, sizeof(swTable_iterator));
+    sw_memset_zero(table->iterator, sizeof(swTable_iterator));
     table->memory = nullptr;
 
     return table;
@@ -197,7 +197,7 @@ static sw_inline swTableRow* swTable_hash(swTable *table, const char *key, int k
 
 void swTable_iterator_rewind(swTable *table)
 {
-    bzero(table->iterator, sizeof(swTable_iterator));
+    sw_memset_zero(table->iterator, sizeof(swTable_iterator));
 }
 
 static sw_inline swTableRow* swTable_iterator_get(swTable *table, uint32_t index)
@@ -283,7 +283,7 @@ swTableRow* swTableRow_get(swTable *table, const char *key, int keylen, swTableR
 
 static inline void swTableRow_init(swTable *table, swTableRow *new_row, const char *key, int keylen)
 {
-    bzero(new_row, sizeof(swTableRow));
+    sw_memset_zero(new_row, sizeof(swTableRow));
     memcpy(new_row->key, key, keylen);
     new_row->key[keylen] = '\0';
     new_row->key_len = keylen;
@@ -372,7 +372,7 @@ int swTableRow_del(swTable *table, const char *key, int keylen)
     {
         if (sw_mem_equal(row->key, row->key_len, key, keylen))
         {
-            bzero(row, sizeof(swTableRow));
+            sw_memset_zero(row, sizeof(swTableRow));
             goto _delete_element;
         }
         else
@@ -416,7 +416,7 @@ int swTableRow_del(swTable *table, const char *key, int keylen)
             prev->next = tmp->next;
         }
         table->lock.lock(&table->lock);
-        bzero(tmp, sizeof(swTableRow) + table->item_size);
+        sw_memset_zero(tmp, sizeof(swTableRow) + table->item_size);
         table->pool->free(table->pool, tmp);
         table->lock.unlock(&table->lock);
     }

--- a/src/network/client.cc
+++ b/src/network/client.cc
@@ -62,7 +62,7 @@ void swClient_init_reactor(swReactor *reactor)
 
 int swClient_create(swClient *cli, enum swSocket_type type, int async)
 {
-    bzero(cli, sizeof(swClient));
+    sw_memset_zero(cli, sizeof(swClient));
 
     int sockfd = swSocket_create(type, async, 1);
     if (sockfd < 0)
@@ -639,7 +639,7 @@ static int swClient_tcp_connect_async(swClient *cli, const char *host, int port,
     if (cli->wait_dns)
     {
         swAio_event ev;
-        bzero(&ev, sizeof(swAio_event));
+        sw_memset_zero(&ev, sizeof(swAio_event));
 
         int len = strlen(cli->server_host);
         if (strlen(cli->server_host) < SW_IP_MAX_LENGTH)

--- a/src/network/socket.cc
+++ b/src/network/socket.cc
@@ -294,7 +294,7 @@ ssize_t swSocket_udp_sendto(int server_sock, const char *dst_ip, int dst_port, c
 ssize_t swSocket_udp_sendto6(int server_sock, const char *dst_ip, int dst_port, const char *data, uint32_t len)
 {
     struct sockaddr_in6 addr;
-    bzero(&addr, sizeof(addr));
+    sw_memset_zero(&addr, sizeof(addr));
     if (inet_pton(AF_INET6, dst_ip, &addr.sin6_addr) < 0)
     {
         swWarn("ip[%s] is invalid", dst_ip);
@@ -308,7 +308,7 @@ ssize_t swSocket_udp_sendto6(int server_sock, const char *dst_ip, int dst_port, 
 ssize_t swSocket_unix_sendto(int server_sock, const char *dst_path, const char *data, uint32_t len)
 {
     struct sockaddr_un addr;
-    bzero(&addr, sizeof(addr));
+    sw_memset_zero(&addr, sizeof(addr));
     addr.sun_family = AF_UNIX;
     strncpy(addr.sun_path, dst_path, sizeof(addr.sun_path) - 1);
     return swSocket_sendto_blocking(server_sock, data, len, 0, (struct sockaddr *) &addr, sizeof(addr));
@@ -786,7 +786,7 @@ int swSocket_sendfile(swSocket *conn, const char *filename, off_t offset, size_t
         swWarn("malloc for swTask_sendfile failed");
         return SW_ERR;
     }
-    bzero(task, sizeof(swTask_sendfile));
+    sw_memset_zero(task, sizeof(swTask_sendfile));
 
     task->filename = sw_strdup(filename);
     task->fd = file_fd;

--- a/src/network/stream.cc
+++ b/src/network/stream.cc
@@ -83,7 +83,7 @@ swStream* swStream_new(const char *dst_host, int dst_port, enum swSocket_type ty
     {
         return nullptr;
     }
-    bzero(stream, sizeof(swStream));
+    sw_memset_zero(stream, sizeof(swStream));
 
     swClient *cli = &stream->client;
     if (swClient_create(cli, type, 1) < 0)

--- a/src/os/base.cc
+++ b/src/os/base.cc
@@ -515,7 +515,7 @@ void swAio_handler_gethostbyname(swAio_event *event)
 
     ret = swoole_gethostbyname(event->flags, (char*) event->buf, addr);
     
-    bzero(event->buf, event->nbytes);
+    sw_memset_zero(event->buf, event->nbytes);
 #ifndef HAVE_GETHOSTBYNAME2_R
     SwooleG.lock.unlock(&SwooleG.lock);
 #endif

--- a/src/os/msg_queue.cc
+++ b/src/os/msg_queue.cc
@@ -57,7 +57,7 @@ int swMsgQueue_create(swMsgQueue *q, int blocking, key_t msg_key, int perms)
     }
     else
     {
-        bzero(q, sizeof(swMsgQueue));
+        sw_memset_zero(q, sizeof(swMsgQueue));
         q->msg_id = msg_id;
         q->perms = perms;
         q->blocking = blocking;

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -63,7 +63,7 @@ static void swProcessPool_kill_timeout_worker(swTimer *timer, swTimer_node *tnod
  */
 int swProcessPool_create(swProcessPool *pool, uint32_t worker_num, key_t msgqueue_key, int ipc_mode)
 {
-    bzero(pool, sizeof(swProcessPool));
+    sw_memset_zero(pool, sizeof(swProcessPool));
 
     uint32_t i;
 
@@ -127,7 +127,7 @@ int swProcessPool_create(swProcessPool *pool, uint32_t worker_num, key_t msgqueu
             swWarn("malloc[2] failed");
             return SW_ERR;
         }
-        bzero(pool->stream, sizeof(swStreamInfo));
+        sw_memset_zero(pool->stream, sizeof(swStreamInfo));
     }
     else
     {

--- a/src/os/signal.cc
+++ b/src/os/signal.cc
@@ -218,14 +218,14 @@ void swSignal_clear(void)
             }
         }
     }
-    bzero(&signals, sizeof(signals));
+    sw_memset_zero(&signals, sizeof(signals));
 }
 
 #ifdef HAVE_SIGNALFD
 void swSignalfd_init()
 {
     sigemptyset(&signalfd_mask);
-    bzero(&signals, sizeof(signals));
+    sw_memset_zero(&signals, sizeof(signals));
 }
 
 static void swSignalfd_set(int signo, swSignalHandler handler)
@@ -233,7 +233,7 @@ static void swSignalfd_set(int signo, swSignalHandler handler)
     if (handler == nullptr && signals[signo].active)
     {
         sigdelset(&signalfd_mask, signo);
-        bzero(&signals[signo], sizeof(swSignal));
+        sw_memset_zero(&signals[signo], sizeof(swSignal));
     }
     else
     {
@@ -307,7 +307,7 @@ static void swSignalfd_clear()
             swSocket_free(signal_socket);
             signal_socket = nullptr;
         }
-        bzero(&signalfd_mask, sizeof(signalfd_mask));
+        sw_memset_zero(&signalfd_mask, sizeof(signalfd_mask));
     }
     signal_fd = 0;
 }
@@ -357,7 +357,7 @@ static void swKqueueSignal_set(int signo, swSignalHandler handler)
     if (handler == nullptr)
     {
         signal(signo, SIG_DFL);
-        bzero(&signals[signo], sizeof(swSignal));
+        sw_memset_zero(&signals[signo], sizeof(swSignal));
         EV_SET(&ev, signo, EVFILT_SIGNAL, EV_DELETE, 0, 0, nullptr);
     }
     // add/update signal

--- a/src/os/thread_pool.cc
+++ b/src/os/thread_pool.cc
@@ -21,7 +21,7 @@ static void* swThreadPool_loop(void *arg);
 
 int swThreadPool_create(swThreadPool *pool, int thread_num)
 {
-    bzero(pool, sizeof(swThreadPool));
+    sw_memset_zero(pool, sizeof(swThreadPool));
 
     pool->threads = (swThread *) sw_calloc(thread_num, sizeof(swThread));
     if (!pool->threads)

--- a/src/pipe/unix_socket.cc
+++ b/src/pipe/unix_socket.cc
@@ -85,7 +85,7 @@ int swPipeUnsock_create(swPipe *p, int blocking, int protocol)
         swWarn("malloc() failed");
         return SW_ERR;
     }
-    bzero(object, sizeof(swPipeUnsock));
+    sw_memset_zero(object, sizeof(swPipeUnsock));
     p->blocking = blocking;
     ret = socketpair(AF_UNIX, protocol, 0, object->socks);
     if (ret < 0)

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -611,7 +611,7 @@ void swHttpRequest_free(swConnection *conn)
     {
         swString_free(request->buffer);
     }
-    bzero(request, sizeof(swHttpRequest));
+    sw_memset_zero(request, sizeof(swHttpRequest));
     sw_free(request);
     conn->object = nullptr;
 }

--- a/src/protocol/redis.cc
+++ b/src/protocol/redis.cc
@@ -51,7 +51,7 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
             swWarn("malloc(%ld) failed", sizeof(swRedis_request));
             return SW_ERR;
         }
-        bzero(request, sizeof(swRedis_request));
+        sw_memset_zero(request, sizeof(swRedis_request));
         conn->object = request;
     }
     else
@@ -170,7 +170,7 @@ int swRedis_recv(swProtocol *protocol, swConnection *conn, swString *buffer)
                             return SW_OK;
                         }
                         swString_clear(buffer);
-                        bzero(request, sizeof(swRedis_request));
+                        sw_memset_zero(request, sizeof(swRedis_request));
                         return SW_OK;
                     }
                 }

--- a/src/protocol/websocket.cc
+++ b/src/protocol/websocket.cc
@@ -245,7 +245,7 @@ int swWebSocket_dispatch_frame(swProtocol *proto, swSocket *_socket, const char 
     swServer *serv = (swServer *) proto->private_data_2;
     swConnection *conn = (swConnection *) _socket->object;
     swString frame;
-    bzero(&frame, sizeof(frame));
+    sw_memset_zero(&frame, sizeof(frame));
     frame.str = const_cast<char*>(data);
     frame.length = length;
 

--- a/src/reactor/base.cc
+++ b/src/reactor/base.cc
@@ -42,7 +42,7 @@ static void defer_task_add(swReactor *reactor, swCallback callback, void *data);
 int swReactor_create(swReactor *reactor, int max_event)
 {
     int ret;
-    bzero(reactor, sizeof(swReactor));
+    sw_memset_zero(reactor, sizeof(swReactor));
 
 #ifdef HAVE_EPOLL
     ret = swReactorEpoll_create(reactor, max_event);

--- a/src/reactor/epoll.cc
+++ b/src/reactor/epoll.cc
@@ -83,7 +83,7 @@ int swReactorEpoll_create(swReactor *reactor, int max_event_num)
         swWarn("malloc[0] failed");
         return SW_ERR;
     }
-    bzero(object, sizeof(swReactorEpoll));
+    sw_memset_zero(object, sizeof(swReactorEpoll));
     reactor->object = object;
     reactor->max_event_num = max_event_num;
 

--- a/src/reactor/poll.cc
+++ b/src/reactor/poll.cc
@@ -40,7 +40,7 @@ int swReactorPoll_create(swReactor *reactor, int max_fd_num)
         swWarn("malloc[0] failed");
         return SW_ERR;
     }
-    bzero(object, sizeof(swReactorPoll));
+    sw_memset_zero(object, sizeof(swReactorPoll));
 
     object->fds = (swSocket **) sw_calloc(max_fd_num, sizeof(swSocket*));
     if (object->fds == nullptr)

--- a/src/server/base.cc
+++ b/src/server/base.cc
@@ -120,7 +120,7 @@ static int swFactory_end(swFactory *factory, int fd)
     swSendData _send;
     swDataHead info;
 
-    bzero(&_send, sizeof(_send));
+    sw_memset_zero(&_send, sizeof(_send));
     _send.info.fd = fd;
     _send.info.len = 0;
     _send.info.type = SW_SERVER_EVENT_CLOSE;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -290,7 +290,7 @@ dtls::Session* swServer_dtls_accept(swServer *serv, swListenPort *port, swSocket
     }
     if (conn)
     {
-        bzero(conn, sizeof(*conn));
+        sw_memset_zero(conn, sizeof(*conn));
     }
     if (session)
     {
@@ -845,7 +845,7 @@ int swServer_start(swServer *serv)
 void swServer_init(swServer *serv)
 {
     swoole_init();
-    bzero(serv, sizeof(swServer));
+    sw_memset_zero(serv, sizeof(swServer));
 
     serv->factory_mode = SW_MODE_BASE;
 
@@ -1092,7 +1092,7 @@ static int swServer_tcp_feedback(swServer *serv, int session_id, int event)
     }
 
     swSendData _send;
-    bzero(&_send, sizeof(_send));
+    sw_memset_zero(&_send, sizeof(_send));
     _send.info.type = event;
     _send.info.fd = session_id;
     _send.info.reactor_id = conn->reactor_id;
@@ -1137,7 +1137,7 @@ swPipe * swServer_get_pipe_object(swServer *serv, int pipe_fd)
 static int swServer_tcp_send(swServer *serv, int session_id, void *data, uint32_t length)
 {
     swSendData _send;
-    bzero(&_send.info, sizeof(_send.info));
+    sw_memset_zero(&_send.info, sizeof(_send.info));
     swFactory *factory = &(serv->factory);
 
     if (sw_unlikely(swIsMaster()))
@@ -1980,7 +1980,7 @@ static swConnection* swServer_connection_new(swServer *serv, swListenPort *ls, s
     }
 
     swConnection *connection = &(serv->connection_list[fd]);
-    bzero(connection, sizeof(*connection));
+    sw_memset_zero(connection, sizeof(*connection));
     _socket->object = connection;
     _socket->removed = 1;
     _socket->buffer_size = ls->socket_buffer_size;
@@ -2100,7 +2100,7 @@ int swServer_create_pipe_buffers(swServer *serv)
             swSysError("malloc[sndbuf][%d] failed", i);
             return SW_ERR;
         }
-        bzero(serv->pipe_buffers[i], sizeof(swDataHead));
+        sw_memset_zero(serv->pipe_buffers[i], sizeof(swDataHead));
     }
 
     return SW_OK;

--- a/src/server/process.cc
+++ b/src/server/process.cc
@@ -190,7 +190,7 @@ static int swFactoryProcess_start(swFactory *factory)
         swSysError("malloc[send_buffer] failed");
         return SW_ERR;
     }
-    bzero(object->send_buffer, sizeof(swDataHead));
+    sw_memset_zero(object->send_buffer, sizeof(swDataHead));
 
     /**
      * The manager process must be started first, otherwise it will have a thread fork

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -534,7 +534,7 @@ static int swReactorProcess_send2client(swFactory *factory, swSendData *data)
         swTrace("session->reactor_id=%d, SwooleWG.id=%d", session->reactor_id, SwooleWG.id);
         swWorker *worker = swProcessPool_get_worker(&serv->gs->event_workers, session->reactor_id);
         swEventData proxy_msg;
-        bzero(&proxy_msg.info, sizeof(proxy_msg.info));
+        sw_memset_zero(&proxy_msg.info, sizeof(proxy_msg.info));
 
         if (data->info.type == SW_SERVER_EVENT_SEND_DATA)
         {
@@ -599,7 +599,7 @@ static void swReactorProcess_onTimeout(swTimer *timer, swTimer_node *tnode)
     int fd;
     int checktime;
 
-    bzero(&notify_ev, sizeof(notify_ev));
+    sw_memset_zero(&notify_ev, sizeof(notify_ev));
     notify_ev.type = SW_FD_SESSION;
 
     int serv_max_fd = swServer_get_maxfd(serv);

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -140,7 +140,7 @@ static int swReactorThread_onPacketReceived(swReactor *reactor, swEvent *event)
 
     pkt->socket_addr.len = sizeof(pkt->socket_addr.addr);
 
-    bzero(&task.info, sizeof(task.info));
+    sw_memset_zero(&task.info, sizeof(task.info));
     task.info.server_fd = fd;
     task.info.reactor_id = SwooleTG.id;
     task.info.type = SW_SERVER_EVENT_SNED_DGRAM;
@@ -334,7 +334,7 @@ int swReactorThread_close(swReactor *reactor, swSocket *socket)
         swServer_set_maxfd(serv, find_max_fd);
         swServer_unlock(serv);
     }
-    bzero(conn, sizeof(swConnection));
+    sw_memset_zero(conn, sizeof(swConnection));
     return swReactor_close(reactor, socket);
 }
 
@@ -346,7 +346,7 @@ static int swReactorThread_onClose(swReactor *reactor, swEvent *event)
     swServer *serv = (swServer *) reactor->ptr;
     int fd = event->fd;
     swDataHead notify_ev;
-    bzero(&notify_ev, sizeof(notify_ev));
+    sw_memset_zero(&notify_ev, sizeof(notify_ev));
     swSocket *socket = event->socket;
 
     assert(fd % serv->reactor_num == reactor->id);
@@ -1218,7 +1218,7 @@ int swReactorThread_dispatch(swProtocol *proto, swSocket *_socket, const char *d
 
     swConnection *conn = (swConnection *) _socket->object;
 
-    bzero(&task.info, sizeof(task.info));
+    sw_memset_zero(&task.info, sizeof(task.info));
     task.info.server_fd = conn->server_fd;
     task.info.reactor_id = conn->reactor_id;
     task.info.ext_flags = proto->ext_flags;

--- a/src/server/task_worker.cc
+++ b/src/server/task_worker.cc
@@ -88,7 +88,7 @@ int swTaskWorker_onTask(swProcessPool *pool, swEventData *task)
 int swTaskWorker_large_pack(swEventData *task, const void *data, size_t data_len)
 {
     swPacket_task pkg;
-    bzero(&pkg, sizeof(pkg));
+    sw_memset_zero(&pkg, sizeof(pkg));
 
     memcpy(pkg.tmpfile, SwooleG.task_tmpdir, SwooleG.task_tmpdir_len);
 
@@ -251,7 +251,7 @@ static int swTaskWorker_loop_async(swProcessPool *pool, swWorker *worker)
 int swTaskWorker_finish(swServer *serv, const char *data, size_t data_len, int flags, swEventData *current_task)
 {
     swEventData buf;
-    bzero(&buf.info, sizeof(buf.info));
+    sw_memset_zero(&buf.info, sizeof(buf.info));
     if (serv->task_worker_num < 1)
     {
         swWarn("cannot use task/finish, because no set serv->task_worker_num");

--- a/src/server/worker.cc
+++ b/src/server/worker.cc
@@ -217,7 +217,7 @@ static int swWorker_onStreamPackage(swProtocol *proto, swSocket *sock, const cha
     memcpy(&task.info, data + 4, sizeof(task.info));
     task.info.flags = SW_EVENT_DATA_PTR;
 
-    bzero(&task.data, sizeof(task.data));
+    sw_memset_zero(&task.data, sizeof(task.data));
     task.data.length = length - (uint32_t) sizeof(task.info) - 4;
     task.data.str = (char*) (data + 4 + sizeof(task.info));
 

--- a/src/wrapper/server.cc
+++ b/src/wrapper/server.cc
@@ -222,7 +222,7 @@ int Server::task(DataBuffer &data, int dst_worker_id)
     }
 
     swEventData buf;
-    bzero(&buf.info, sizeof(buf.info));
+    sw_memset_zero(&buf.info, sizeof(buf.info));
     if (check_task_param(dst_worker_id) < 0)
     {
         return false;
@@ -568,7 +568,7 @@ DataBuffer Server::taskwait(const DataBuffer &data, double timeout, int dst_work
 
     uint64_t notify;
     swEventData *task_result = &(serv.task_result[SwooleWG.id]);
-    bzero(task_result, sizeof(swEventData));
+    sw_memset_zero(task_result, sizeof(swEventData));
     swPipe *task_notify_pipe = &serv.task_notify[SwooleWG.id];
     swSocket *task_notify_socket = task_notify_pipe->getSocket(task_notify_pipe, 0);
 
@@ -612,7 +612,7 @@ map<int, DataBuffer> Server::taskWaitMulti(const vector<DataBuffer> &tasks, doub
 
     uint64_t notify;
     swEventData *task_result = &(serv.task_result[SwooleWG.id]);
-    bzero(task_result, sizeof(swEventData));
+    sw_memset_zero(task_result, sizeof(swEventData));
     swPipe *task_notify_pipe = &serv.task_notify[SwooleWG.id];
     swWorker *worker = swServer_get_worker(&serv, SwooleWG.id);
 

--- a/swoole_async_coro.cc
+++ b/swoole_async_coro.cc
@@ -183,7 +183,7 @@ PHP_FUNCTION(swoole_async_dns_lookup_coro)
     if (cache_iterator == request_cache_map.end())
     {
         cache = (dns_cache *) emalloc(sizeof(dns_cache));
-        bzero(cache, sizeof(dns_cache));
+        sw_memset_zero(cache, sizeof(dns_cache));
         request_cache_map[key] = cache;
     }
     else

--- a/swoole_coroutine_system.cc
+++ b/swoole_coroutine_system.cc
@@ -350,7 +350,7 @@ PHP_METHOD(swoole_coroutine_system, fread)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     ev.nbytes = length;
     ev.buf = emalloc(ev.nbytes + 1);
@@ -405,7 +405,7 @@ PHP_METHOD(swoole_coroutine_system, fgets)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     php_stream_from_res(stream, Z_RES_P(handle));
 
@@ -494,7 +494,7 @@ PHP_METHOD(swoole_coroutine_system, fwrite)
     }
 
     swAio_event ev;
-    bzero(&ev, sizeof(swAio_event));
+    sw_memset_zero(&ev, sizeof(swAio_event));
 
     ev.nbytes = length;
     ev.buf = estrndup(str, length);

--- a/swoole_event.cc
+++ b/swoole_event.cc
@@ -425,7 +425,7 @@ int swoole_convert_to_fd_ex(zval *zsocket, int *async)
 php_socket* swoole_convert_to_socket(int sock)
 {
     php_socket *socket_object = (php_socket *) emalloc(sizeof *socket_object);
-    bzero(socket_object, sizeof(php_socket));
+    sw_memset_zero(socket_object, sizeof(php_socket));
     socket_object->bsd_socket = sock;
     socket_object->blocking = 1;
 

--- a/swoole_runtime.cc
+++ b/swoole_runtime.cc
@@ -1779,7 +1779,7 @@ static void hook_func(const char *name, size_t l_name, zif_handler handler)
     }
 
     rf = (real_func *) emalloc(sizeof(real_func));
-    bzero(rf, sizeof(real_func));
+    sw_memset_zero(rf, sizeof(real_func));
     rf->function = zf;
     rf->ori_handler = zf->internal_function.handler;
     zf->internal_function.handler = handler;

--- a/swoole_server.cc
+++ b/swoole_server.cc
@@ -1005,7 +1005,7 @@ static void php_swoole_task_wait_co(swServer *serv, swEventData *req, double tim
     swTask_type(req) |= (SW_TASK_NONBLOCK | SW_TASK_COROUTINE);
 
     swTaskCo *task_co = (swTaskCo *) emalloc(sizeof(swTaskCo));
-    bzero(task_co, sizeof(swTaskCo));
+    sw_memset_zero(task_co, sizeof(swTaskCo));
     task_co->count = 1;
     Z_LVAL(task_co->context.coro_params) = req->info.fd;
 
@@ -3486,7 +3486,7 @@ static PHP_METHOD(swoole_server, taskwait)
 
     uint64_t notify;
     swEventData *task_result = &(serv->task_result[SwooleWG.id]);
-    bzero(task_result, sizeof(swEventData));
+    sw_memset_zero(task_result, sizeof(swEventData));
     swPipe *task_notify_pipe = &serv->task_notify[SwooleWG.id];
     swSocket *task_notify_socket = task_notify_pipe->getSocket(task_notify_pipe, SW_PIPE_READ);
 
@@ -3583,7 +3583,7 @@ static PHP_METHOD(swoole_server, taskWaitMulti)
 
     uint64_t notify;
     swEventData *task_result = &(serv->task_result[SwooleWG.id]);
-    bzero(task_result, sizeof(swEventData));
+    sw_memset_zero(task_result, sizeof(swEventData));
     swPipe *task_notify_pipe = &serv->task_notify[SwooleWG.id];
     swWorker *worker = swServer_get_worker(serv, SwooleWG.id);
 


### PR DESCRIPTION
The POSIX function `bzero()` is deprecated in IEEE Std 1003.1-2001 and **removed** in IEEE Std 1003.1-2008. 

Although most platforms reserve it for compatibility, it is not guarenteed to exist, even in `<strings.h>`.

It is recommented that we replace that call with `memset()` instead, which is a standard ISO C function:
```C
#define sw_bzero(s, n)         memset(s, '\0', n)
```