### PR TITLE
Fix coredump: when stream context is null

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -761,9 +761,12 @@ static int socket_enable_crypto(php_stream *stream, Socket *sock, php_stream_xpo
         return sock->ssl_shutdown() ? 0 : -1;
     }
 
-    zval *val = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", "capture_peer_cert");
-    if (val && zend_is_true(val)) {
-        return php_openssl_capture_peer_certs(stream, sock) ? 0 : -1;
+    php_stream_context *context = PHP_STREAM_CONTEXT(stream);
+    if (context) {
+        zval *val = php_stream_context_get_option(context, "ssl", "capture_peer_cert");
+        if (val && zend_is_true(val)) {
+            return php_openssl_capture_peer_certs(stream, sock) ? 0 : -1;
+        }
     }
 
     return 0;

--- a/tests/swoole_runtime/stream_context_pass_null.phpt
+++ b/tests/swoole_runtime/stream_context_pass_null.phpt
@@ -1,0 +1,19 @@
+--TEST--
+swoole_runtime: stream context pass null
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+swoole\runtime::enableCoroutine();
+go(function() {
+   //This function internal send null stream context parameter to `php_stream_open_wrapper_ex`
+   $md5 = md5_file('https://www.baidu.com');
+   var_dump(!empty($md5));
+});
+swoole_event_wait();
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Function `md5_file` internal call `php_stream_open_wrapper` macro open stream according to filename argument passed function, this macro use is null stream context and send to `_php_stream_open_wrapper_ex` , but function `socket_enable_crypto` in `ext-src/swoole_runtime.cc` not check stream context is null, when use https url send to function`md5_file` occur coredump.