### PR TITLE
get rid of inet_ntoa and inet_aton calls

### DIFF
--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -1210,7 +1210,12 @@ static PHP_METHOD(swoole_client, getsockname) {
         }
     } else {
         add_assoc_long(return_value, "port", ntohs(cli->socket->info.addr.inet_v4.sin_port));
-        add_assoc_string(return_value, "host", inet_ntoa(cli->socket->info.addr.inet_v4.sin_addr));
+        char tmp[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &cli->socket->info.addr.inet_v4.sin_addr, tmp, sizeof(tmp))) {
+            add_assoc_string(return_value, "host", tmp);
+        } else {
+            php_swoole_fatal_error(E_WARNING, "inet_ntop() failed");
+        }
     }
 }
 
@@ -1248,7 +1253,13 @@ static PHP_METHOD(swoole_client, getpeername) {
     if (cli->socket->socket_type == SW_SOCK_UDP) {
         array_init(return_value);
         add_assoc_long(return_value, "port", ntohs(cli->remote_addr.addr.inet_v4.sin_port));
-        add_assoc_string(return_value, "host", inet_ntoa(cli->remote_addr.addr.inet_v4.sin_addr));
+        char tmp[INET_ADDRSTRLEN];
+
+        if (inet_ntop(AF_INET, &cli->remote_addr.addr.inet_v4.sin_addr, tmp, sizeof(tmp))) {
+            add_assoc_string(return_value, "host", tmp);
+        } else {
+            php_swoole_fatal_error(E_WARNING, "inet_ntop() failed");
+        }
     } else if (cli->socket->socket_type == SW_SOCK_UDP6) {
         array_init(return_value);
         add_assoc_long(return_value, "port", ntohs(cli->remote_addr.addr.inet_v6.sin6_port));

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1366,7 +1366,7 @@ ssize_t Socket::sendto(const std::string &host, int port, const void *__buf, siz
 
     for (size_t i = 0; i < 2; i++) {
         if (type == SW_SOCK_UDP) {
-            if (::inet_aton(ip.c_str(), &addr.in.sin_addr) == 0) {
+            if (::inet_pton(AF_INET, ip.c_str(), &addr.in.sin_addr) == 0) {
                 read_co = write_co = Coroutine::get_current_safe();
                 ip = System::gethostbyname(host, sock_domain, dns_timeout);
                 read_co = write_co = nullptr;

--- a/src/network/address.cc
+++ b/src/network/address.cc
@@ -23,7 +23,9 @@ static thread_local char tmp_address[INET6_ADDRSTRLEN];
 
 const char *Address::get_addr() {
     if (type == SW_SOCK_TCP || type == SW_SOCK_UDP) {
-        return inet_ntoa(addr.inet_v4.sin_addr);
+        if (inet_ntop(AF_INET, &addr.inet_v4.sin_addr, tmp_address, sizeof(tmp_address))) {
+            return tmp_address;
+        }
     } else if (type == SW_SOCK_TCP6 || type == SW_SOCK_UDP6) {
         if (inet_ntop(AF_INET6, &addr.inet_v6.sin6_addr, tmp_address, sizeof(tmp_address))) {
             return tmp_address;

--- a/thirdparty/php/sockets/sockaddr_conv.cc
+++ b/thirdparty/php/sockets/sockaddr_conv.cc
@@ -77,7 +77,7 @@ int php_set_inet_addr(struct sockaddr_in *sin, char *string, Socket *php_sock) /
 	struct in_addr tmp;
 	struct hostent *host_entry;
 
-	if (inet_aton(string, &tmp)) {
+	if (inet_pton(AF_INET, string, &tmp)) {
 		sin->sin_addr.s_addr = tmp.s_addr;
 	} else {
 #if PHP_VERSION_ID >= 70006


### PR DESCRIPTION
These functions are deprecated and may be forbidden in some distro.

Already erraticated in php-src

* https://github.com/php/php-src/commit/f9547f2b47633d30087703df04f7d8e20f89ec80
* https://github.com/php/php-src/commit/e5b6f43ec7813392d83ea586b7902e0396a1f792
* https://github.com/php/php-src/commit/99d67d121acd4c324738509679d23acaf759d065

third-party file seems a copy paste from ph-src, perhaps need a full refresh