### PR TITLE
Support Channel::push() not yield coroutine

### DIFF
--- a/ext-src/swoole_channel_coro.cc
+++ b/ext-src/swoole_channel_coro.cc
@@ -150,16 +150,18 @@ static PHP_METHOD(swoole_channel_coro, push) {
     Channel *chan = php_swoole_get_channel(ZEND_THIS);
     zval *zdata;
     double timeout = -1;
+    bool yield = true;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 2)
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 3)
     Z_PARAM_ZVAL(zdata)
     Z_PARAM_OPTIONAL
     Z_PARAM_DOUBLE(timeout)
+    Z_PARAM_BOOL(yield)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     Z_TRY_ADDREF_P(zdata);
     zdata = sw_zval_dup(zdata);
-    if (chan->push(zdata, timeout)) {
+    if (chan->push(zdata, timeout, yield)) {
         zend_update_property_long(
             swoole_channel_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("errCode"), Channel::ERROR_OK);
         RETURN_TRUE;

--- a/include/swoole_coroutine_channel.h
+++ b/include/swoole_coroutine_channel.h
@@ -53,7 +53,7 @@ class Channel {
     };
 
     void *pop(double timeout = -1);
-    bool push(void *data, double timeout = -1);
+    bool push(void *data, double timeout = -1, bool yield = true);
     bool close();
 
     Channel(size_t _capacity = 1) : capacity(_capacity) {}

--- a/stubs/php_swoole_channel_coro.stub.php
+++ b/stubs/php_swoole_channel_coro.stub.php
@@ -2,7 +2,7 @@
 namespace Swoole\Coroutine {
 	class Channel {
 		public function __construct(int $size = 1) {}
-		public function push(mixed $data, float $timeout = -1): bool {}
+		public function push(mixed $data, float $timeout = -1, bool $yield = true): bool {}
 		public function pop(float $timeout = -1): mixed {}
 		public function stats(): array {}
 		public function close(): bool {}

--- a/stubs/php_swoole_channel_coro_arginfo.h
+++ b/stubs/php_swoole_channel_coro_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2ed4e36fbf2cabffca5dd794ba4be3dc1c6c086a */
+ * Stub hash: dd8b1737d2089d01a5e46378bd8df553d9b625de */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_Channel___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "1")
@@ -8,6 +8,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_Channel_push, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, yield, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_Channel_pop, 0, 0, IS_MIXED, 0)

--- a/tests/swoole_channel_coro/benchmark_not_yield.phpt
+++ b/tests/swoole_channel_coro/benchmark_not_yield.phpt
@@ -1,0 +1,69 @@
+--TEST--
+swoole_channel_coro: 100W benchmark
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+$time = [];
+
+// spl queue
+$time['splQueue'] = microtime(true);
+$queue = new SplQueue;
+for ($i = MAX_LOOPS; $i--;) {
+    $queue->enqueue($i);
+}
+$i = MAX_LOOPS;
+while (!$queue->isEmpty()) {
+    Assert::same((--$i), $queue->dequeue());
+}
+$time['splQueue'] = microtime(true) - $time['splQueue'];
+
+// channel
+go(function () use (&$time) {
+    $time['channel_raw'] = microtime(true);
+    $chan = new Chan(MAX_LOOPS);
+    for ($i = MAX_LOOPS; $i--;) {
+        $chan->push($i, -1, false);
+    }
+    $i = MAX_LOOPS;
+    while (!$chan->isEmpty()) {
+        Assert::same((--$i), $chan->pop());
+    }
+    $time['channel_raw'] = microtime(true) - $time['channel_raw'];
+});
+
+// channel with scheduler
+$chan = new Chan;
+go(function () use (&$time, $chan) {
+    co::sleep(0.1);
+    $time['channel_scheduler'] = microtime(true);
+    for ($i = MAX_LOOPS; $i--;) {
+        $chan->push($i, -1, false);
+    }
+    $chan->push(false, -1, false);
+});
+go(function () use (&$time, $chan) {
+    $i = MAX_LOOPS;
+    while (($ret = $chan->pop()) !== false) {
+        Assert::same((--$i), $ret);
+    }
+    $time['channel_scheduler'] = microtime(true) - $time['channel_scheduler'];
+    $chan->close();
+});
+
+Swoole\Event::wait();
+var_dump($time);
+$diff = $time['channel_raw'] - $time['splQueue'];
+var_dump($diff);
+?>
+--EXPECTF--
+array(3) {
+  ["splQueue"]=>
+  float(%f)
+  ["channel_raw"]=>
+  float(%f)
+  ["channel_scheduler"]=>
+  float(%f)
+}
+float(%f)

--- a/tests/swoole_channel_coro/push_not_yield.phpt
+++ b/tests/swoole_channel_coro/push_not_yield.phpt
@@ -1,0 +1,28 @@
+--TEST--
+swoole_channel_coro: push yield=false
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+Co\run(function(){
+    $chan = new chan();
+    go(function() use ($chan) {
+        while (false !== ($value = $chan->pop())) {
+            var_dump($value);
+        }
+    });
+    for($i = 0; $i < 3; ++$i) {
+        $chan->push($i, -1, false);
+    }
+    $chan->close();
+    var_dump('complete');
+});
+
+?>
+--EXPECTF--
+int(0)
+string(8) "complete"
+int(1)
+int(2)


### PR DESCRIPTION
Some scenarios need to traverse the array and push to the channel

Every push will yield coroutine to the consumer, and the performance is not very good

**benchmark:**

![image](https://user-images.githubusercontent.com/20104656/150293164-f1a2b8a5-73ef-40ce-be17-58a094bff540.png)
