### PR TITLE
Fix server port type

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -976,7 +976,15 @@ static zval *php_swoole_server_add_port(ServerObject *server_object, ListenPort 
 
     zend_update_property_string(swoole_server_port_ce, SW_Z8_OBJ_P(zport), ZEND_STRL("host"), port->get_host());
     zend_update_property_long(swoole_server_port_ce, SW_Z8_OBJ_P(zport), ZEND_STRL("port"), port->get_port());
+#ifdef SW_USE_OPENSSL
+    long type = (long) port->get_type();
+    if (port->ssl) {
+        type |= SW_SOCK_SSL;
+    }
+    zend_update_property_long(swoole_server_port_ce, SW_Z8_OBJ_P(zport), ZEND_STRL("type"), type);
+#else
     zend_update_property_long(swoole_server_port_ce, SW_Z8_OBJ_P(zport), ZEND_STRL("type"), port->get_type());
+#endif
     zend_update_property_long(swoole_server_port_ce, SW_Z8_OBJ_P(zport), ZEND_STRL("sock"), port->get_fd());
 
     do {

--- a/tests/swoole_server/addListener_type.phpt
+++ b/tests/swoole_server/addListener_type.phpt
@@ -1,0 +1,16 @@
+--TEST--
+swoole_server: addlistener type
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server(TCP_SERVER_HOST, get_one_free_port());
+$port = $server->addListener(TCP_SERVER_HOST, get_one_free_port(), SWOOLE_SOCK_TCP | SWOOLE_SSL);
+
+Assert::assert((SWOOLE_SOCK_TCP | SWOOLE_SSL) === $port->type);
+?>
+--EXPECT--


### PR DESCRIPTION
修复 `$server->addListener()->type` 的值，不包含 `SWOOLE_SSL`

`$server->type` 是可以获取到带 `SWOOLE_SSL` 的值的
