### PR TITLE
Allow setting content-length HTTP header in application layer

### DIFF
--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -379,8 +379,8 @@ static bool parse_header_flags(http_context *ctx, const char *key, size_t keylen
         header_flags |= HTTP_HEADER_CONNECTION;
     } else if (SW_STRCASEEQ(key, keylen, "Date")) {
         header_flags |= HTTP_HEADER_DATE;
-    } else if (SW_STRCASEEQ(key, keylen, "Content-Length") && ctx->parser.method != PHP_HTTP_HEAD) {
-        return false;
+    } else if (SW_STRCASEEQ(key, keylen, "Content-Length")) {
+        header_flags |= HTTP_HEADER_CONTENT_LENGTH;
     } else if (SW_STRCASEEQ(key, keylen, "Content-Type")) {
         header_flags |= HTTP_HEADER_CONTENT_TYPE;
     } else if (SW_STRCASEEQ(key, keylen, "Transfer-Encoding")) {
@@ -514,8 +514,10 @@ static void http_build_header(http_context *ctx, swString *response, size_t body
             body_length = swoole_zlib_buffer->length;
         }
 #endif
-        n = sw_snprintf(buf, l_buf, "Content-Length: %zu\r\n", body_length);
-        response->append(buf, n);
+        if (!(header_flags & HTTP_HEADER_CONTENT_LENGTH)) {
+            n = sw_snprintf(buf, l_buf, "Content-Length: %zu\r\n", body_length);
+            response->append(buf, n);
+        }
     }
 #ifdef SW_HAVE_COMPRESSION
     // http compress

--- a/tests/swoole_http_server/duplicate_header.phpt
+++ b/tests/swoole_http_server/duplicate_header.phpt
@@ -50,6 +50,7 @@ $pm->run();
 ?>
 --EXPECTF--
 HTTP/1.1 200 OK
+Content-Length: 11
 Test-Value: a
 Test-Value: b1234
 Test-Value: d5678
@@ -60,6 +61,5 @@ Server: swoole-http-server
 Connection: keep-alive
 Content-Type: text/html
 Date: %s
-Content-Length: 11
 
 hello world

--- a/tests/swoole_http_server/duplicate_header.phpt
+++ b/tests/swoole_http_server/duplicate_header.phpt
@@ -29,7 +29,8 @@ $pm->childFunc = function () use ($pm) {
         $pm->wakeup();
     });
     $http->on('request', function (swoole_http_request $request, swoole_http_response $response) {
-        $response->header("content-length", "10000 ");
+        $msg = "hello world";
+        $response->header("content-length", strlen($msg) . " ");
         $response->header("Test-Value", [
             "a\r\n",
             "b1234 ",
@@ -39,7 +40,7 @@ $pm->childFunc = function () use ($pm) {
             5678,
             3.1415926,
         ]);
-        $response->end("hello world");
+        $response->end($msg);
     });
     $http->start();
 };

--- a/tests/swoole_http_server/set_content_length.phpt
+++ b/tests/swoole_http_server/set_content_length.phpt
@@ -1,0 +1,44 @@
+--TEST--
+swoole_http_server: allow setting content length header
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$data = str_repeat('a', 100);
+
+$pm = new SwooleTest\ProcessManager;
+$pm->parentFunc = function () use ($pm, $data) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "http://127.0.0.1:" . $pm->getFreePort() . '/');
+    curl_setopt($ch, CURLOPT_HEADER, 1);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $header = substr($response, 0, $header_size);
+    Assert::assert(strrpos($header, 'Content-Length: 50') > 0);
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm, $data) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
+
+    $http->on("WorkerStart", function ($serv, $wid) {
+        global $pm;
+        $pm->wakeup();
+    });
+
+    $http->on('request', function ($req, Swoole\Http\Response $resp) use ($data) {
+        $resp->header('Content-Type', 'application/json');
+        $resp->header('Content-Length', 50);
+        $resp->end($data);
+    });
+
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
Allow application set the content-length HTTP header if the content length is known.

User set content-length header is overriding the body length calculated by server.

Ref: #3901