### PR TITLE
Fix readv_all and writev_all

### DIFF
--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -954,6 +954,7 @@ ssize_t Socket::readv_all(const struct iovec *iov, int iovcnt) {
 
     if (offset_bytes == _iov[index].iov_len) {
         index++;
+        offset_bytes = 0;
     }
     _iov += index;
     remain_cnt -= index;
@@ -962,10 +963,11 @@ ssize_t Socket::readv_all(const struct iovec *iov, int iovcnt) {
         return retval;
     }
 
+    _iov->iov_base = (char *) _iov->iov_base + offset_bytes;
+    _iov->iov_len = _iov->iov_len - offset_bytes;
+
     EventBarrier barrier = [&remain_cnt, &total_bytes, &retval, &offset_bytes, &index, &_iov, this]() -> bool {
         do {
-            _iov->iov_base = (char *) _iov->iov_base + offset_bytes;
-            _iov->iov_len = _iov->iov_len - offset_bytes;
             retval = socket->readv(_iov, remain_cnt);
 
             if (retval <= 0) {
@@ -977,10 +979,14 @@ ssize_t Socket::readv_all(const struct iovec *iov, int iovcnt) {
 
             if (offset_bytes == _iov[index].iov_len) {
                 index++;
+                offset_bytes = 0;
             }
 
             _iov += index;
             remain_cnt -= index;
+
+            _iov->iov_base = (char *) _iov->iov_base + offset_bytes;
+            _iov->iov_len = _iov->iov_len - offset_bytes;
         } while (retval > 0 && remain_cnt > 0);
 
         return retval < 0 && socket->catch_error(errno) == SW_WAIT;

--- a/tests/swoole_socket_coro/readv_eagain.phpt
+++ b/tests/swoole_socket_coro/readv_eagain.phpt
@@ -1,0 +1,74 @@
+--TEST--
+swoole_socket_coro: readv with eagain
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Socket;
+
+use function Swoole\Coroutine\run;
+
+require __DIR__ . '/../include/bootstrap.php';
+
+$totalLength = 0;
+$iovector = [];
+$packedStr = '';
+
+
+for ($i = 0; $i < 10; $i++) {
+    $iovector[$i] = str_repeat(get_safe_random(1024), 128);
+    $totalLength += strlen($iovector[$i]);
+    $packedStr .= $iovector[$i];
+}
+$totalLength2 = rand(strlen($packedStr) / 2, strlen($packedStr) - 1024 * 128);
+
+run(function () {
+    $server = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    $port = get_one_free_port();
+
+    go(function () use ($server, $port) {
+        Assert::assert($server->bind('127.0.0.1', $port));
+        Assert::assert($server->listen(512));
+        $conn = $server->accept();
+        Assert::assert($conn instanceof  Socket);
+        Assert::assert($conn->fd > 0);
+
+        global $packedStr, $iovector, $totalLength2;
+        Assert::assert($conn instanceof Socket);
+        $iov = [];
+        for ($i = 0; $i < 10; $i++) {
+            $iov[] = 1024 * 128;
+        }
+
+        Assert::eq($conn->readVectorAll($iov), $iovector);
+        Assert::eq(implode('', $conn->readVectorAll($iov)), substr($packedStr, 0, $totalLength2));
+
+        // has close
+        Assert::eq($conn->readVectorAll($iov), []);
+    });
+
+    go(function () use ($server, $port) {
+        global $packedStr, $totalLength, $totalLength2;
+
+        $conn = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        Assert::assert($conn->connect('127.0.0.1', $port));
+
+        // Let readVectorAll trigger EAGAIN (verify the correctness of the error returned by readVectorAll)
+        Coroutine::sleep(0.5);
+
+        $ret = $conn->sendAll($packedStr);
+        Assert::eq($ret, $totalLength);
+
+        $ret = $conn->sendAll(substr($packedStr, 0, $totalLength2));
+        Assert::eq($ret, $totalLength2);
+
+        $server->close();
+    });
+});
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_socket_coro/writev_eagain.phpt
+++ b/tests/swoole_socket_coro/writev_eagain.phpt
@@ -1,0 +1,58 @@
+--TEST--
+swoole_socket_coro: writev with eagain
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Socket;
+
+use function Swoole\Coroutine\run;
+
+require __DIR__ . '/../include/bootstrap.php';
+
+$totalLength = 0;
+$iovector = [];
+$packedStr = '';
+
+for ($i = 0; $i < 10; $i++) {
+    $iovector[$i] = str_repeat(get_safe_random(1024), 128);
+    $totalLength += strlen($iovector[$i]);
+    $packedStr .= $iovector[$i];
+}
+
+run(function () {
+    $server = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    $port = get_one_free_port();
+
+    go(function () use ($server, $port) {
+        Assert::assert($server->bind('127.0.0.1', $port));
+        Assert::assert($server->listen(512));
+        $conn = $server->accept();
+        Assert::assert($conn instanceof  Socket);
+        Assert::assert($conn->fd > 0);
+
+        global $totalLength, $packedStr;
+        Assert::assert($conn instanceof Socket);
+
+        // Let writeVectorAll trigger EAGAIN (verify the correctness of the error returned by writeVectorAll)
+        Coroutine::sleep(0.5);
+        Assert::eq($conn->recvAll($totalLength), $packedStr);
+    });
+
+    go(function () use ($server, $port) {
+        global $iovector, $totalLength;
+
+        $conn = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        Assert::assert($conn->connect('127.0.0.1', $port));
+        $ret = $conn->writeVectorAll($iovector);
+        Assert::eq($ret, $totalLength);
+        $server->close();
+    });
+});
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
we should not modify the iov after the readv call is failed, for example EAGAIN.

we should only modify the iov after the readv call is successful.