### PR TITLE
Update to C99

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -327,9 +327,7 @@ AC_COMPILE_IFELSE([
 )
 AC_MSG_RESULT([$CLANG])
 
-if test "$CLANG" = "yes"; then
-    CFLAGS="$CFLAGS -std=gnu89"
-fi
+AC_PROG_CC_C99
 
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
Fix build error:

```bash
/root/codeDir/cppCode/swoole-src/thirdparty/hiredis/read.c: In function 'processLineItem':
/root/codeDir/cppCode/swoole-src/thirdparty/hiredis/read.c:351:13: error: 'for' loop initial declarations are only allowed in C99 mode
             for (int i = 0; i < len; i++) {
```