### PR TITLE
test: add TEST(coroutine_base, get_elapsed)

### DIFF
--- a/core-tests/src/coroutine/base.cpp
+++ b/core-tests/src/coroutine/base.cpp
@@ -152,7 +152,7 @@ TEST(coroutine_base, get_peak_num) {
 }
 
 TEST(coroutine_base, get_elapsed) {
-    long elapsed_time;
+    long elapsed_time = 0;
     Coroutine::create(
         [](void *arg) {
             auto co = Coroutine::get_current();
@@ -160,6 +160,6 @@ TEST(coroutine_base, get_elapsed) {
             *(long *) arg = Coroutine::get_elapsed(co->get_cid());
         },
         &elapsed_time);
-    ASSERT_GE(elapsed_time, 0);
+    ASSERT_GE(elapsed_time, 2);
 }
 

--- a/core-tests/src/coroutine/base.cpp
+++ b/core-tests/src/coroutine/base.cpp
@@ -150,3 +150,16 @@ TEST(coroutine_base, get_peak_num) {
     Coroutine::create(
         [](void *_arg) { Coroutine::create([](void *_arg) { ASSERT_GE(Coroutine::get_peak_num(), 2); }); });
 }
+
+TEST(coroutine_base, get_elapsed) {
+    long elapsed_time;
+    Coroutine::create(
+        [](void *arg) {
+            auto co = Coroutine::get_current();
+            usleep(2000);
+            *(long *) arg = Coroutine::get_elapsed(co->get_cid());
+        },
+        &elapsed_time);
+    ASSERT_GE(elapsed_time, 0);
+}
+


### PR DESCRIPTION
[       OK ] coroutine_base.get_elapsed (3 ms)
[----------] 1 test from coroutine_base (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.