### PR TITLE
Fix hook socket in non-coroutine

### DIFF
--- a/core-tests/src/coroutine/hook.cpp
+++ b/core-tests/src/coroutine/hook.cpp
@@ -51,18 +51,20 @@ TEST(coroutine_hook, file) {
 }
 
 TEST(coroutine_hook, gethostbyname) {
-    coroutine::run([](void *arg) {
+    auto callback = [](void *arg) {
         auto result1 = swoole_coroutine_gethostbyname(host_1);
         ASSERT_NE(result1, nullptr);
 
         auto result2 = swoole_coroutine_gethostbyname(host_2);
         ASSERT_EQ(result2, nullptr);
         ASSERT_EQ(h_errno, HOST_NOT_FOUND);
-    });
+    };
+    coroutine::run(callback);
+    callback(nullptr);
 }
 
 TEST(coroutine_hook, getaddrinfo) {
-    coroutine::run([](void *arg) {
+    auto callback = [](void *arg) {
         struct addrinfo hints;
         sw_memset_zero(&hints, sizeof(struct addrinfo));
         hints.ai_family = AF_INET;
@@ -90,7 +92,9 @@ TEST(coroutine_hook, getaddrinfo) {
         ASSERT_EQ(result2, EAI_NONAME);
         ASSERT_EQ(result, nullptr);
         freeaddrinfo(result);
-    });
+    };
+    coroutine::run(callback);
+    callback(nullptr);
 }
 
 TEST(coroutine_hook, fstat) {

--- a/src/coroutine/hook.cc
+++ b/src/coroutine/hook.cc
@@ -515,12 +515,20 @@ int swoole_coroutine_getaddrinfo(const char *name,
                                  const char *service,
                                  const struct addrinfo *req,
                                  struct addrinfo **pai) {
+    if (sw_unlikely(is_no_coro())) {
+        return getaddrinfo(name, service, req, pai);
+    }
+
     int retval = -1;
     async([&]() { retval = getaddrinfo(name, service, req, pai); });
     return retval;
 }
 
 struct hostent *swoole_coroutine_gethostbyname(const char *name) {
+    if (sw_unlikely(is_no_coro())) {
+        return gethostbyname(name);
+    }
+
     struct hostent *retval = nullptr;
     int _tmp_h_errno;
     async([&]() {


### PR DESCRIPTION
Other functions that are hooked are compatible in the non-coroutine

<https://github.com/swoole/swoole-src/blob/3965e3a0640c693d70233142120a4e0cc387385a/include/swoole_socket_hook.h>