### PR TITLE
Enhancing the support for query of /etc/hosts and simplifying the code.

### DIFF
--- a/core-tests/include/test_core.h
+++ b/core-tests/include/test_core.h
@@ -14,7 +14,7 @@
 #include <thread>
 #include <mutex>
 #include <unordered_map>
-#include <sstream>
+#include <fstream>
 
 #define TEST_HOST "127.0.0.1"
 #define TEST_PORT 9501

--- a/core-tests/include/test_core.h
+++ b/core-tests/include/test_core.h
@@ -14,6 +14,7 @@
 #include <thread>
 #include <mutex>
 #include <unordered_map>
+#include <sstream>
 
 #define TEST_HOST "127.0.0.1"
 #define TEST_PORT 9501

--- a/core-tests/include/test_core.h
+++ b/core-tests/include/test_core.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <fstream>
 
+
 #define TEST_HOST "127.0.0.1"
 #define TEST_PORT 9501
 #define TEST_TMP_FILE "/tmp/swoole_core_test_file"

--- a/core-tests/src/coroutine/hook.cpp
+++ b/core-tests/src/coroutine/hook.cpp
@@ -180,39 +180,39 @@ TEST(coroutine_hook, rename) {
     });
 }
 
-TEST(coroutine_hook, flock) {
-    long start_time = swoole::time<std::chrono::milliseconds>();
-    coroutine::run([&](void *arg) {
-        swoole::Coroutine::create([&](void *arg) {
-            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
-            System::sleep(0.1);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
-            swoole_coroutine_close(fd);
-        });
-        swoole::Coroutine::create([&](void *arg) {
-            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-            System::sleep(2);
-            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-            swoole_coroutine_close(fd);
-        });
-    });
-    // LOCK_NB
-    coroutine::run([](void *arg) {
-        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
-        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
-        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
-        swoole_coroutine_close(fd1);
-        swoole_coroutine_close(fd2);
-    });
-}
+//TEST(coroutine_hook, flock) {
+//    long start_time = swoole::time<std::chrono::milliseconds>();
+//    coroutine::run([&](void *arg) {
+//        swoole::Coroutine::create([&](void *arg) {
+//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
+//            System::sleep(0.1);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
+//            swoole_coroutine_close(fd);
+//        });
+//        swoole::Coroutine::create([&](void *arg) {
+//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+//            System::sleep(2);
+//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+//            swoole_coroutine_close(fd);
+//        });
+//    });
+//    // LOCK_NB
+//    coroutine::run([](void *arg) {
+//        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
+//        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+//        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
+//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
+//        swoole_coroutine_close(fd1);
+//        swoole_coroutine_close(fd2);
+//    });
+//}
 
 TEST(coroutine_hook, read_dir) {
     auto fp = opendir("/tmp");

--- a/core-tests/src/coroutine/hook.cpp
+++ b/core-tests/src/coroutine/hook.cpp
@@ -180,39 +180,39 @@ TEST(coroutine_hook, rename) {
     });
 }
 
-//TEST(coroutine_hook, flock) {
-//    long start_time = swoole::time<std::chrono::milliseconds>();
-//    coroutine::run([&](void *arg) {
-//        swoole::Coroutine::create([&](void *arg) {
-//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
-//            System::sleep(0.1);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
-//            swoole_coroutine_close(fd);
-//        });
-//        swoole::Coroutine::create([&](void *arg) {
-//            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
-//            System::sleep(2);
-//            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
-//            swoole_coroutine_close(fd);
-//        });
-//    });
-//    // LOCK_NB
-//    coroutine::run([](void *arg) {
-//        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
-//        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
-//        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
-//        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
-//        swoole_coroutine_close(fd1);
-//        swoole_coroutine_close(fd2);
-//    });
-//}
+TEST(coroutine_hook, flock) {
+    long start_time = swoole::time<std::chrono::milliseconds>();
+    coroutine::run([&](void *arg) {
+        swoole::Coroutine::create([&](void *arg) {
+            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_EX), 0);
+            System::sleep(0.1);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+            ASSERT_LE(swoole::time<std::chrono::milliseconds>() - start_time, 1000);
+            swoole_coroutine_close(fd);
+        });
+        swoole::Coroutine::create([&](void *arg) {
+            int fd = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_SH), 0);
+            System::sleep(2);
+            ASSERT_EQ(swoole_coroutine_flock(fd, LOCK_UN), 0);
+            swoole_coroutine_close(fd);
+        });
+    });
+    // LOCK_NB
+    coroutine::run([](void *arg) {
+        int fd1 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_EX), 0);
+        int fd2 = swoole_coroutine_open(TEST_TMP_FILE, O_WRONLY, 0);
+        ASSERT_EQ(swoole_coroutine_flock(fd2, LOCK_EX | LOCK_NB), -1);
+        ASSERT_EQ(swoole_coroutine_flock(fd1, LOCK_UN), 0);
+        swoole_coroutine_close(fd1);
+        swoole_coroutine_close(fd2);
+    });
+}
 
 TEST(coroutine_hook, read_dir) {
     auto fp = opendir("/tmp");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,33 +99,9 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
-    /**
-     * the contents of /etc/hosts file are as follow
-     *
-     * 127.0.0.1
-     * 127.0.0.1 localhost                www.baidu.com
-     *                  127.0.0.1                       bbb.com  #ccc.com
-     *
-     * # 127.0.0.1                         ddd.com
-     */
-
-    std::string ip = swoole::coroutine::get_ip_by_hosts("");
-    ASSERT_EQ(ip, "");
-
     ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("bbb.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-    ASSERT_EQ(ip, "");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -110,7 +110,7 @@ TEST(dns, gethosts) {
     file << "127.0.0.1";
     file << "127.0.0.1 localhost\n";
     file << "# 127.0.0.1 aaa.com\n";
-    file << "127.0.0.1 bbb.com               ccc.com    #ddd.com\n";
+    file << "       127.0.0.1 bbb.com               ccc.com    #ddd.com\n";
     file.close();
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,7 +99,7 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
-    ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -136,5 +136,7 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
 
-    rename(hosts_backup_file, hosts_file);
+    if (!ret) {
+        rename(hosts_backup_file, hosts_file);
+    }
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -105,7 +105,7 @@ TEST(dns, gethosts) {
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
     if (ret && ENOENT != errno) {
-        std::cout << strerror(errno)  << std::endl;
+        std::cout << "rename file failed: " + strerror(errno)  << std::endl;
         throw strerror(errno);
     }
 
@@ -118,7 +118,7 @@ TEST(dns, gethosts) {
 
     ofstream file(hosts_file);
     if (!file) {
-        std::cout << strerror(errno)  << std::endl;
+        std::cout << "file open failed: " + strerror(errno)  << std::endl;
         throw strerror(errno);
     }
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,14 +112,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-    ASSERT_EQ(ip, "127.0.0.1");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-    ASSERT_EQ(ip, "");
-
-    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-    ASSERT_EQ(ip, "");
+//    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+//    ASSERT_EQ(ip, "127.0.0.1");
+//
+//    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+//    ASSERT_EQ(ip, "");
+//
+//    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+//    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,14 +112,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-//    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
-//    ASSERT_EQ(ip, "127.0.0.1");
-//
-//    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
-//    ASSERT_EQ(ip, "");
-//
-//    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-//    ASSERT_EQ(ip, "");
+    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ASSERT_EQ(ip, "");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,12 +104,14 @@ TEST(dns, gethosts) {
      *
      * 127.0.0.1
      * 127.0.0.1 localhost www.baidu.com
-     *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
+     *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
      * # 127.0.0.1 ddd.com
      */
 
+    ip = swoole::coroutine::get_ip_by_hosts("");
+    ASSERT_EQ(ip, "");
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
-    ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -101,7 +101,10 @@ TEST(dns, load_resolv_conf) {
 TEST(dns, gethosts) {
     char hosts_file[] = "/etc/hosts";
     char hosts_backup_file[] = "/etc/hosts_bak";
-    rename(hosts_file, hosts_backup_file);
+    int ret = rename(hosts_file, hosts_backup_file);
+    if (ret && ENOENT != errno) {
+        throw "rename /etc/hosts to /etc/hosts_bak failed.";
+    }
 
     ofstream file(hosts_file);
     if (!file) {

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,8 +99,25 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
+    /**
+     * the contents of /etc/hosts are as follow
+     * 127.0.0.1 localhost www.baidu.com
+     *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
+     * # 127.0.0.1 ddd.com
+     */
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ASSERT_EQ(ip, "");
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -115,7 +115,7 @@ TEST(dns, gethosts) {
     file << "127.0.0.1\n";
     file << "127.0.0.1 localhost\n";
     file << "# 127.0.0.1 aaa.com\n";
-    file << "       127.0.0.1 bbb.com               ccc.com     #ddd.com\n";
+    file << "       127.0.0.1 bbb.com               ccc.com      #ddd.com\n";
     file.close();
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,12 +104,7 @@ TEST(dns, gethosts) {
     char hosts_file[] = "/etc/hosts";
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
-    ofstream file();
-
     ON_SCOPE_EXIT {
-        if (file) {
-            file.close();
-        }
         if (!ret) {
             rename(hosts_backup_file, hosts_file);
         }
@@ -119,7 +114,12 @@ TEST(dns, gethosts) {
         throw "rename /etc/hosts to /etc/hosts_bak failed.";
     }
 
-    file.open(hosts_file);
+
+    ofstream file(hosts_file);
+    ON_SCOPE_EXIT {
+        file.close();
+    };
+
     if (!file) {
         throw "open /etc/hosts failed.";
     }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,15 +104,21 @@ TEST(dns, gethosts) {
      *
      * 127.0.0.1
      * 127.0.0.1 localhost                www.baidu.com
-     *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
+     *                  127.0.0.1                       bbb.com  #ccc.com
      *
-     * # 127.0.0.1 ddd.com
+     * # 127.0.0.1                         ddd.com
      */
+
+    std::string ip = swoole::coroutine::get_ip_by_hosts("");
+    ASSERT_EQ(ip, "");
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("bbb.com");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("ccc.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,9 +99,11 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
-    rename("/etc/hosts","/etc/hosts_bak");
+    string hosts_file = "/etc/hosts";
+    string hosts_backup_file = "/etc/hosts_bak";
+    rename(hosts_file, hosts_backup_file);
 
-    ofstream file("etc/hosts", ofstream::out);
+    ofstream file(hosts_file, ofstream::out);
     if (!file) {
         throw "open /etc/hosts failed.";
     }
@@ -131,5 +133,5 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
 
-    rename("/etc/hosts_bak", "/etc/hosts");
+    rename(hosts_backup_file, hosts_file);
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -108,9 +108,6 @@ TEST(dns, gethosts) {
      * # 127.0.0.1 ddd.com
      */
 
-    ip = swoole::coroutine::get_ip_by_hosts("");
-    ASSERT_EQ(ip, "");
-
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,8 +99,8 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
-    string hosts_file = "/etc/hosts";
-    string hosts_backup_file = "/etc/hosts_bak";
+    char hosts_file[] = "/etc/hosts";
+    char hosts_backup_file[] = "/etc/hosts_bak";
     rename(hosts_file, hosts_backup_file);
 
     ofstream file(hosts_file);

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -136,5 +136,5 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
 
-//    rename(hosts_backup_file, hosts_file);
+    rename(hosts_backup_file, hosts_file);
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -109,14 +109,14 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
+    ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
 
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
     ASSERT_EQ(ip, "");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
+    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -115,7 +115,7 @@ TEST(dns, gethosts) {
     file << "127.0.0.1\n";
     file << "127.0.0.1 localhost\n";
     file << "# 127.0.0.1 aaa.com\n";
-    file << "       127.0.0.1 bbb.com               ccc.com    #ddd.com\n";
+    file << "       127.0.0.1 bbb.com               ccc.com     #ddd.com\n";
     file.close();
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -132,7 +132,6 @@ TEST(dns, gethosts) {
     file << "       127.0.0.1 bbb.com               ccc.com      #ddd.com\n";
     file.close();
 
-
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,10 +104,12 @@ TEST(dns, gethosts) {
     char hosts_file[] = "/etc/hosts";
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
-    ofstream file(hosts_file);
+    ofstream file();
 
     ON_SCOPE_EXIT {
-        file.close();
+        if (file) {
+            file.close();
+        }
         if (!ret) {
             rename(hosts_backup_file, hosts_file);
         }
@@ -117,6 +119,7 @@ TEST(dns, gethosts) {
         throw "rename /etc/hosts to /etc/hosts_bak failed.";
     }
 
+    file.open(hosts_file);
     if (!file) {
         throw "open /etc/hosts failed.";
     }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -109,7 +109,7 @@ TEST(dns, gethosts) {
     }
 
     file << "\n";
-    file << "127.0.0.1";
+    file << "127.0.0.1\n";
     file << "127.0.0.1 localhost\n";
     file << "# 127.0.0.1 aaa.com\n";
     file << "       127.0.0.1 bbb.com               ccc.com    #ddd.com\n";
@@ -133,5 +133,5 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
 
-    rename(hosts_backup_file, hosts_file);
+//    rename(hosts_backup_file, hosts_file);
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -130,4 +130,6 @@ TEST(dns, gethosts) {
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
+
+    rename("/etc/hosts_bak", "/etc/hosts");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -124,6 +124,7 @@ TEST(dns, gethosts) {
         file.close();
     };
 
+
     file << "\n";
     file << "127.0.0.1\n";
     file << "127.0.0.1 localhost\n";

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -119,6 +119,6 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
-    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
-    ASSERT_EQ(ip, "");
+//    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
+//    ASSERT_EQ(ip, "");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -102,7 +102,6 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
-
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -103,12 +103,14 @@ TEST(dns, gethosts) {
      * the contents of /etc/hosts file are as follow
      *
      * 127.0.0.1
-     * 127.0.0.1 localhost www.baidu.com
+     * 127.0.0.1 localhost                www.baidu.com
      *                  127.0.0.1 aaa.com                       bbb.com  #ccc.com
+     *
      * # 127.0.0.1 ddd.com
      */
 
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
@@ -119,6 +121,6 @@ TEST(dns, gethosts) {
     ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "");
 
-//    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
-//    ASSERT_EQ(ip, "");
+    ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
+    ASSERT_EQ(ip, "");
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -105,7 +105,8 @@ TEST(dns, gethosts) {
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
     if (ret && ENOENT != errno) {
-        throw "rename /etc/hosts to /etc/hosts_bak failed.";
+        std::cout << strerror(errno)  << std::endl;
+        throw strerror(errno);
     }
 
     ON_SCOPE_EXIT {
@@ -117,7 +118,8 @@ TEST(dns, gethosts) {
 
     ofstream file(hosts_file);
     if (!file) {
-        throw "open /etc/hosts failed.";
+        std::cout << strerror(errno)  << std::endl;
+        throw strerror(errno);
     }
 
     ON_SCOPE_EXIT {

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -149,4 +149,5 @@ TEST(dns, gethosts) {
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");
+
 }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -103,7 +103,7 @@ TEST(dns, gethosts) {
     string hosts_backup_file = "/etc/hosts_bak";
     rename(hosts_file, hosts_backup_file);
 
-    ofstream file(hosts_file, ofstream::out);
+    ofstream file(hosts_file);
     if (!file) {
         throw "open /etc/hosts failed.";
     }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -115,7 +115,6 @@ TEST(dns, gethosts) {
         }
     };
 
-
     ofstream file(hosts_file);
     if (!file) {
         std::cout << std::string("file open failed: ") + std::string(strerror(errno)) << std::endl;

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -112,7 +112,7 @@ TEST(dns, gethosts) {
     std::string ip = swoole::coroutine::get_ip_by_hosts("");
     ASSERT_EQ(ip, "");
 
-    std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -104,25 +104,25 @@ TEST(dns, gethosts) {
     char hosts_file[] = "/etc/hosts";
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
+    if (ret && ENOENT != errno) {
+        throw "rename /etc/hosts to /etc/hosts_bak failed.";
+    }
+
     ON_SCOPE_EXIT {
         if (!ret) {
             rename(hosts_backup_file, hosts_file);
         }
     };
 
-    if (ret && ENOENT != errno) {
-        throw "rename /etc/hosts to /etc/hosts_bak failed.";
-    }
-
 
     ofstream file(hosts_file);
-    ON_SCOPE_EXIT {
-        file.close();
-    };
-
     if (!file) {
         throw "open /etc/hosts failed.";
     }
+
+    ON_SCOPE_EXIT {
+        file.close();
+    };
 
     file << "\n";
     file << "127.0.0.1\n";

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -99,7 +99,33 @@ TEST(dns, load_resolv_conf) {
 }
 
 TEST(dns, gethosts) {
+    rename("/etc/hosts","/etc/hosts_bak");
+
+    ofstream file("etc/hosts", ofstream::out);
+    if (!file) {
+        throw "open /etc/hosts failed.";
+    }
+
+    file << "\n";
+    file << "127.0.0.1";
+    file << "127.0.0.1 localhost\n";
+    file << "# 127.0.0.1 aaa.com\n";
+    file << "127.0.0.1 bbb.com               ccc.com    #ddd.com\n";
+    file.close();
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("aaa.com");
+    ASSERT_EQ(ip, "");
+
+    ip = swoole::coroutine::get_ip_by_hosts("bbb.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
+    ASSERT_EQ(ip, "127.0.0.1");
+
+    ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -100,7 +100,9 @@ TEST(dns, load_resolv_conf) {
 
 TEST(dns, gethosts) {
     /**
-     * the contents of /etc/hosts are as follow
+     * the contents of /etc/hosts file are as follow
+     *
+     * 127.0.0.1
      * 127.0.0.1 localhost www.baidu.com
      *                  127.0.0.1 aaa.com   bbb.com  #ccc.com
      * # 127.0.0.1 ddd.com
@@ -111,7 +113,6 @@ TEST(dns, gethosts) {
 
     ip = swoole::coroutine::get_ip_by_hosts("www.baidu.com");
     ASSERT_EQ(ip, "127.0.0.1");
-
 
     ip = swoole::coroutine::get_ip_by_hosts("ccc.com");
     ASSERT_EQ(ip, "");

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -107,7 +107,7 @@ TEST(dns, gethosts) {
     ofstream file(hosts_file);
 
     ON_SCOPE_EXIT {
-        file.close()
+        file.close();
         if (!ret) {
             rename(hosts_backup_file, hosts_file);
         }

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -131,6 +131,7 @@ TEST(dns, gethosts) {
     file << "       127.0.0.1 bbb.com               ccc.com      #ddd.com\n";
     file.close();
 
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -105,7 +105,7 @@ TEST(dns, gethosts) {
     char hosts_backup_file[] = "/etc/hosts_bak";
     int ret = rename(hosts_file, hosts_backup_file);
     if (ret && ENOENT != errno) {
-        std::cout << "rename file failed: " + strerror(errno)  << std::endl;
+        std::cout << std::string("rename file failed: ") + std::string(strerror(errno)) << std::endl;
         throw strerror(errno);
     }
 
@@ -118,7 +118,7 @@ TEST(dns, gethosts) {
 
     ofstream file(hosts_file);
     if (!file) {
-        std::cout << "file open failed: " + strerror(errno)  << std::endl;
+        std::cout << std::string("file open failed: ") + std::string(strerror(errno)) << std::endl;
         throw strerror(errno);
     }
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -120,6 +120,7 @@ TEST(dns, gethosts) {
     file.close();
 
     swoole::coroutine::swoole_set_hosts_path(hosts_file);
+
     std::string ip = swoole::coroutine::get_ip_by_hosts("localhost");
     ASSERT_EQ(ip, "127.0.0.1");
 

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -63,7 +63,7 @@ TEST(dns, cancel) {
     // swoole_set_log_level(SW_LOG_TRACE);
     test::coroutine::run([](void *arg) {
         auto co = Coroutine::get_current_safe();
-        Coroutine::create([co](void *){
+        Coroutine::create([co](void *) {
             System::sleep(0.002);
             co->cancel();
         });
@@ -124,7 +124,6 @@ TEST(dns, gethosts) {
     ON_SCOPE_EXIT {
         file.close();
     };
-
 
     file << "\n";
     file << "127.0.0.1\n";

--- a/core-tests/src/network/dns.cpp
+++ b/core-tests/src/network/dns.cpp
@@ -128,7 +128,7 @@ TEST(dns, gethosts) {
     ASSERT_EQ(ip, "127.0.0.1");
 
     ip = swoole::coroutine::get_ip_by_hosts("ddd.com");
-    ASSERT_EQ(ip, "127.0.0.1");
+    ASSERT_EQ(ip, "");
 
     ip = swoole::coroutine::get_ip_by_hosts("non.exist.com");
     ASSERT_EQ(ip, "");

--- a/include/swoole_coroutine_socket.h
+++ b/include/swoole_coroutine_socket.h
@@ -575,6 +575,7 @@ class ProtocolSwitch {
     bool ori_open_length_check;
     Protocol ori_protocol;
     Socket *socket_;
+
   public:
     ProtocolSwitch(Socket *socket) {
         ori_open_eof_check = socket->open_eof_check;
@@ -596,7 +597,7 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
 #ifdef SW_USE_CARES
 std::vector<std::string> dns_lookup_impl_with_cares(const char *domain, int family, double timeout);
 #endif
-std::string get_ip_by_hosts(const std::string& domain);
+std::string get_ip_by_hosts(const std::string &domain);
 void swoole_set_hosts_path(char *hosts_file);
 //-------------------------------------------------------------------------------
 }  // namespace coroutine

--- a/include/swoole_coroutine_socket.h
+++ b/include/swoole_coroutine_socket.h
@@ -596,7 +596,8 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
 #ifdef SW_USE_CARES
 std::vector<std::string> dns_lookup_impl_with_cares(const char *domain, int family, double timeout);
 #endif
-std::string get_ip_by_hosts(std::string domain);
+std::string get_ip_by_hosts(const std::string& domain);
+void swoole_set_hosts_path(char *hosts_file);
 //-------------------------------------------------------------------------------
 }  // namespace coroutine
 }  // namespace swoole

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -104,20 +104,17 @@ struct RR_FLAGS {
 };
 
 static uint16_t dns_request_id = 1;
+char *swoole_hosts = nullptr;
 
 static int domain_encode(const char *src, int n, char *dest);
 static void domain_decode(char *str);
 static std::string parse_ip_address(void *vaddr, int type);
 
-std::string get_ip_by_hosts(std::string search_domain) {
-    std::ifstream file(SW_PATH_HOSTS);
-    if (!file) {
+std::string get_ip_by_hosts(const std::string &search_domain) {
+    std::ifstream file(swoole_hosts ? swoole_hosts : SW_PATH_HOSTS);
+    if (!file.is_open()) {
         return "";
     }
-
-    ON_SCOPE_EXIT {
-        file.close();
-    };
 
     std::string line;
     std::string domain;
@@ -131,7 +128,7 @@ std::string get_ip_by_hosts(std::string search_domain) {
             line[ops] = '\0';
         }
 
-        if (line[0] == '\n' || line[0] == '\0') {
+        if (line[0] == '\n' || line[0] == '\0' || line[0] == '\r') {
             continue;
         }
 
@@ -161,6 +158,10 @@ std::string get_ip_by_hosts(std::string search_domain) {
     }
 
     return "";
+}
+
+void swoole_set_hosts_path(char *hosts_file) {
+    swoole_hosts = hosts_file;
 }
 
 static std::string parse_ip_address(void *vaddr, int type) {

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -152,7 +152,7 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
     size_t linesize;
-    std::string txtaddr;
+    std::string txtaddr = nullptr;
     std::string domain;
     std::vector<std::string> domains;
 
@@ -172,13 +172,13 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
             domains.push_back(domain);
         }
 
-        if (domains.size() <= 1){
+        if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;
         }
 
         txtaddr = domains[0];
-        for(unsigned int i = 1; i < domains.size(); i++) {
+        for(size_t i = 1; i < domains.size(); i++) {
             result.insert(std::make_pair(domains[i], txtaddr));
         }
 

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -152,7 +152,7 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
     size_t linesize;
-    std::string txtaddr = nullptr;
+    std::string txtaddr;
     std::string domain;
     std::vector<std::string> domains;
 

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -157,7 +157,6 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
-    printf("123\n");
     while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
         if((q = (char *) memchr(p, '#', linesize))){
@@ -172,7 +171,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         while(stream >> domain){
             domains.push_back(domain);
         }
-        printf("456\n");
+
         if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -136,7 +136,6 @@ std::string get_ip_by_hosts(const std::string &search_domain) {
         while (stream >> domain) {
             domains.push_back(domain);
         }
-
         if (domains.empty() || domains.size() == 1) {
             domains.clear();
             continue;

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -157,6 +157,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
+    printf("123\n");
     while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
         if((q = (char *) memchr(p, '#', linesize))){
@@ -171,7 +172,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         while(stream >> domain){
             domains.push_back(domain);
         }
-
+        printf("456\n");
         if (domains.empty() || domains.size() == 1){
             domains.clear();
             continue;

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <vector>
 #include <unordered_map>
-#include <algorithm>
 #include <sstream>
 
 #define SW_PATH_HOSTS "/etc/hosts"
@@ -161,12 +160,12 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     std::unordered_map<std::string , std::string> result{};
     while ((status = read_line(fp, &line, &linesize)) == SW_OK) {
         p = line;
-        if((q = (char *) memchr(p, '#', linesize))){
-            *q = '\0';
+        if (*p == '\0') {
+            continue;
         }
 
-        if (*p == '\0' || *p == '\n') {
-            continue;
+        if((q = (char *) memchr(p, '#', linesize))){
+            *q = '\0';
         }
 
         std::stringstream stream(p);

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -149,17 +149,17 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
     return SW_OK;
 }
 
-static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
+static std::unordered_map<std::string, std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
     size_t linesize;
     std::string txtaddr;
     std::string domain;
     std::vector<std::string> domains;
 
-    std::unordered_map<std::string , std::string> result{};
+    std::unordered_map<std::string, std::string> result{};
     while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
-        if((q = (char *) memchr(p, '#', linesize))){
+        if ((q = (char *) memchr(p, '#', linesize))) {
             *q = '\0';
         }
 
@@ -168,17 +168,17 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         }
 
         std::istringstream stream(p);
-        while(stream >> domain){
+        while (stream >> domain) {
             domains.push_back(domain);
         }
 
-        if (domains.empty() || domains.size() == 1){
+        if (domains.empty() || domains.size() == 1) {
             domains.clear();
             continue;
         }
 
         txtaddr = domains[0];
-        for(size_t i = 1; i < domains.size(); i++) {
+        for (size_t i = 1; i < domains.size(); i++) {
             result.insert(std::make_pair(domains[i], txtaddr));
         }
 
@@ -202,7 +202,7 @@ std::string get_ip_by_hosts(std::string domain) {
     };
     while (1) {
         auto result = get_hostent(fp);
-        if (result.empty()){
+        if (result.empty()) {
             break;
         }
 
@@ -337,7 +337,7 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
         temp = &packet[steps];
         j = 0;
         while (*temp != 0) {
-            if ((uchar)(*temp) == 0xc0) {
+            if ((uchar) (*temp) == 0xc0) {
                 ++temp;
                 temp = &packet[(uint8_t) *temp];
             } else {
@@ -366,7 +366,7 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
             temp = &packet[steps];
             j = 0;
             while (*temp != 0) {
-                if ((uchar)(*temp) == 0xc0) {
+                if ((uchar) (*temp) == 0xc0) {
                     ++temp;
                     temp = &packet[(uint8_t) *temp];
                 } else {

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -286,7 +286,7 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
         temp = &packet[steps];
         j = 0;
         while (*temp != 0) {
-            if ((uchar) (*temp) == 0xc0) {
+            if ((uchar)(*temp) == 0xc0) {
                 ++temp;
                 temp = &packet[(uint8_t) *temp];
             } else {
@@ -315,7 +315,7 @@ std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int fam
             temp = &packet[steps];
             j = 0;
             while (*temp != 0) {
-                if ((uchar) (*temp) == 0xc0) {
+                if ((uchar)(*temp) == 0xc0) {
                     ++temp;
                     temp = &packet[(uint8_t) *temp];
                 } else {

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -155,6 +155,7 @@ std::string get_ip_by_hosts(std::string search_domain) {
             return iter->second;
         } else {
             result.clear();
+            domains.clear();
             continue;
         }
     }

--- a/src/network/dns.cc
+++ b/src/network/dns.cc
@@ -151,24 +151,23 @@ static int read_line(FILE *fp, char **buf, size_t *bufsize) {
 
 static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
     char *line = nullptr, *p, *q;
-    int status;
     size_t linesize;
     std::string txtaddr;
     std::string domain;
     std::vector<std::string> domains;
 
     std::unordered_map<std::string , std::string> result{};
-    while ((status = read_line(fp, &line, &linesize)) == SW_OK) {
+    while (read_line(fp, &line, &linesize) == SW_OK) {
         p = line;
-        if (*p == '\0') {
-            continue;
-        }
-
         if((q = (char *) memchr(p, '#', linesize))){
             *q = '\0';
         }
 
-        std::stringstream stream(p);
+        if (*p == '\0') {
+            continue;
+        }
+
+        std::istringstream stream(p);
         while(stream >> domain){
             domains.push_back(domain);
         }
@@ -179,7 +178,7 @@ static std::unordered_map<std::string , std::string> get_hostent(FILE *fp) {
         }
 
         txtaddr = domains[0];
-        for(int i = 1; i < domains.size(); i++) {
+        for(unsigned int i = 1; i < domains.size(); i++) {
             result.insert(std::make_pair(domains[i], txtaddr));
         }
 


### PR DESCRIPTION
Enhancing the support for query of /etc/hosts and simplifying the code.

```shell
# the contents of /etc/hosts file are as follow
127.0.0.1
127.0.0.1 localhost                www.baidu.com
                 127.0.0.1                       bbb.com  #ccc.com
# 127.0.0.1                         ddd.com
```

so , the programs can handle complex configurations of /etc/hosts file just like linux os.

Thanks.