### PR TITLE
Support a new concurrency mode

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -384,6 +384,9 @@ void php_swoole_set_global_option(HashTable *vht) {
     if (php_swoole_array_get_value(vht, "socket_timeout", ztmp)) {
         Socket::default_read_timeout = Socket::default_write_timeout = timeout_format(ztmp);
     }
+    if (php_swoole_array_get_value(vht, "max_concurrency", ztmp)) {
+        SwooleG.max_concurrency = (uint32_t) SW_MAX(0, zval_get_long(ztmp));
+    }
 }
 
 void php_swoole_register_rshutdown_callback(swoole::Callback cb, void *private_data) {

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -643,6 +643,7 @@ struct Global {
     uint32_t pagesize;
     struct utsname uname;
     uint32_t max_sockets;
+    uint32_t max_concurrency;
     //-----------------------[Memory]--------------------------
     MemoryPool *memory_pool;
     Allocator std_allocator;

--- a/include/swoole_process_pool.h
+++ b/include/swoole_process_pool.h
@@ -93,6 +93,7 @@ struct WorkerGlobal {
     String **output_buffer;
     Worker *worker;
     time_t exit_time;
+    uint32_t worker_concurrency = 0;
 };
 
 struct Worker {

--- a/src/core/base.cc
+++ b/src/core/base.cc
@@ -148,6 +148,7 @@ void swoole_init(void) {
     // init global shared memory
     SwooleG.memory_pool = new swoole::GlobalMemory(SW_GLOBAL_MEMORY_PAGESIZE, true);
     SwooleG.max_sockets = SW_MAX_SOCKETS_DEFAULT;
+    SwooleG.max_concurrency = 0;
     struct rlimit rlmt;
     if (getrlimit(RLIMIT_NOFILE, &rlmt) < 0) {
         swSysWarn("getrlimit() failed");

--- a/tests/swoole_server/max_concurrency.phpt
+++ b/tests/swoole_server/max_concurrency.phpt
@@ -1,0 +1,74 @@
+--TEST--
+swoole_server: max_concurrency
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Client;
+use Swoole\Timer;
+use Swoole\Event;
+use Swoole\Server;
+
+$pm = new SwooleTest\ProcessManager;
+
+$pm->parentFunc = function ($pid) use ($pm) {
+    for ($i=0; $i < 5; $i++) { 
+        go(function () use ($pm, $i) {
+            $client = new Client(SWOOLE_SOCK_TCP);
+            $client->set([
+                "open_eof_check" => true,
+                "open_eof_split" => true,
+                "package_eof" => "\r\n\r\n",
+            ]);
+            $r = $client->connect('127.0.0.1', $pm->getFreePort(), -1);
+            $data = "$i\r\n\r\n";
+            $client->send($data);
+            $ret = $client->recv();
+            var_dump(trim($ret));
+            $client->close();
+        });
+    }
+    
+    Event::wait();
+
+    swoole_process::kill($pid);
+};
+
+$pm->childFunc = function () use ($pm)
+{
+    Co::set(['max_concurrency' => 1]);
+    $serv = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $serv->set([
+        'worker_num' => 1,
+        'dispatch_mode' => 1,
+        'open_eof_split' => true,
+        'package_eof' => "\r\n\r\n",
+        'log_file' => '/dev/null',
+    ]);
+    $serv->on("WorkerStart", function (Server $serv)  use ($pm)
+    {
+        $pm->wakeup();
+    });
+    $serv->on("Receive", function (Server $serv, $fd, $reactorId, $data)
+    {
+        global $count;
+        $count = 0;
+        co::sleep(0.05);
+        $count += 1;
+        $serv->send($fd, "$count\r\n\r\n");
+    });
+    $serv->start();
+};
+
+$pm->childFirst();
+$pm->run();
+
+?>
+--EXPECT--
+string(1) "1"
+string(1) "1"
+string(1) "1"
+string(1) "1"
+string(1) "1"


### PR DESCRIPTION
* Allow applications to control max concurrent requests on each worker (Linux) process
* When the `max_concurrency = 1`, global variables and static variables are considered safe for the current request
* Allow `Laravel Octane` to use coroutines at the request level to reduce the latency