### PR TITLE
Fix not serializable classes for 8.1.0beta1

### DIFF
--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -634,9 +634,14 @@ static sw_inline void add_assoc_ulong_safe(zval *arg, const char *key, zend_ulon
         }                                                                                                              \
     } while (0)
 
-#define SW_SET_CLASS_SERIALIZABLE(module, _serialize, _unserialize)                                                    \
-    module##_ce->serialize = _serialize;                                                                               \
-    module##_ce->unserialize = _unserialize
+#if PHP_VERSION_ID < 80100
+#define SW_SET_CLASS_NOT_SERIALIZABLE(module)                                                                          \
+    module##_ce->serialize = zend_class_serialize_deny;                                                                               \
+    module##_ce->unserialize = zend_class_unserialize_deny;
+#else
+#define SW_SET_CLASS_NOT_SERIALIZABLE(module)                                                                          \
+    module##_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#endif
 
 #define sw_zend_class_clone_deny NULL
 #define SW_SET_CLASS_CLONEABLE(module, _clone_obj) module##_handlers.clone_obj = _clone_obj

--- a/ext-src/swoole_atomic.cc
+++ b/ext-src/swoole_atomic.cc
@@ -244,7 +244,7 @@ static const zend_function_entry swoole_atomic_long_methods[] =
 
 void php_swoole_atomic_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_atomic, "Swoole\\Atomic", "swoole_atomic", nullptr, swoole_atomic_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_atomic, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_atomic);
     SW_SET_CLASS_CLONEABLE(swoole_atomic, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(
@@ -252,7 +252,7 @@ void php_swoole_atomic_minit(int module_number) {
 
     SW_INIT_CLASS_ENTRY(
         swoole_atomic_long, "Swoole\\Atomic\\Long", "swoole_atomic_long", nullptr, swoole_atomic_long_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_atomic_long, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_atomic_long);
     SW_SET_CLASS_CLONEABLE(swoole_atomic_long, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_atomic_long, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_atomic_long,

--- a/ext-src/swoole_channel_coro.cc
+++ b/ext-src/swoole_channel_coro.cc
@@ -120,7 +120,7 @@ static zend_object *php_swoole_channel_coro_create_object(zend_class_entry *ce) 
 void php_swoole_channel_coro_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_channel_coro, "Swoole\\Coroutine\\Channel", nullptr, "Co\\Channel", swoole_channel_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_channel_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_channel_coro);
     SW_SET_CLASS_CLONEABLE(swoole_channel_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_channel_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_channel_coro,

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -240,7 +240,7 @@ static const zend_function_entry swoole_client_methods[] =
 
 void php_swoole_client_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_client, "Swoole\\Client", "swoole_client", nullptr, swoole_client_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_client, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_client);
     SW_SET_CLASS_CLONEABLE(swoole_client, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_client, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -169,7 +169,7 @@ static zend_object *php_swoole_client_coro_create_object(zend_class_entry *ce) {
 void php_swoole_client_coro_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_client_coro, "Swoole\\Coroutine\\Client", nullptr, "Co\\Client", swoole_client_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_client_coro);
     SW_SET_CLASS_CLONEABLE(swoole_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_client_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(

--- a/ext-src/swoole_coroutine_scheduler.cc
+++ b/ext-src/swoole_coroutine_scheduler.cc
@@ -111,7 +111,7 @@ void php_swoole_coroutine_scheduler_minit(int module_number) {
                         nullptr,
                         "Co\\Scheduler",
                         swoole_coroutine_scheduler_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_coroutine_scheduler, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_coroutine_scheduler);
     SW_SET_CLASS_CLONEABLE(swoole_coroutine_scheduler, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_coroutine_scheduler, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_coroutine_scheduler);

--- a/ext-src/swoole_http2_client_coro.cc
+++ b/ext-src/swoole_http2_client_coro.cc
@@ -317,7 +317,7 @@ void php_swoole_http2_client_coro_minit(int module_number) {
                         nullptr,
                         "Co\\Http2\\Client",
                         swoole_http2_client_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http2_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http2_client_coro);
     SW_SET_CLASS_CLONEABLE(swoole_http2_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http2_client_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_http2_client_coro,
@@ -334,13 +334,13 @@ void php_swoole_http2_client_coro_minit(int module_number) {
                            swoole_exception);
 
     SW_INIT_CLASS_ENTRY(swoole_http2_request, "Swoole\\Http2\\Request", "swoole_http2_request", nullptr, nullptr);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http2_request, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http2_request);
     SW_SET_CLASS_CLONEABLE(swoole_http2_request, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http2_request, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http2_request);
 
     SW_INIT_CLASS_ENTRY(swoole_http2_response, "Swoole\\Http2\\Response", "swoole_http2_response", nullptr, nullptr);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http2_response, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http2_response);
     SW_SET_CLASS_CLONEABLE(swoole_http2_response, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http2_response, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http2_response);

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -1712,7 +1712,7 @@ void php_swoole_http_client_coro_minit(int module_number) {
                         nullptr,
                         "Co\\Http\\Client",
                         swoole_http_client_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http_client_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http_client_coro);
     SW_SET_CLASS_CLONEABLE(swoole_http_client_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_client_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_client_coro,

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -225,7 +225,7 @@ const zend_function_entry swoole_http_request_methods[] =
 void php_swoole_http_request_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_http_request, "Swoole\\Http\\Request", "swoole_http_request", nullptr, swoole_http_request_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http_request, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http_request);
     SW_SET_CLASS_CLONEABLE(swoole_http_request, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_request, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_request,

--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -263,7 +263,7 @@ const zend_function_entry swoole_http_response_methods[] =
 void php_swoole_http_response_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_http_response, "Swoole\\Http\\Response", "swoole_http_response", nullptr, swoole_http_response_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http_response, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http_response);
     SW_SET_CLASS_CLONEABLE(swoole_http_response, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_response, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_http_response,

--- a/ext-src/swoole_http_server.cc
+++ b/ext-src/swoole_http_server.cc
@@ -147,7 +147,7 @@ _dtor_and_return:
 void php_swoole_http_server_minit(int module_number) {
     SW_INIT_CLASS_ENTRY_EX(
         swoole_http_server, "Swoole\\Http\\Server", "swoole_http_server", nullptr, nullptr, swoole_server);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http_server, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http_server);
     SW_SET_CLASS_CLONEABLE(swoole_http_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_server, sw_zend_class_unset_property_deny);
 }

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -302,7 +302,7 @@ void php_swoole_http_server_coro_minit(int module_number) {
                         nullptr,
                         "Co\\Http\\Server",
                         swoole_http_server_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_http_server_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_http_server_coro);
     SW_SET_CLASS_CLONEABLE(swoole_http_server_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_http_server_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_http_server_coro);

--- a/ext-src/swoole_lock.cc
+++ b/ext-src/swoole_lock.cc
@@ -113,7 +113,7 @@ static const zend_function_entry swoole_lock_methods[] =
 
 void php_swoole_lock_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_lock, "Swoole\\Lock", "swoole_lock", nullptr, swoole_lock_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_lock, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_lock);
     SW_SET_CLASS_CLONEABLE(swoole_lock, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_lock, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -1690,7 +1690,7 @@ static sw_inline void swoole_mysql_coro_sync_execute_result_properties(zval *zob
 
 void php_swoole_mysql_coro_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_mysql_coro, "Swoole\\Coroutine\\MySQL", nullptr, "Co\\MySQL", swoole_mysql_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_mysql_coro);
     SW_SET_CLASS_CLONEABLE(swoole_mysql_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(
@@ -1701,7 +1701,7 @@ void php_swoole_mysql_coro_minit(int module_number) {
                         nullptr,
                         "Co\\MySQL\\Statement",
                         swoole_mysql_coro_statement_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro_statement, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_mysql_coro_statement);
     SW_SET_CLASS_CLONEABLE(swoole_mysql_coro_statement, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro_statement, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_mysql_coro_statement,
@@ -1716,7 +1716,7 @@ void php_swoole_mysql_coro_minit(int module_number) {
                            "Co\\MySQL\\Exception",
                            nullptr,
                            swoole_exception);
-    SW_SET_CLASS_SERIALIZABLE(swoole_mysql_coro_exception, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_mysql_coro_exception);
     SW_SET_CLASS_CLONEABLE(swoole_mysql_coro_exception, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro_exception, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_mysql_coro_exception);

--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -258,7 +258,7 @@ static const zend_function_entry swoole_process_methods[] =
 
 void php_swoole_process_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_process, "Swoole\\Process", "swoole_process", nullptr, swoole_process_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_process, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_process);
     SW_SET_CLASS_CLONEABLE(swoole_process, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -189,7 +189,7 @@ static const zend_function_entry swoole_process_pool_methods[] =
 void php_swoole_process_pool_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_process_pool, "Swoole\\Process\\Pool", "swoole_process_pool", nullptr, swoole_process_pool_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_process_pool, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_process_pool);
     SW_SET_CLASS_CLONEABLE(swoole_process_pool, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_process_pool, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_process_pool,

--- a/ext-src/swoole_redis_coro.cc
+++ b/ext-src/swoole_redis_coro.cc
@@ -1895,7 +1895,7 @@ static const zend_function_entry swoole_redis_coro_methods[] =
 
 void php_swoole_redis_coro_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_redis_coro, "Swoole\\Coroutine\\Redis", nullptr, "Co\\Redis", swoole_redis_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_redis_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_redis_coro);
     SW_SET_CLASS_CLONEABLE(swoole_redis_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_redis_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_redis_coro);

--- a/ext-src/swoole_redis_server.cc
+++ b/ext-src/swoole_redis_server.cc
@@ -71,7 +71,7 @@ void php_swoole_redis_server_minit(int module_number) {
                            nullptr,
                            swoole_redis_server_methods,
                            swoole_server);
-    SW_SET_CLASS_SERIALIZABLE(swoole_redis_server, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_redis_server);
     SW_SET_CLASS_CLONEABLE(swoole_redis_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_redis_server, sw_zend_class_unset_property_deny);
 

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -608,7 +608,7 @@ static const zend_function_entry swoole_server_task_methods[] =
 void php_swoole_server_minit(int module_number) {
     // ---------------------------------------Server-------------------------------------
     SW_INIT_CLASS_ENTRY(swoole_server, "Swoole\\Server", "swoole_server", nullptr, swoole_server_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_server, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_server);
     SW_SET_CLASS_CLONEABLE(swoole_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_server, server_create_object, server_free_object, ServerObject, std);
@@ -623,7 +623,7 @@ void php_swoole_server_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_server_task, "Swoole\\Server\\Task", "swoole_server_task", nullptr, swoole_server_task_methods);
     swoole_server_task_ce->ce_flags |= ZEND_ACC_FINAL;
-    SW_SET_CLASS_SERIALIZABLE(swoole_server_task, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_server_task);
     SW_SET_CLASS_CLONEABLE(swoole_server_task, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server_task, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_server_task,
@@ -673,7 +673,7 @@ void php_swoole_server_minit(int module_number) {
                         "swoole_connection_iterator",
                         nullptr,
                         swoole_connection_iterator_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_connection_iterator, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_connection_iterator);
     SW_SET_CLASS_CLONEABLE(swoole_connection_iterator, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_connection_iterator, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_connection_iterator,

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -166,7 +166,7 @@ const zend_function_entry swoole_server_port_methods[] =
 void php_swoole_server_port_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_server_port, "Swoole\\Server\\Port", "swoole_server_port", nullptr, swoole_server_port_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_server_port, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_server_port);
     SW_SET_CLASS_CLONEABLE(swoole_server_port, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_server_port, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_server_port,

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -803,7 +803,7 @@ static void swoole_socket_coro_register_constants(int module_number) {
 void php_swoole_socket_coro_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(
         swoole_socket_coro, "Swoole\\Coroutine\\Socket", nullptr, "Co\\Socket", swoole_socket_coro_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_socket_coro, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_socket_coro);
     SW_SET_CLASS_CLONEABLE(swoole_socket_coro, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_socket_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_socket_coro,

--- a/ext-src/swoole_table.cc
+++ b/ext-src/swoole_table.cc
@@ -220,7 +220,7 @@ static const zend_function_entry swoole_table_methods[] =
 
 void php_swoole_table_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_table, "Swoole\\Table", "swoole_table", nullptr, swoole_table_methods);
-    SW_SET_CLASS_SERIALIZABLE(swoole_table, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_table);
     SW_SET_CLASS_CLONEABLE(swoole_table, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_table, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(

--- a/ext-src/swoole_websocket_server.cc
+++ b/ext-src/swoole_websocket_server.cc
@@ -628,7 +628,7 @@ void php_swoole_websocket_server_minit(int module_number) {
                            nullptr,
                            swoole_websocket_server_methods,
                            swoole_http_server);
-    SW_SET_CLASS_SERIALIZABLE(swoole_websocket_server, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_websocket_server);
     SW_SET_CLASS_CLONEABLE(swoole_websocket_server, sw_zend_class_clone_deny);
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_websocket_server, sw_zend_class_unset_property_deny);
 

--- a/thirdparty/php/curl/interface.cc
+++ b/thirdparty/php/curl/interface.cc
@@ -315,7 +315,7 @@ void swoole_native_curl_minit(int module_number) {
 #if PHP_VERSION_ID >= 80000
     SW_INIT_CLASS_ENTRY(
         swoole_coroutine_curl_handle, "Swoole\\Coroutine\\Curl\\Handle", nullptr, "Co\\Curl\\Handle", nullptr);
-    SW_SET_CLASS_SERIALIZABLE(swoole_coroutine_curl_handle, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(swoole_coroutine_curl_handle);
     SW_SET_CLASS_CUSTOM_OBJECT(swoole_coroutine_curl_handle, curl_create_object, curl_free_obj, php_curl, std);
     swoole_coroutine_curl_handle_ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;
     swoole_coroutine_curl_handle_handlers.get_gc = curl_get_gc;

--- a/thirdparty/php/curl/multi.cc
+++ b/thirdparty/php/curl/multi.cc
@@ -694,8 +694,8 @@ void curl_multi_register_class(const zend_function_entry *method_entries) {
                         nullptr,
                         "Co\\Curl\\MultiHandle",
                         nullptr);
-    SW_SET_CLASS_SERIALIZABLE(
-        swoole_coroutine_curl_multi_handle, zend_class_serialize_deny, zend_class_unserialize_deny);
+    SW_SET_CLASS_NOT_SERIALIZABLE(
+        swoole_coroutine_curl_multi_handle);
     SW_SET_CLASS_CUSTOM_OBJECT(
         swoole_coroutine_curl_multi_handle, curl_multi_create_object, curl_multi_free_obj, php_curlm, std);
     swoole_coroutine_curl_multi_handle_ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;


### PR DESCRIPTION
From UPGRADING.INTERNALS 

```
 f. Non-serializable classes should be indicated using the
     ZEND_ACC_NOT_SERIALIZABLE (@not-serializable in stubs) rather than the
     zend_class_(un)serialize_deny handlers which are removed.

```