### PR TITLE
Fix #3792 and add a test for it

### DIFF
--- a/src/coroutine/hook.cc
+++ b/src/coroutine/hook.cc
@@ -38,7 +38,6 @@ using swoole::coroutine::System;
 
 static std::unordered_map<int, Socket *> socket_map;
 static std::mutex socket_map_lock;
-static thread_local struct dirent _tmp_dirent;
 
 static sw_inline bool is_no_coro() {
     return SwooleTG.reactor == nullptr || !Coroutine::get_current();
@@ -337,15 +336,10 @@ struct dirent *swoole_coroutine_readdir(DIR *dirp) {
         return readdir(dirp);
     }
 
-    struct dirent *retval = &_tmp_dirent;
+    struct dirent *retval;
 
     swoole::coroutine::async([&retval, dirp]() {
-        struct dirent *tmp = readdir(dirp);
-        if (tmp) {
-            memcpy(retval, tmp, sizeof(*tmp));
-        } else {
-            retval = nullptr;
-        }
+        retval = readdir(dirp);
     });
 
     return retval;

--- a/tests/swoole_runtime/file_hook/bug_scandir.phpt
+++ b/tests/swoole_runtime/file_hook/bug_scandir.phpt
@@ -1,0 +1,44 @@
+--TEST--
+swoole_runtime/file_hook: fseek ftell file larger than 2G bug
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+$testDir = sys_get_temp_dir() . '/swoole_scandir_bug';
+
+if (!is_dir($testDir)) {
+    mkdir($testDir);
+}
+for ($i = 0; $i++ < 3;) {
+    touch("{$testDir}/{$i}.txt");
+}
+
+\Swoole\Runtime::enableCoroutine(true);
+\Swoole\Coroutine\run(
+    function () use ($testDir) {
+        for ($i = 0; $i < MAX_CONCURRENCY; $i++) {
+            go(
+                function () use ($testDir) {
+                    $files = scandir($testDir);
+                    Assert::same($files, [
+                        '.',
+                        '..',
+                        '1.txt',
+                        '2.txt',
+                        '3.txt',
+                    ]);
+                }
+            );
+        }
+    }
+);
+
+echo "DONE\n";
+
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
尽管readdir的返回值指向的是一块静态内存, 但实际看来它并不是一块全局内存, 而是和DIR存在绑定关系(在Linux上, 它表现为DIR所申请的内存的一部分), 这也是为什么不断调用readdir会改变上一次dirent的状态但不会影响到其它DIR上的dirent.
在这里_tmp_dirent的兼容措施是错误的, 引用同一块全局静态内存反而会导致不同DIR调用readdir时出现混乱