### PR TITLE
Fix System::waitSignal() deadlock

### DIFF
--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -386,7 +386,7 @@ void PHPCoroutine::shutdown() {
 }
 
 void PHPCoroutine::deadlock_check() {
-    if (Coroutine::count() == 0) {
+    if (Coroutine::count() == 0 || Coroutine::count() == SwooleTG.co_signal_listener_num) {
         return;
     }
     if (php_swoole_is_fatal_error() || (sw_reactor() && sw_reactor()->bailout)) {

--- a/tests/swoole_coroutine_system/waitSignalProcess.phpt
+++ b/tests/swoole_coroutine_system/waitSignalProcess.phpt
@@ -1,0 +1,45 @@
+--TEST--
+swoole_coroutine_system: waitSignalProcess
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine;
+use Swoole\Coroutine\System;
+use Swoole\Event;
+use Swoole\Process;
+
+$atomic = new Atomic();
+
+Coroutine::create(function () {
+    $result = System::waitSignal(\SIGUSR1);
+    var_dump('parent', $result);
+});
+
+$parentPid = getmypid();
+
+$process = new Process(function ($process) use ($atomic, $parentPid) {
+    var_dump('process');
+    Co\run(function () use ($parentPid, $process) {
+        $result = System::waitSignal(\SIGUSR2);
+        var_dump('child', $result);
+        Process::kill($parentPid, \SIGUSR1);
+        $process->exit();
+    });
+    $atomic->wakeup();
+});
+$process->start();
+$atomic->wait();
+var_dump(Process::kill($process->pid, \SIGUSR2));
+Event::wait();
+?>
+--EXPECT--
+string(7) "process"
+bool(true)
+string(5) "child"
+bool(true)
+string(6) "parent"
+bool(true)


### PR DESCRIPTION
```php
<?php

use Swoole\Coroutine\System;
use Swoole\Process;

go(function () {
    System::waitSignal(\SIGTERM, 3);
});

$process = new Process(function () {
    var_dump('process');
});
$process->start();
$process->wait();

```

wrong outout:
```
===================================================================
 [FATAL ERROR]: all coroutines (count: 1) are asleep - deadlock!
===================================================================

 [Coroutine-1]
--------------------------------------------------------------------
#0  Swoole\Coroutine\System::waitSignal() called at [/mnt/d/projects/imi-private/test.php:7]

string(7) "process"
```