### PR TITLE
Compatibility with 8.0.0

### DIFF
--- a/ext-src/php_swoole.h
+++ b/ext-src/php_swoole.h
@@ -912,7 +912,7 @@ static sw_inline zend_bool sw_zend_is_callable_at_frame(zval *zcallable, zval *z
 {
     zend_string *name;
     zend_bool ret;
-#if PHP_VERSION_ID < 80001
+#if PHP_VERSION_ID < 80000
     ret = zend_is_callable_ex(zcallable, zobject ? Z_OBJ_P(zobject) : NULL, check_flags, &name, fci_cache, error);
 #else
     ret = zend_is_callable_at_frame(zcallable, zobject ? Z_OBJ_P(zobject) : NULL, frame, check_flags, fci_cache, error);


### PR DESCRIPTION
Re https://github.com/php/php-src/commits/PHP-8.0.0 `zend_is_callable_at_frame` is included in 8.0.0 