### PR TITLE
fix build error:  invalid conversion  from 'const char*' to 'char*'

### DIFF
--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -512,7 +512,7 @@ static int swSSL_check_name(const char *name, ASN1_STRING *pattern) {
     char *s, *end;
     size_t slen, plen;
 
-    s = name;
+    s = (char *)name;
     slen = strlen(name);
 
     uchar *p = ASN1_STRING_data(pattern);


### PR DESCRIPTION
ON RHEL / CentOS 6

```
/builddir/build/BUILD/php73-php-pecl-swoole4-4.5.4/NTS/src/protocol/ssl.cc:513:9: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
     s = name;
         ^~~~
```

Trivial fix, but a better fix will be to constify lot of internal API.