### PR TITLE
using arc4random api as alternative backend for swoole_random_bytes,

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -303,6 +303,7 @@ if test "$PHP_SWOOLE" != "no"; then
     AC_CHECK_LIB(c, gethostbyname2_r, AC_DEFINE(HAVE_GETHOSTBYNAME2_R, 1, [have gethostbyname2_r]))
     AC_CHECK_LIB(c, ptrace, AC_DEFINE(HAVE_PTRACE, 1, [have ptrace]))
     AC_CHECK_LIB(c, getrandom, AC_DEFINE(HAVE_GETRANDOM, 1, [have getrandom]))
+    AC_CHECK_LIB(c, arc4random, AC_DEFINE(HAVE_ARC4RANDOM, 1, [have arc4random]))
     AC_CHECK_LIB(pthread, pthread_rwlock_init, AC_DEFINE(HAVE_RWLOCK, 1, [have pthread_rwlock_init]))
     AC_CHECK_LIB(pthread, pthread_spin_lock, AC_DEFINE(HAVE_SPINLOCK, 1, [have pthread_spin_lock]))
     AC_CHECK_LIB(pthread, pthread_mutex_timedlock, AC_DEFINE(HAVE_MUTEX_TIMEDLOCK, 1, [have pthread_mutex_timedlock]))

--- a/src/core/base.cc
+++ b/src/core/base.cc
@@ -56,6 +56,10 @@ using swoole::String;
 #include <sys/random.h>
 #else
 static ssize_t getrandom(void *buffer, size_t size, unsigned int __flags) {
+#ifdef HAVE_ARC4RANDOM
+    arc4random_buf(buffer, size);
+    return size;
+#else
     int fd = open("/dev/urandom", O_RDONLY);
     if (fd < 0) {
         return -1;
@@ -73,6 +77,7 @@ static ssize_t getrandom(void *buffer, size_t size, unsigned int __flags) {
     close(fd);
 
     return read_bytes;
+#endif
 }
 #endif
 


### PR DESCRIPTION
lessening file descriptor usage in the process too.