### PR TITLE
Fix build failure on systems without clock_gettime

### DIFF
--- a/src/core/timer.cc
+++ b/src/core/timer.cc
@@ -243,8 +243,8 @@ int Timer::select() {
     return SW_OK;
 }
 
-#if defined(SW_USE_MONOTONIC_TIME) && defined(CLOCK_MONOTONIC)
 int Timer::now(struct timeval *time) {
+#if defined(SW_USE_MONOTONIC_TIME) && defined(CLOCK_MONOTONIC)
     struct timespec _now;
     if (clock_gettime(CLOCK_MONOTONIC, &_now) < 0) {
         swoole_sys_warning("clock_gettime(CLOCK_MONOTONIC) failed");
@@ -253,12 +253,12 @@ int Timer::now(struct timeval *time) {
     time->tv_sec = _now.tv_sec;
     time->tv_usec = _now.tv_nsec / 1000;
 #else
-if (gettimeofday(time, nullptr) < 0) {
-    swoole_sys_warning("gettimeofday() failed");
-    return SW_ERR;
-}
+    if (gettimeofday(time, nullptr) < 0) {
+        swoole_sys_warning("gettimeofday() failed");
+        return SW_ERR;
+    }
 #endif
     return SW_OK;
-}  // namespace swoole
+}
 
 };  // namespace swoole


### PR DESCRIPTION
Building swoole 4.8.7 on OS X 10.11.6 and earlier fails:

```
src/core/timer.cc:256:1: error: expected unqualified-id
if (gettimeofday(time, nullptr) < 0) {
^
src/core/timer.cc:261:5: error: expected unqualified-id
    return SW_OK;
    ^
src/core/timer.cc:264:1: error: extraneous closing brace ('}')
};  // namespace swoole
^
```

This PR fixes it.

The `#if` was mistakenly placed before the function signature rather than after when this code was refactored in d6add5e. As a result, a subsequent clang format misformatted the code in 3aa03bb.

Closes #3896