### PR TITLE
Fixed: don't need block signals

### DIFF
--- a/include/swoole_signal.h
+++ b/include/swoole_signal.h
@@ -33,6 +33,7 @@ int swSignalfd_setup(swReactor *reactor);
 #endif
 
 swSignalHandler swSignal_set(int signo, swSignalHandler func);
+swSignalHandler swSignal_set(int signo, swSignalHandler func, int restart, int mask);
 swSignalHandler swSignal_get_handler(int signo);
 void swSignal_clear(void);
 void swSignal_none(void);

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -304,7 +304,6 @@ void ProcessPool::shutdown() {
     swWorker *worker;
     running = 0;
 
-    swSignal_none();
     // concurrent kill
     for (i = 0; i < worker_num; i++) {
         worker = &workers[i];

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -318,7 +318,6 @@ void ProcessPool::shutdown() {
             swSysWarn("waitpid(%d) failed", worker->pid);
         }
     }
-    destroy();
     started = false;
 }
 

--- a/src/os/signal.cc
+++ b/src/os/signal.cc
@@ -82,7 +82,7 @@ swSignalHandler swSignal_set(int signo, swSignalHandler func, int restart, int m
         func = SIG_DFL;
     }
 
-    struct sigaction act, oact;
+    struct sigaction act{}, oact{};
     act.sa_handler = func;
     if (mask) {
         sigfillset(&act.sa_mask);
@@ -118,7 +118,7 @@ swSignalHandler swSignal_set(int signo, swSignalHandler handler) {
             signals[signo].handler = handler;
             signals[signo].activated = true;
             signals[signo].signo = signo;
-            return swSignal_set(signo, swSignal_async_handler, 1, 0);
+            return swSignal_set(signo, swSignal_async_handler, 1, 1);
         }
     }
 }

--- a/src/os/signal.cc
+++ b/src/os/signal.cc
@@ -118,7 +118,7 @@ swSignalHandler swSignal_set(int signo, swSignalHandler handler) {
             signals[signo].handler = handler;
             signals[signo].activated = true;
             signals[signo].signo = signo;
-            return swSignal_set(signo, swSignal_async_handler, 1, 1);
+            return swSignal_set(signo, swSignal_async_handler, 1, 0);
         }
     }
 }

--- a/src/os/signal.cc
+++ b/src/os/signal.cc
@@ -58,7 +58,7 @@ char *swSignal_str(int sig) {
 }
 
 /**
- * clear all singal
+ * block all singal
  */
 void swSignal_none(void) {
     sigset_t mask;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -774,6 +774,7 @@ void Server::destroy() {
         swTraceLog(SW_TRACE_SERVER, "terminate task workers");
         if (task_worker_num > 0) {
             gs->task_workers.shutdown();
+            gs->task_workers.destroy();
         }
     } else {
         swTraceLog(SW_TRACE_SERVER, "terminate reactor threads");

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -1282,6 +1282,8 @@ void Server::init_signal_handler() {
     swSignal_set(SIGHUP, nullptr);
     if (factory_mode == SW_MODE_PROCESS) {
         swSignal_set(SIGCHLD, Server_signal_handler);
+    } else {
+        swSignal_set(SIGIO, Server_signal_handler);
     }
     swSignal_set(SIGUSR1, Server_signal_handler);
     swSignal_set(SIGUSR2, Server_signal_handler);

--- a/swoole_process_pool.cc
+++ b/swoole_process_pool.cc
@@ -521,6 +521,9 @@ static PHP_METHOD(swoole_process_pool, start) {
 
     current_pool = pool;
 
+    swSignal_set(SIGCHLD, SIG_IGN);
+    swSignal_set(SIGPIPE, SIG_IGN);
+
     if (pp->onStart) {
         zval args[1];
         args[0] = *ZEND_THIS;

--- a/tests/swoole_process_pool/start_pool_twice_in_same_process.phpt
+++ b/tests/swoole_process_pool/start_pool_twice_in_same_process.phpt
@@ -1,0 +1,29 @@
+--TEST--
+swoole_process_pool: start pool twice in the same process
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process\Pool;
+
+$pool = new Swoole\Process\Pool(1);
+
+$pool->on("WorkerStart", function (Pool $pool, $workerId) {
+    $pool->shutdown();
+});
+
+$pool->start();
+
+$pool = new Swoole\Process\Pool(1);
+
+$pool->on("WorkerStart", function (Pool $pool, $workerId) {
+    $pool->shutdown();
+});
+
+$pool->start();
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_process_pool/start_twice.phpt
+++ b/tests/swoole_process_pool/start_twice.phpt
@@ -1,0 +1,28 @@
+--TEST--
+swoole_process_pool: start twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process\Pool;
+
+$pool = new Swoole\Process\Pool(1);
+
+$pool->on("WorkerStart", function (Pool $pool, $workerId) {
+    echo "CHILD START\n";
+    $pool->shutdown();
+    sleep(1);
+});
+
+$pool->start();
+echo "START 1\n";
+$pool->start();
+echo "START 2\n";
+?>
+--EXPECT--
+CHILD START
+START 1
+CHILD START
+START 2


### PR DESCRIPTION
Maybe we should change the name. For example `swSignal_unblock_all `