### PR TITLE
enables explictly shadow stack and indirect branch tracking on intel

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -324,6 +324,24 @@ AC_DEFUN([AC_SWOOLE_CHECK_SOCKETS], [
     if test "$ac_cv_gethostbyname2_r" = yes; then
         AC_DEFINE(HAVE_GETHOSTBYNAME2_R,1,[Whether you have gethostbyname2_r])
     fi
+
+    AC_CACHE_CHECK([Intel/AMD CET support],[ac_cv_intel_amd_cet],
+    [
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],
+	[[
+		#ifdef __CET__
+		return 0;
+		#else
+		return 1;
+		#endif
+	]])],
+	    [ac_cv_intel_amd_cet=yes], [ac_cv_intel_amd_cet=no])
+    ])
+
+    if test "$ac_cv_intel_amd_cet" = yes; then
+	CFLAGS="$CFLAGS -Wl,-zibt -Wl,-zshstk"
+    fi
+
 ])
 
 AC_MSG_CHECKING([if compiling with clang])


### PR DESCRIPTION
based cpus (if supported).

w/o changes the NT_GNU_PROPERTY_TYPE_0 elf section does not appear
 on those cpus.

inspired by the  [https://github.com/php/php-src/pull/8339]( https://github.com/php/php-src/pull/8339) proposition.