### PR TITLE
Fix OpenBSD build.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -320,6 +320,7 @@ if test "$PHP_SWOOLE" != "no"; then
     AC_CHECK_LIB(pthread, pthread_spin_lock, AC_DEFINE(HAVE_SPINLOCK, 1, [have pthread_spin_lock]))
     AC_CHECK_LIB(pthread, pthread_mutex_timedlock, AC_DEFINE(HAVE_MUTEX_TIMEDLOCK, 1, [have pthread_mutex_timedlock]))
     AC_CHECK_LIB(pthread, pthread_barrier_init, AC_DEFINE(HAVE_PTHREAD_BARRIER, 1, [have pthread_barrier_init]))
+    AC_CHECK_LIB(pthread, pthread_mutexattr_setpshared, AC_DEFINE(HAVE_PTHREAD_MUTEXATTR_SETPSHARED, 1, [have pthread_mutexattr_setpshared]))
     AC_CHECK_LIB(pthread, pthread_mutexattr_setrobust, AC_DEFINE(HAVE_PTHREAD_MUTEXATTR_SETROBUST, 1, [have pthread_mutexattr_setrobust]))
     AC_CHECK_LIB(pthread, pthread_mutex_consistent, AC_DEFINE(HAVE_PTHREAD_MUTEX_CONSISTENT, 1, [have pthread_mutex_consistent]))
     AC_CHECK_LIB(pcre, pcre_compile, AC_DEFINE(HAVE_PCRE, 1, [have pcre]))

--- a/src/lock/mutex.cc
+++ b/src/lock/mutex.cc
@@ -40,7 +40,11 @@ Mutex::Mutex(int flags) : Lock() {
     pthread_mutexattr_init(&impl->attr_);
 
     if (flags & PROCESS_SHARED) {
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST
         pthread_mutexattr_setpshared(&impl->attr_, PTHREAD_PROCESS_SHARED);
+#else
+        swWarn("PTHREAD_MUTEX_PSHARED is not supported");
+#endif
     }
 
     if (flags & ROBUST) {


### PR DESCRIPTION
Also in case fiber context stack creation via mmap is enabled, adding MAP_STACK flag for this platform.