### PR TITLE
Fix sleep large number

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -1611,9 +1611,9 @@ static PHP_FUNCTION(swoole_sleep) {
     }
 
     if (Coroutine::get_current()) {
-        RETURN_LONG(System::sleep((double) num) < 0 ? num : 0);
+        RETURN_LONG(System::sleep((double) (unsigned int) num) < 0 ? num : 0);
     } else {
-        RETURN_LONG(php_sleep(num));
+        RETURN_LONG(php_sleep((unsigned int) num));
     }
 }
 

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -1611,7 +1611,7 @@ static PHP_FUNCTION(swoole_sleep) {
     }
 
     if (Coroutine::get_current()) {
-        RETURN_LONG(System::sleep((double) (unsigned int) num) < 0 ? num : 0);
+        RETURN_LONG(System::sleep((double) num) < 0 ? num : 0);
     } else {
         RETURN_LONG(php_sleep((unsigned int) num));
     }


### PR DESCRIPTION
Fix: ` WARNING Timer::add() (ERRNO 505): msec value[-9223372036854775808] is invalid`

```php
<?php

declare(strict_types=1);

Co\run(function () {
    sleep(\PHP_INT_MAX);
});
```
