### PR TITLE
Add enable hook can only be run in CLI mode

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -965,7 +965,7 @@ static php_stream *socket_create(const char *proto,
 }
 
 bool PHPCoroutine::enable_hook(uint32_t flags) {
-    if (!SWOOLE_G(cli)) {
+    if (flags && !SWOOLE_G(cli)) {
         php_swoole_fatal_error(E_ERROR, "must be used in PHP CLI mode");
         return false;
     }

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -965,6 +965,10 @@ static php_stream *socket_create(const char *proto,
 }
 
 bool PHPCoroutine::enable_hook(uint32_t flags) {
+    if (!SWOOLE_G(cli)) {
+        php_swoole_fatal_error(E_ERROR, "must be used in PHP CLI mode");
+        return false;
+    }
     if (!hook_init) {
         HashTable *xport_hash = php_stream_xport_get_hash();
         // php_stream

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -965,10 +965,6 @@ static php_stream *socket_create(const char *proto,
 }
 
 bool PHPCoroutine::enable_hook(uint32_t flags) {
-    if (flags && !SWOOLE_G(cli)) {
-        php_swoole_fatal_error(E_ERROR, "must be used in PHP CLI mode");
-        return false;
-    }
     if (!hook_init) {
         HashTable *xport_hash = php_stream_xport_get_hash();
         // php_stream
@@ -1167,6 +1163,10 @@ bool PHPCoroutine::disable_hook() {
 }
 
 static PHP_METHOD(swoole_runtime, enableCoroutine) {
+    if (!SWOOLE_G(cli)) {
+        php_swoole_fatal_error(E_ERROR, "must be used in PHP CLI mode");
+        RETURN_FALSE;
+    }
     zval *zflags = nullptr;
     zend_long flags = PHPCoroutine::HOOK_ALL;
 
@@ -1204,6 +1204,10 @@ static PHP_METHOD(swoole_runtime, getHookFlags) {
 }
 
 static PHP_METHOD(swoole_runtime, setHookFlags) {
+    if (!SWOOLE_G(cli)) {
+        php_swoole_fatal_error(E_ERROR, "must be used in PHP CLI mode");
+        RETURN_FALSE;
+    }
     zend_long flags = PHPCoroutine::HOOK_ALL;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)


### PR DESCRIPTION
When use hook in non-PHP CLI mode, some methods will not be found, such as

```shell
Swoole\Runtime::enableCoroutine(): function 'swoole_exec' is not callable
```

So we should disable it to make sure we get right error message.