### PR TITLE
fix: fix build error

### DIFF
--- a/core-tests/src/coroutine/socket.cpp
+++ b/core-tests/src/coroutine/socket.cpp
@@ -3,8 +3,6 @@
 #include "test_server.h"
 #include "swoole_cxx.h"
 
-#include <sys/random.h>
-
 using namespace swoole::test;
 
 using swoole::coroutine::Socket;


### PR DESCRIPTION
without `sys/random.h`, `core-tests` will fail to compile.