### PR TITLE
fix bug #4327 mkdir create failed on coroutines

### DIFF
--- a/tests/swoole_runtime/file_hook/bug_4327.phpt
+++ b/tests/swoole_runtime/file_hook/bug_4327.phpt
@@ -1,0 +1,46 @@
+--TEST--
+mkdir failed when coroutines: bug #4372
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+?>
+--FILE--
+<?php
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Barrier;
+use function Swoole\Coroutine\run;
+
+require __DIR__.'/../../include/bootstrap.php';
+
+Swoole\Runtime::enableCoroutine($flags = SWOOLE_HOOK_ALL);
+
+run(function () {
+    $barrier = Barrier::make();
+    $baseDir = __DIR__.DIRECTORY_SEPARATOR.rand(1000, 9999).DIRECTORY_SEPARATOR;
+
+    for ($i = 0; $i < 10; $i++) {
+        Coroutine::create(static function () use ($i, $baseDir, $barrier) {
+            if (!mkdir($directory = $baseDir.$i, 0755, true) && !is_dir($directory)) {
+                rmdir($directory);
+                echo "SUCCESS".PHP_EOL;
+            }
+        });
+    }
+    Barrier::wait($barrier);
+    rmdir($baseDir);
+});
+?>
+
+--EXPECT--
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+

--- a/thirdparty/php/streams/plain_wrapper.c
+++ b/thirdparty/php/streams/plain_wrapper.c
@@ -1085,7 +1085,7 @@ static int php_plain_files_mkdir(
 
         if (p == buf) {
             ret = mkdir(dir, mode);
-        } else if (!(ret = mkdir(buf, mode))) {
+        } else if ((ret = mkdir(buf, mode)) <= 0) {
             if (!p) {
                 p = buf;
             }

--- a/thirdparty/php/streams/plain_wrapper.c
+++ b/thirdparty/php/streams/plain_wrapper.c
@@ -1085,7 +1085,7 @@ static int php_plain_files_mkdir(
 
         if (p == buf) {
             ret = mkdir(dir, mode);
-        } else if ((ret = mkdir(buf, mode)) <= 0) {
+        } else if (!(ret = mkdir(buf, mode)) || EEXIST == errno) {
             if (!p) {
                 p = buf;
             }


### PR DESCRIPTION
fix bug #4327

```php
for ($index = 0; $index < 100; $index++) {
        Coroutine::create(static function () use ($index, $barrier) {
            if (!mkdir($concurrentDirectory = __DIR__.'/test/'.$index, 0755, true) && !is_dir($concurrentDirectory)) {
                throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
            }
        });
    }
```

One of these coroutines can create top level directory  successfully, but other coroutines will fail because the directory has been created.

So I add this code to solve it. (plain_wrapper.c 1088)

```c
else if (!(ret = mkdir(buf, mode)) || EEXIST == errno)
```

Thanks!