### PR TITLE
Respect SETTINGS_HEADER_TABLE_SIZE http2 setting

### DIFF
--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -125,7 +125,7 @@ static ssize_t http2_server_build_trailer(HttpContext *ctx, uchar *buffer) {
         nghttp2_hd_deflater *deflater = client->deflater;
 
         if (!deflater) {
-            int ret = nghttp2_hd_deflate_new2(&deflater, SW_HTTP2_DEFAULT_HEADER_TABLE_SIZE, php_nghttp2_mem());
+            int ret = nghttp2_hd_deflate_new2(&deflater, client->remote_settings.header_table_size, php_nghttp2_mem());
             if (ret != 0) {
                 swoole_warning("nghttp2_hd_deflate_new2() failed with error: %s", nghttp2_strerror(ret));
                 return -1;
@@ -361,7 +361,7 @@ static ssize_t http2_server_build_header(HttpContext *ctx, uchar *buffer, size_t
     Http2Session *client = http2_sessions[ctx->fd];
     nghttp2_hd_deflater *deflater = client->deflater;
     if (!deflater) {
-        ret = nghttp2_hd_deflate_new2(&deflater, client->local_settings.header_table_size, php_nghttp2_mem());
+        ret = nghttp2_hd_deflate_new2(&deflater, client->remote_settings.header_table_size, php_nghttp2_mem());
         if (ret != 0) {
             swoole_warning("nghttp2_hd_deflate_new2() failed with error: %s", nghttp2_strerror(ret));
             return -1;


### PR DESCRIPTION
**My nginx config:**

```conf
upstream grpcServer {
    server host.docker.internal:13009;
    keepalive 3600;
}

server { 
    listen       8890 http2;

    access_log  /var/log/nginx/test.access.log  main;
    error_log  /var/log/nginx/test.error.log  error;

    add_header 'Access-Control-Allow-Origin' '*';
    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
    add_header 'Access-Control-Allow-Headers' 'authorization,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';

    # grpc
    location ~* ^/(.+)\.(.+)/(.+)$ {
		grpc_set_header Host $host;
		grpc_set_header X-Real-IP $remote_addr;
		grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
		grpc_socket_keepalive on;
		proxy_next_upstream off;
        grpc_pass grpc://grpcServer;
    }

    location / {
        index index.html index.htm;
        root /var/www/;
    }

    gzip on;
    gzip_min_length 1k;
    gzip_comp_level 2;
    gzip_types text/plain application/javascript application/x-javascript text/css application/xml text/javascript application/x-httpd-php image/jpeg image/gif image/png;
    gzip_vary on;
}
```

**Error log:**

```log
2022/02/28 13:07:34 [error] 22#22: *1 upstream sent invalid http2 table index: 67 while reading response header from upstream, client: 172.23.0.1, server: , request: "POST /grpc.GrpcService/login HTTP/2.0", upstream: "grpc://192.168.65.2:13009", host: "localhost:8890"
2022/02/28 13:07:34 [error] 22#22: *1 upstream sent invalid header while reading response header from upstream, client: 172.23.0.1, server: , request: "POST /grpc.GrpcService/login HTTP/2.0", upstream: "grpc://192.168.65.2:13009", host: "localhost:8890"
```

**Reference:**
<https://trac.nginx.org/nginx/ticket/1538>
<https://github.com/grpc/grpc-go/pull/2045>