### PR TITLE
Add Content-Encoding header for websocket response.

### DIFF
--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -408,6 +408,16 @@ void HttpContext::build_header(String *http_buffer, size_t body_length) {
         http_buffer->append(ZEND_STRL("Server: " SW_HTTP_SERVER_SOFTWARE "\r\n"));
     }
 
+#ifdef SW_HAVE_COMPRESSION
+    // http compress
+    if (accept_compression) {
+        const char *content_encoding = get_content_encoding();
+        http_buffer->append(ZEND_STRL("Content-Encoding: "));
+        http_buffer->append((char *) content_encoding, strlen(content_encoding));
+        http_buffer->append(ZEND_STRL("\r\n"));
+    }
+#endif
+
     // websocket protocol (subsequent header info is unnecessary)
     if (upgrade == 1) {
         http_buffer->append(ZEND_STRL("\r\n"));
@@ -447,15 +457,7 @@ void HttpContext::build_header(String *http_buffer, size_t body_length) {
             http_buffer->append(buf, n);
         }
     }
-#ifdef SW_HAVE_COMPRESSION
-    // http compress
-    if (accept_compression) {
-        const char *content_encoding = get_content_encoding();
-        http_buffer->append(ZEND_STRL("Content-Encoding: "));
-        http_buffer->append((char *) content_encoding, strlen(content_encoding));
-        http_buffer->append(ZEND_STRL("\r\n"));
-    }
-#endif
+
     http_buffer->append(ZEND_STRL("\r\n"));
     send_header_ = 1;
 }


### PR DESCRIPTION
Environment：
Nginx，hyperf (websocket server)
Nginx proxy request to websocket server.

My Nginx config:
```c
location /ws/ {
        proxy_http_version 1.1;
        proxy_set_header Upgrade websocket;
        proxy_set_header Connection "Upgrade";
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_read_timeout 1800s ;
        proxy_pass http://127.0.0.1:9502/;
    }
```

It will regards response as file and download it if we request http://x.x.x.x/ws and set Accept-Encoding at the brsower because swoole server compress the response but never set Content-Encoding in the response header.
Brsower can not understand which method can decompress response.

