### PR TITLE
Add coroutine_base.get_init_msec test

### DIFF
--- a/core-tests/src/coroutine/base.cpp
+++ b/core-tests/src/coroutine/base.cpp
@@ -23,6 +23,15 @@ TEST(coroutine_base, get_current) {
     ASSERT_EQ(cid, _cid);
 }
 
+TEST(coroutine_base, get_init_msec) {
+    Coroutine::create([](void *arg) {
+        auto co = Coroutine::get_current();
+        long init_msec = co->get_init_msec();
+
+        ASSERT_GT(init_msec, 0);
+    });
+}
+
 TEST(coroutine_base, yield_resume) {
     long _cid;
     long cid = Coroutine::create(
@@ -162,4 +171,3 @@ TEST(coroutine_base, get_elapsed) {
         &elapsed_time);
     ASSERT_GE(elapsed_time, 2);
 }
-


### PR DESCRIPTION
```shell
Note: Google Test filter = coroutine_base.get_init_msec
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from coroutine_base
[ RUN      ] coroutine_base.get_init_msec
[       OK ] coroutine_base.get_init_msec (1 ms)
[----------] 1 test from coroutine_base (2 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.
```