### PR TITLE
Support mysql client prepare field type identification

### DIFF
--- a/ext-src/php_swoole_mysql_proto.h
+++ b/ext-src/php_swoole_mysql_proto.h
@@ -301,6 +301,11 @@ enum sw_mysql_server_status_flags
                 sw_mysql_int4store((T),def_temp); \
                 sw_mysql_int4store((T+4),def_temp2); } while (0)
 
+#define sw_mysql_doublestore(T,A) do { \
+                double def_temp = (double) A; \
+                memcpy(T, &def_temp, sizeof(double)); \
+                } while (0)
+
 #if defined(SW_DEBUG) && defined(SW_LOG_TRACE_OPEN)
 #define swMysqlPacketDump(length, number, data, title) \
     if (SW_LOG_TRACE >= sw_logger()->get_level() && (SW_TRACE_MYSQL_CLIENT & SwooleG.trace_flags)) \

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -1246,7 +1246,7 @@ void mysql_statement::send_execute_request(zval *return_value, zval *params) {
         zend_ulong index = 0;
         zval *value;
         ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(params), value) {
-            switch (Z_TYPE_P(value)) {
+            switch (client->strict_type ? Z_TYPE_P(value) : IS_STRING) {
                 case IS_NULL:
                     *((buffer->str + null_start_offset) + (index / 8)) |= (1UL << (index % 8));
                     sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_NULL);

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -1246,19 +1246,37 @@ void mysql_statement::send_execute_request(zval *return_value, zval *params) {
         zend_ulong index = 0;
         zval *value;
         ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(params), value) {
-            if (ZVAL_IS_NULL(value)) {
-                *((buffer->str + null_start_offset) + (index / 8)) |= (1UL << (index % 8));
-                sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_NULL);
-            } else {
-                zend::String str_value(value);
-                uint8_t lcb_size = mysql::write_lcb(stack_buffer, str_value.len());
-                sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_VAR_STRING);
-                if (buffer->append(stack_buffer, lcb_size) < 0) {
-                    RETURN_FALSE;
-                }
-                if (buffer->append(str_value.val(), str_value.len()) < 0) {
-                    RETURN_FALSE;
-                }
+            switch (Z_TYPE_P(value)) {
+                case IS_NULL:
+                    *((buffer->str + null_start_offset) + (index / 8)) |= (1UL << (index % 8));
+                    sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_NULL);
+                    break;
+                case IS_TRUE:
+                case IS_FALSE:
+                case IS_LONG:
+                    sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_LONGLONG);
+                    sw_mysql_int8store(stack_buffer, zval_get_long(value));
+                    if (buffer->append(stack_buffer, mysql::get_static_type_size(SW_MYSQL_TYPE_LONGLONG)) < 0) {
+                        RETURN_FALSE;
+                    }
+                    break;
+                case IS_DOUBLE:
+                    sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_DOUBLE);
+                    sw_mysql_doublestore(stack_buffer, zval_get_double(value));
+                    if (buffer->append(stack_buffer, mysql::get_static_type_size(SW_MYSQL_TYPE_DOUBLE)) < 0) {
+                        RETURN_FALSE;
+                    }
+                    break;
+                default:
+                    zend::String str_value(value);
+                    uint8_t lcb_size = mysql::write_lcb(stack_buffer, str_value.len());
+                    sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_VAR_STRING);
+                    if (buffer->append(stack_buffer, lcb_size) < 0) {
+                        RETURN_FALSE;
+                    }
+                    if (buffer->append(str_value.val(), str_value.len()) < 0) {
+                        RETURN_FALSE;
+                    }
             }
             index++;
         }

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -1246,7 +1246,7 @@ void mysql_statement::send_execute_request(zval *return_value, zval *params) {
         zend_ulong index = 0;
         zval *value;
         ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(params), value) {
-            switch (client->strict_type ? Z_TYPE_P(value) : IS_STRING) {
+            switch (client->strict_type ? Z_TYPE_P(value) : (IS_NULL == Z_TYPE_P(value) ? IS_NULL : IS_STRING)) {
                 case IS_NULL:
                     *((buffer->str + null_start_offset) + (index / 8)) |= (1UL << (index % 8));
                     sw_mysql_int2store((buffer->str + type_start_offset) + (index * 2), SW_MYSQL_TYPE_NULL);

--- a/tests/swoole_mysql_coro/defer_and_fetch.phpt
+++ b/tests/swoole_mysql_coro/defer_and_fetch.phpt
@@ -23,8 +23,19 @@ go(function () {
             $statement = $mysql->recv();
             Assert::isInstanceOf($statement, Swoole\Coroutine\MySQL\Statement::class);
         }
+        // int
         $a = mt_rand(0, 65535);
         $b = mt_rand(0, 65535);
+        /** @var $statement Swoole\Coroutine\MySQL\Statement */
+        Assert::true($statement->execute([$a, $b]));
+        Assert::true($statement->recv());
+        $result = $statement->fetchAll();
+        if (Assert::isArray($result)) {
+            Assert::same(reset($result[0]), $a + $b);
+        }
+        // float
+        $a = (float) $a;
+        $b = (float) $b;
         /** @var $statement Swoole\Coroutine\MySQL\Statement */
         Assert::true($statement->execute([$a, $b]));
         Assert::true($statement->recv());

--- a/tests/swoole_mysql_coro/defer_and_fetch.phpt
+++ b/tests/swoole_mysql_coro/defer_and_fetch.phpt
@@ -23,19 +23,8 @@ go(function () {
             $statement = $mysql->recv();
             Assert::isInstanceOf($statement, Swoole\Coroutine\MySQL\Statement::class);
         }
-        // int
         $a = mt_rand(0, 65535);
         $b = mt_rand(0, 65535);
-        /** @var $statement Swoole\Coroutine\MySQL\Statement */
-        Assert::true($statement->execute([$a, $b]));
-        Assert::true($statement->recv());
-        $result = $statement->fetchAll();
-        if (Assert::isArray($result)) {
-            Assert::same(reset($result[0]), $a + $b);
-        }
-        // float
-        $a = (float) $a;
-        $b = (float) $b;
         /** @var $statement Swoole\Coroutine\MySQL\Statement */
         Assert::true($statement->execute([$a, $b]));
         Assert::true($statement->recv());

--- a/tests/swoole_mysql_coro/prepare_field_type.phpt
+++ b/tests/swoole_mysql_coro/prepare_field_type.phpt
@@ -16,6 +16,7 @@ Co::create(function () {
         'user' => MYSQL_SERVER_USER,
         'password' => MYSQL_SERVER_PWD,
         'database' => MYSQL_SERVER_DB,
+        'strict_type' => true,
     ];
 
     $ret1 = $db->connect($server);
@@ -25,21 +26,21 @@ Co::create(function () {
         return;
     }
 
-    $stmt = $db->prepare('SELECT ? as a, ? as b, ? as c, ? as d');
+    $stmt = $db->prepare('SELECT ? as a, ? as b, ? as c, ? as d, ? + ? as e');
     if (! $stmt) {
         echo "PREPARE ERROR\n";
 
         return;
     }
 
-    $ret3 = $stmt->execute([123, 3.14, true, false]);
+    $ret3 = $stmt->execute([123, 3.14, true, false, 11, 22]);
     if (! $ret3) {
         echo "EXECUTE ERROR#{$stmt->errno}: {$stmt->error}\n";
 
         return;
     }
     if (Assert::isArray($ret3)) {
-        Assert::same(reset($ret3), ['a' => 123, 'b' => 3.14, 'c' => 1, 'd' => 0]);
+        Assert::same(reset($ret3), ['a' => 123, 'b' => 3.14, 'c' => 1, 'd' => 0, 'e' => 33]);
     }
 });
 

--- a/tests/swoole_mysql_coro/prepare_field_type.phpt
+++ b/tests/swoole_mysql_coro/prepare_field_type.phpt
@@ -1,10 +1,10 @@
 --TEST--
 swoole_mysql_coro: mysql prepare field type
 --SKIPIF--
-<?php require __DIR__.'/../include/skipif.inc'; ?>
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
 <?php
-require __DIR__.'/../include/bootstrap.php';
+require __DIR__ . '/../include/bootstrap.php';
 
 use Swoole\Coroutine as Co;
 
@@ -38,7 +38,9 @@ Co::create(function () {
 
         return;
     }
-    Assert::same($ret3, ['a' => 123, 'b' => 3.14, 'c' => 1, 'd' => 0]);
+    if (Assert::isArray($ret3)) {
+        Assert::same(reset($ret3), ['a' => 123, 'b' => 3.14, 'c' => 1, 'd' => 0]);
+    }
 });
 
 ?>

--- a/tests/swoole_mysql_coro/prepare_field_type.phpt
+++ b/tests/swoole_mysql_coro/prepare_field_type.phpt
@@ -1,0 +1,45 @@
+--TEST--
+swoole_mysql_coro: mysql prepare field type
+--SKIPIF--
+<?php require __DIR__.'/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__.'/../include/bootstrap.php';
+
+use Swoole\Coroutine as Co;
+
+Co::create(function () {
+    $db = new Co\MySQL();
+    $server = [
+        'host' => MYSQL_SERVER_HOST,
+        'port' => MYSQL_SERVER_PORT,
+        'user' => MYSQL_SERVER_USER,
+        'password' => MYSQL_SERVER_PWD,
+        'database' => MYSQL_SERVER_DB,
+    ];
+
+    $ret1 = $db->connect($server);
+    if (! $ret1) {
+        echo "CONNECT ERROR\n";
+
+        return;
+    }
+
+    $stmt = $db->prepare('SELECT ? as a, ? as b, ? as c, ? as d');
+    if (! $stmt) {
+        echo "PREPARE ERROR\n";
+
+        return;
+    }
+
+    $ret3 = $stmt->execute([123, 3.14, true, false]);
+    if (! $ret3) {
+        echo "EXECUTE ERROR#{$stmt->errno}: {$stmt->error}\n";
+
+        return;
+    }
+    Assert::same($ret3, ['a' => 123, 'b' => 3.14, 'c' => 1, 'd' => 0]);
+});
+
+?>
+--EXPECT--


### PR DESCRIPTION
This problem may also affect the operation of JSON fields, resulting in values in JSON being strings

```php
<?php

use Swoole\Coroutine\MySQL;
use function Swoole\Coroutine\run;

run(function () {
    $db = new MySQL();
    var_dump($db->connect([
        'host'     => '127.0.0.1',
        'port'     => 3306,
        'user'     => 'root',
        'password' => 'root',
        'database' => 'db_imi_test',
    ]));
    $stmt = $db->prepare('select ? as a, ? as b, ? as c, ? as d, ? + ? as e');
    if (false == $stmt)
    {
        var_dump($db->errno, $db->error);

        return;
    }
    else
    {
        $ret2 = $stmt->execute([123, 3.14, true, false, 11, 22]);
        var_dump($ret2);
    }
});
```

wrong:

```
bool(true)
array(1) {
  [0]=>
  array(5) {
    ["a"]=>
    string(3) "123"
    ["b"]=>
    string(4) "3.14"
    ["c"]=>
    string(1) "1"
    ["d"]=>
    string(0) ""
    ["e"]=>
    float(33)
  }
}
```

right:

```
bool(true)
array(1) {
  [0]=>
  array(5) {
    ["a"]=>
    int(123)
    ["b"]=>
    float(3.14)
    ["c"]=>
    int(1)
    ["d"]=>
    int(0)
    ["e"]=>
    int(33)
  }
}
```