### PR TITLE
Fix headers_sent() with output buffering in coroutines

### DIFF
--- a/swoole_coroutine.h
+++ b/swoole_coroutine.h
@@ -59,6 +59,7 @@ struct php_coro_task
     zend_error_handling_t error_handling;
     zend_class_entry *exception_class;
     zend_object *exception;
+    unsigned char headers_sent;
     zend_output_globals *output_ptr;
     /* for array_walk non-reentrancy */
     php_swoole_fci *array_walk_fci;
@@ -211,6 +212,8 @@ protected:
     static inline void restore_vm_stack(php_coro_task *task);
     static inline void save_og(php_coro_task *task);
     static inline void restore_og(php_coro_task *task);
+    static inline void save_sg(php_coro_task *task);
+    static inline void restore_sg(php_coro_task *task);
     static inline void save_task(php_coro_task *task);
     static inline void restore_task(php_coro_task *task);
     static void on_yield(void *arg);

--- a/tests/swoole_http_server/headers_sent.phpt
+++ b/tests/swoole_http_server/headers_sent.phpt
@@ -1,0 +1,49 @@
+--TEST--
+swoole_http_server: headers sent (coroutine disabled)
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:{$pm->getFreePort()}/");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    echo curl_exec($ch);
+    echo curl_exec($ch);
+    curl_close($ch);
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $http = new swoole_http_server('127.0.0.1', $pm->getFreePort());
+    $http->set([
+        'worker_num' => 1,
+        'enable_coroutine' => false,
+        'log_file' => '/dev/null'
+    ]);
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (swoole_http_request $request, swoole_http_response $response) {
+        ob_start();
+        echo 'Test';
+        $output = ob_get_clean();
+        $response->write('buffered_output=' . $output . "\n");
+        $response->write('headers_sent=' . (int)headers_sent() . "\n");
+        $response->end();
+    });
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+buffered_output=Test
+headers_sent=0
+buffered_output=Test
+headers_sent=0

--- a/tests/swoole_http_server/headers_sent_coroutine.phpt
+++ b/tests/swoole_http_server/headers_sent_coroutine.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_http_server: output buffering
+swoole_http_server: headers sent (coroutine enabled)
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
@@ -22,6 +22,7 @@ $pm->childFunc = function () use ($pm) {
     $http = new swoole_http_server('127.0.0.1', $pm->getFreePort());
     $http->set([
         'worker_num' => 1,
+        'enable_coroutine' => true,
         'log_file' => '/dev/null'
     ]);
     $http->on('workerStart', function () use ($pm) {

--- a/tests/swoole_http_server/output_buffering.phpt
+++ b/tests/swoole_http_server/output_buffering.phpt
@@ -1,0 +1,48 @@
+--TEST--
+swoole_http_server: output buffering
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:{$pm->getFreePort()}/");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    echo curl_exec($ch);
+    echo curl_exec($ch);
+    curl_close($ch);
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $http = new swoole_http_server('127.0.0.1', $pm->getFreePort());
+    $http->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null'
+    ]);
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (swoole_http_request $request, swoole_http_response $response) {
+        ob_start();
+        echo 'Test';
+        $output = ob_get_clean();
+        $response->write('buffered_output=' . $output . "\n");
+        $response->write('headers_sent=' . (int)headers_sent() . "\n");
+        $response->end();
+    });
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+buffered_output=Test
+headers_sent=0
+buffered_output=Test
+headers_sent=0


### PR DESCRIPTION
- Test output buffering `ob_*()` functions
- Assert invariance of `headers_sent()` state