### PR TITLE
SW_CORO_TIME compile option.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -101,6 +101,11 @@ PHP_ARG_ENABLE([thread-context],
   [AS_HELP_STRING([--enable-thread-context],
     [Use thread context])], [no], [no])
 
+PHP_ARG_ENABLE([swoole-coro-time],
+  [whether to enable coroutine execution time ],
+  [AS_HELP_STRING([--enable-swoole-coro-time],
+    [Calculating coroutine execution time])], [no], [no])
+
 AC_DEFUN([SWOOLE_HAVE_PHP_EXT], [
     extname=$1
     haveext=$[PHP_]translit($1,a-z_-,A-Z__)
@@ -405,6 +410,10 @@ if test "$PHP_SWOOLE" != "no"; then
 
     if test "$PHP_SWOOLE_CURL" = "yes"; then
         AC_DEFINE(SW_USE_CURL, 1, [do we enable cURL native client])
+    fi
+
+    if test "$PHP_SWOOLE_CORO_TIME" = "yes"; then
+        AC_DEFINE(SW_CORO_TIME, 1, [do we enable to calculate coroutine execution time])
     fi
 
     if test "$PHP_SWOOLE_PGSQL" != "no"; then

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -118,7 +118,9 @@ static PHP_METHOD(swoole_coroutine, getStackUsage);
 static PHP_METHOD(swoole_coroutine, list);
 static PHP_METHOD(swoole_coroutine, enableScheduler);
 static PHP_METHOD(swoole_coroutine, disableScheduler);
+#ifdef SW_CORO_TIME
 static PHP_METHOD(swoole_coroutine, getExecuteTime);
+#endif
 SW_EXTERN_C_END
 
 // clang-format off
@@ -151,7 +153,9 @@ static const zend_function_entry swoole_coroutine_methods[] =
     PHP_MALIAS(swoole_coroutine, listCoroutines, list,    arginfo_class_Swoole_Coroutine_listCoroutines,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, enableScheduler,             arginfo_class_Swoole_Coroutine_enableScheduler,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(swoole_coroutine, disableScheduler,            arginfo_class_Swoole_Coroutine_disableScheduler, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+#ifdef SW_CORO_TIME
     PHP_ME(swoole_coroutine, getExecuteTime,              arginfo_class_Swoole_Coroutine_getExecuteTime,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+#endif
     /**
      * Coroutine System API
      */
@@ -1306,9 +1310,11 @@ static PHP_METHOD(swoole_coroutine, list) {
     zval_ptr_dtor(&zlist);
 }
 
+#ifdef SW_CORO_TIME
 static PHP_METHOD(swoole_coroutine, getExecuteTime) {
     RETURN_LONG(PHPCoroutine::get_execute_time());
 }
+#endif
 
 PHP_METHOD(swoole_coroutine, enableScheduler) {
     RETURN_BOOL(PHPCoroutine::enable_scheduler());

--- a/include/swoole_coroutine.h
+++ b/include/swoole_coroutine.h
@@ -35,6 +35,12 @@
 
 typedef std::chrono::microseconds seconds_type;
 
+#ifdef SW_CORO_TIME
+#define CALC_EXECUTE_USEC(yield_coroutine, resume_coroutine) calc_execute_usec(yield_coroutine, resume_coroutine)
+#else
+#define CALC_EXECUTE_USEC(yield_coroutine, resume_coroutine)
+#endif
+
 namespace swoole {
 class Coroutine {
   public:
@@ -255,7 +261,7 @@ class Coroutine {
         long cid = this->cid;
         origin = current;
         current = this;
-        calc_execute_usec(origin, this);
+        CALC_EXECUTE_USEC(origin, nullptr);
         ctx.swap_in();
         check_end();
         return cid;

--- a/src/coroutine/base.cc
+++ b/src/coroutine/base.cc
@@ -61,7 +61,7 @@ void Coroutine::yield() {
     }
     current = origin;
 
-    calc_execute_usec(this, current);
+    CALC_EXECUTE_USEC(this, current);
     ctx.swap_out();
 }
 
@@ -115,7 +115,7 @@ void Coroutine::resume() {
     origin = current;
     current = this;
 
-    calc_execute_usec(origin, this);
+    CALC_EXECUTE_USEC(origin, this);
     ctx.swap_in();
     check_end();
 }

--- a/stubs/php_swoole_coroutine_legacy_arginfo.h
+++ b/stubs/php_swoole_coroutine_legacy_arginfo.h
@@ -59,8 +59,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_swoole_coroutine_getStackUsage, 0, 0, 0)
     ZEND_ARG_INFO(0, cid)
 ZEND_END_ARG_INFO()
 
+#ifdef SW_CORO_TIME
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_getExecuteTime, 0, 0, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_Swoole_Coroutine_create           arginfo_swoole_coroutine_create
 #define arginfo_class_Swoole_Coroutine_defer            arginfo_swoole_coroutine_defer
@@ -86,7 +88,9 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Swoole_Coroutine_listCoroutines   arginfo_swoole_coroutine_void
 #define arginfo_class_Swoole_Coroutine_enableScheduler  arginfo_swoole_coroutine_void
 #define arginfo_class_Swoole_Coroutine_disableScheduler arginfo_swoole_coroutine_void
+#ifdef SW_CORO_TIME
 #define arginfo_class_Swoole_Coroutine_getExecuteTime   arginfo_swoole_coroutine_void
+#endif
 
 #define arginfo_class_Swoole_ExitException_getFlags  arginfo_swoole_coroutine_void
 #define arginfo_class_Swoole_ExitException_getStatus arginfo_swoole_coroutine_void

--- a/tests/include/skipif.inc
+++ b/tests/include/skipif.inc
@@ -257,3 +257,8 @@ function skip_unsupported(string $message = '')
 {
     skip($message ?: 'the test cannot continue to work for some implementation reasons');
 }
+
+function skip_if_no_coroutine_get_execute_time()
+{
+    skip('no Swoole\Coroutine::getExecuteTime', !method_exists(Swoole\Coroutine::class, 'getExecuteTime'));
+}

--- a/tests/swoole_coroutine/execute_time.phpt
+++ b/tests/swoole_coroutine/execute_time.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_coroutine: getExecuteTime
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_coroutine_get_execute_time();
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';


### PR DESCRIPTION
We can use SW_CORO_TIME option when compiling swoole to calculate coroutine execution time.