### PR TITLE
fix a typo introduced in pull request #3463

### DIFF
--- a/swoole_mysql_coro.cc
+++ b/swoole_mysql_coro.cc
@@ -479,7 +479,7 @@ ZEND_END_ARG_INFO()
 
 #ifdef SW_USE_MYSQLND
 ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_mysql_coro_escape, 0, 0, 1)
-    ZEND_ARG_INFO(0, String)
+    ZEND_ARG_INFO(0, string)
     ZEND_ARG_INFO(0, flags)
 ZEND_END_ARG_INFO()
 #endif


### PR DESCRIPTION
This is to fix the name of the first parameter in method _\Swoole\Coroutine\MySQL::escape()_. The typo was introduced in pull request [#3463](https://github.com/swoole/swoole-src/pull/3463/files#diff-1a4d6830007617253c17b75c151905eaL475).