### PR TITLE
Multiple domains for one ip

### DIFF
--- a/core-tests/src/coroutine/hook.cpp
+++ b/core-tests/src/coroutine/hook.cpp
@@ -180,39 +180,39 @@ TEST(coroutine_hook, rename) {
     });
 }
 
-TEST(coroutine_hook, flock) {
-    long start_time = swoole::time<std::chrono::milliseconds>();
-    coroutine::run([&](void *arg) {
-        swoole::Coroutine::create([&](void *arg) {
-            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
-            System::sleep(0.1);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
-            swoole_coroutine_close(fd);
-        });
-        swoole::Coroutine::create([&](void *arg) {
-            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-            System::sleep(2);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-            swoole_coroutine_close(fd);
-        });
-    });
-    // LOCK_NB
-    coroutine::run([](void *arg) {
-        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
-        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
-        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
-        swoole_coroutine_close(fd1);
-        swoole_coroutine_close(fd2);
-    });
-}
+//TEST(coroutine_hook, flock) {
+//    long start_time = swoole::time<std::chrono::milliseconds>();
+//    coroutine::run([&](void *arg) {
+//        swoole::Coroutine::create([&](void *arg) {
+//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
+//            System::sleep(0.1);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
+//            swoole_coroutine_close(fd);
+//        });
+//        swoole::Coroutine::create([&](void *arg) {
+//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+//            System::sleep(2);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//            swoole_coroutine_close(fd);
+//        });
+//    });
+//    // LOCK_NB
+//    coroutine::run([](void *arg) {
+//        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
+//        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
+//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
+//        swoole_coroutine_close(fd1);
+//        swoole_coroutine_close(fd2);
+//    });
+//}
 
 TEST(coroutine_hook, read_dir) {
     auto fp = opendir("/tmp");

--- a/core-tests/src/coroutine/hook.cpp
+++ b/core-tests/src/coroutine/hook.cpp
@@ -180,39 +180,39 @@ TEST(coroutine_hook, rename) {
     });
 }
 
-//TEST(coroutine_hook, flock) {
-//    long start_time = swoole::time<std::chrono::milliseconds>();
-//    coroutine::run([&](void *arg) {
-//        swoole::Coroutine::create([&](void *arg) {
-//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
-//            System::sleep(0.1);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
-//            swoole_coroutine_close(fd);
-//        });
-//        swoole::Coroutine::create([&](void *arg) {
-//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-//            System::sleep(2);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//            swoole_coroutine_close(fd);
-//        });
-//    });
-//    // LOCK_NB
-//    coroutine::run([](void *arg) {
-//        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
-//        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
-//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
-//        swoole_coroutine_close(fd1);
-//        swoole_coroutine_close(fd2);
-//    });
-//}
+TEST(coroutine_hook, flock) {
+    long start_time = swoole::time<std::chrono::milliseconds>();
+    coroutine::run([&](void *arg) {
+        swoole::Coroutine::create([&](void *arg) {
+            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
+            System::sleep(0.1);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
+            swoole_coroutine_close(fd);
+        });
+        swoole::Coroutine::create([&](void *arg) {
+            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+            System::sleep(2);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+            swoole_coroutine_close(fd);
+        });
+    });
+    // LOCK_NB
+    coroutine::run([](void *arg) {
+        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
+        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
+        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
+        swoole_coroutine_close(fd1);
+        swoole_coroutine_close(fd2);
+    });
+}
 
 TEST(coroutine_hook, read_dir) {
     auto fp = opendir("/tmp");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,33 +99,9 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
-    /**
-     * the contents of /etc/hosts file are as follow
-     *
-     * 127.0.0.1
-     * 127.0.0.1 localhost                www.baidu.com
-     *                  127.0.0.1                       bbb.com  #ccc.com
-     *
-     * # 127.0.0.1                         ddd.com
-     */
-
-    std::string ip = swoole::coroutine::get_ip_by_hosts("");
-    ASSERT_EQ(ip, "");
-
     ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("bbb.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-    ASSERT_EQ(ip, "");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,14 +112,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-    ASSERT_EQ(ip, "");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-    ASSERT_EQ(ip, "");
+//    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+//    ASSERT_EQ(ip, "127.0.0.1");
+//
+//    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+//    ASSERT_EQ(ip, "");
+//
+//    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+//    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,14 +112,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-//    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-//    ASSERT_EQ(ip, "127.0.0.1");
-//
-//    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-//    ASSERT_EQ(ip, "");
-//
-//    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-//    ASSERT_EQ(ip, "");
+    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ASSERT_EQ(ip, "");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,12 +104,14 @@ TEST(dns, gethosts) {
      *
      * 127.0.0.1
      * 127.0.0.1 localhost www.baidu.com
-     *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
+     *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
      * # 127.0.0.1 ddd.com
      */
 
+    ip = swoole::coroutine::get_ip_by_hosts("");
+    ASSERT_EQ(ip, "");
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
-    ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,8 +99,25 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
+    /**
+     * the contents of /etc/hosts are as follow
+     * 127.0.0.1 localhost www.baidu.com
+     *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
+     * # 127.0.0.1 ddd.com
+     */
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ASSERT_EQ(ip, "");
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,15 +104,21 @@ TEST(dns, gethosts) {
      *
      * 127.0.0.1
      * 127.0.0.1 localhost                www.baidu.com
-     *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
+     *                  127.0.0.1                       bbb.com  #ccc.com
      *
-     * # 127.0.0.1 ddd.com
+     * # 127.0.0.1                         ddd.com
      */
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("");
+    ASSERT_EQ(ip, "");
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("bbb.com");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("ccc.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -108,9 +108,6 @@ TEST(dns, gethosts) {
      * # 127.0.0.1 ddd.com
      */
 
-    ip = swoole::coroutine::get_ip_by_hosts("");
-    ASSERT_EQ(ip, "");
-
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -109,14 +109,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
 
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
     ASSERT_EQ(ip, "");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -119,6 +119,6 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
-    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
-    ASSERT_EQ(ip, "");
+//    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
+//    ASSERT_EQ(ip, "");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -103,12 +103,14 @@ TEST(dns, gethosts) {
      * the contents of /etc/hosts file are as follow
      *
      * 127.0.0.1
-     * 127.0.0.1 localhost www.baidu.com
+     * 127.0.0.1 localhost                www.baidu.com
      *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
+     *
      * # 127.0.0.1 ddd.com
      */
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
@@ -119,6 +121,6 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
-//    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
-//    ASSERT_EQ(ip, "");
+    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
+    ASSERT_EQ(ip, "");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,7 +112,7 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("");
     ASSERT_EQ(ip, "");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -100,7 +100,9 @@ TEST(dns, load_resolv_conf) {
 
 TEST(dns, gethosts) {
     /**
-     * the contents of /etc/hosts are as follow
+     * the contents of /etc/hosts file are as follow
+     *
+     * 127.0.0.1
      * 127.0.0.1 localhost www.baidu.com
      *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
      * # 127.0.0.1 ddd.com
@@ -111,7 +113,6 @@ TEST(dns, gethosts) {
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
-
 
     ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
     ASSERT_EQ(ip, "");

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -152,7 +152,7 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
     size_t linesize;
-    std::string txtaddr;
+    std::string txtaddr = nullptr;
     std::string domain;
     std::vector<std::string> domains;
 
@@ -172,13 +172,13 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
             domains.push_back(domain);
         }
 
-        if (domains.size() <= 1){
+        if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;
         }
 
         txtaddr = domains[0];
-        for(unsigned int i = 1; i < domains.size(); i++) {
+        for(size_t i = 1; i < domains.size(); i++) {
             result.insert(std::make_pair(domains[i], txtaddr));
         }
 

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -152,7 +152,7 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
     size_t linesize;
-    std::string txtaddr = nullptr;
+    std::string txtaddr;
     std::string domain;
     std::vector<std::string> domains;
 

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -157,7 +157,6 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
-    printf("123\n");
     while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
         if((q = (char *) memchr(p, '#', linesize))){
@@ -172,7 +171,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         while(stream >> domain){
             domains.push_back(domain);
         }
-        printf("456\n");
+
         if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -157,6 +157,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
+    printf("123\n");
     while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
         if((q = (char *) memchr(p, '#', linesize))){
@@ -171,7 +172,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         while(stream >> domain){
             domains.push_back(domain);
         }
-
+        printf("456\n");
         if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <vector>
 #include <unordered_map>
-#include <algorithm>
 #include <sstream>
 
 #define SW_PATH_HOSTS "/etc/hosts"
@@ -161,12 +160,12 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::unordered_map<std::string , std::string> result{};
     while ((status = read_line(fp, &line, &linesize)) == SW_OK) {
         p = line;
-        if((q = (char *) memchr(p, '#', linesize))){
-            *q = '\0';
+        if (*p == '\0') {
+            continue;
         }
 
-        if (*p == '\0' || *p == '\n') {
-            continue;
+        if((q = (char *) memchr(p, '#', linesize))){
+            *q = '\0';
         }
 
         std::stringstream stream(p);

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -151,24 +151,23 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
-    int status;
     size_t linesize;
     std::string txtaddr;
     std::string domain;
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
-    while ((status = read_line(fp, &line, &linesize)) == SW_OK) {
+    while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
-        if (*p == '\0') {
-            continue;
-        }
-
         if((q = (char *) memchr(p, '#', linesize))){
             *q = '\0';
         }
 
-        std::stringstream stream(p);
+        if (*p == '\0') {
+            continue;
+        }
+
+        std::istringstream stream(p);
         while(stream >> domain){
             domains.push_back(domain);
         }
@@ -179,7 +178,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         }
 
         txtaddr = domains[0];
-        for(int i = 1; i < domains.size(); i++) {
+        for(unsigned int i = 1; i < domains.size(); i++) {
             result.insert(std::make_pair(domains[i], txtaddr));
         }
 


### PR DESCRIPTION
Enhancing the support for query of /etc/hosts and simplifying the code.

```shell
# the contents of /etc/hosts file are as follow
127.0.0.1
127.0.0.1 localhost                www.baidu.com
                 127.0.0.1                       bbb.com  #ccc.com
# 127.0.0.1                         ddd.com
```

so ,  the programs can handle complex configurations of /etc/hosts file just like linux os.

Thanks.