### PR TITLE
Fix postgresql_coroutine metaData method

### DIFF
--- a/ext-src/swoole_postgresql_coro.cc
+++ b/ext-src/swoole_postgresql_coro.cc
@@ -436,10 +436,11 @@ static int meta_data_result_parse(PGObject *object) {
     }
 
     array_init(object->return_value);
-    array_init(&elem);
+
     for (i = 0; i < num_rows; i++) {
         object->result = pg_result;
         char *name;
+        array_init(&elem);
         /* pg_attribute.attnum */
         add_assoc_long_ex(&elem, "num", sizeof("num") - 1, atoi(PQgetvalue(pg_result, i, 1)));
         /* pg_type.typname */


### PR DESCRIPTION
Fix the result of postgresql coroutine metaData method is  different to pg_meta_data's.