### PR TITLE
add config arg --enable-brotli

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -61,6 +61,11 @@ PHP_ARG_WITH([openssl_dir],
   [AS_HELP_STRING([[--with-openssl-dir[=DIR]]],
     [Include OpenSSL support (requires OpenSSL >= 1.0.2)])], [no], [no])
 
+PHP_ARG_WITH([brotli_dir],
+  [dir of brotli],
+  [AS_HELP_STRING([[--with-brotli-dir[=DIR]]],
+    [Include Brotli support])], [no], [no])
+
 PHP_ARG_WITH([jemalloc_dir],
   [dir of jemalloc],
   [AS_HELP_STRING([[--with-jemalloc-dir[=DIR]]],

--- a/config.m4
+++ b/config.m4
@@ -39,7 +39,7 @@ PHP_ARG_ENABLE([openssl],
 PHP_ARG_ENABLE([brotli],
   [enable brotli support],
   [AS_HELP_STRING([[--enable-brotli]],
-    [Use openssl])], [no], [no])
+    [Use brotli])], [yes], [no])
 
 PHP_ARG_ENABLE([http2],
   [enable http2.0 support],
@@ -418,6 +418,17 @@ if test "$PHP_SWOOLE" != "no"; then
         AC_DEFINE(SW_HAVE_ZLIB, 1, [have zlib])
         PHP_ADD_LIBRARY(z, 1, SWOOLE_SHARED_LIBADD)
     ])
+    
+    if test "$PHP_BROTLI" = "yes"; then
+        AC_CHECK_LIB(brotlienc, BrotliEncoderCreateInstance, [
+            AC_CHECK_LIB(brotlidec, BrotliDecoderCreateInstance, [
+                AC_DEFINE(SW_HAVE_COMPRESSION, 1, [have compression])
+                AC_DEFINE(SW_HAVE_BROTLI, 1, [have brotli encoder])
+                PHP_ADD_LIBRARY(brotlienc, 1, SWOOLE_SHARED_LIBADD)
+                PHP_ADD_LIBRARY(brotlidec, 1, SWOOLE_SHARED_LIBADD)
+            ])
+        ])
+    fi
 
     PHP_ADD_LIBRARY(pthread)
     PHP_SUBST(SWOOLE_SHARED_LIBADD)
@@ -507,16 +518,11 @@ if test "$PHP_SWOOLE" != "no"; then
         PHP_ADD_LIBRARY(crypto, 1, SWOOLE_SHARED_LIBADD)
     fi
 
-    if test "$PHP_BROTLI" != "no" || test "$PHP_BROTLI_DIR" != "no"; then
-        if test "$PHP_BROTLI_DIR" != "no"; then
-            PHP_ADD_INCLUDE("${PHP_BROTLI_DIR}/include")
-            PHP_ADD_LIBRARY_WITH_PATH(brotlienc, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
-            PHP_ADD_LIBRARY_WITH_PATH(brotlidec, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
-        fi
+    if test "$PHP_BROTLI_DIR" != "no"; then
         AC_DEFINE(SW_HAVE_COMPRESSION, 1, [have compression])
         AC_DEFINE(SW_HAVE_BROTLI, 1, [have brotli encoder])
-        PHP_ADD_LIBRARY(brotlienc, 1, SWOOLE_SHARED_LIBADD)
-        PHP_ADD_LIBRARY(brotlidec, 1, SWOOLE_SHARED_LIBADD)
+        PHP_ADD_LIBRARY_WITH_PATH(brotlienc, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
+        PHP_ADD_LIBRARY_WITH_PATH(brotlidec, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
     fi
 
     if test "$PHP_JEMALLOC_DIR" != "no"; then

--- a/config.m4
+++ b/config.m4
@@ -510,6 +510,12 @@ if test "$PHP_SWOOLE" != "no"; then
         PHP_ADD_LIBRARY(ssl, 1, SWOOLE_SHARED_LIBADD)
         PHP_ADD_LIBRARY(crypto, 1, SWOOLE_SHARED_LIBADD)
     fi
+    
+    if test "$PHP_BROTLI_DIR" != "no"; then
+        AC_DEFINE(SW_HAVE_BROTLI, 1, [have brotli encoder])
+        PHP_ADD_INCLUDE("${PHP_BROTLI_DIR}/include")
+        PHP_ADD_LIBRARY_WITH_PATH(brotli, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
+    fi
 
     if test "$PHP_JEMALLOC_DIR" != "no"; then
         AC_DEFINE(SW_USE_JEMALLOC, 1, [use jemalloc])

--- a/config.m4
+++ b/config.m4
@@ -36,6 +36,11 @@ PHP_ARG_ENABLE([openssl],
   [AS_HELP_STRING([--enable-openssl],
     [Use openssl])], [no], [no])
 
+PHP_ARG_ENABLE([brotli],
+  [enable brotli support],
+  [AS_HELP_STRING([[--enable-brotli]],
+    [Use openssl])], [no], [no])
+
 PHP_ARG_ENABLE([http2],
   [enable http2.0 support],
   [AS_HELP_STRING([--enable-http2],
@@ -414,15 +419,6 @@ if test "$PHP_SWOOLE" != "no"; then
         PHP_ADD_LIBRARY(z, 1, SWOOLE_SHARED_LIBADD)
     ])
 
-    AC_CHECK_LIB(brotlienc, BrotliEncoderCreateInstance, [
-        AC_CHECK_LIB(brotlidec, BrotliDecoderCreateInstance, [
-            AC_DEFINE(SW_HAVE_COMPRESSION, 1, [have compression])
-            AC_DEFINE(SW_HAVE_BROTLI, 1, [have brotli encoder])
-            PHP_ADD_LIBRARY(brotlienc, 1, SWOOLE_SHARED_LIBADD)
-            PHP_ADD_LIBRARY(brotlidec, 1, SWOOLE_SHARED_LIBADD)
-        ])
-    ])
-
     PHP_ADD_LIBRARY(pthread)
     PHP_SUBST(SWOOLE_SHARED_LIBADD)
 
@@ -510,11 +506,17 @@ if test "$PHP_SWOOLE" != "no"; then
         PHP_ADD_LIBRARY(ssl, 1, SWOOLE_SHARED_LIBADD)
         PHP_ADD_LIBRARY(crypto, 1, SWOOLE_SHARED_LIBADD)
     fi
-    
-    if test "$PHP_BROTLI_DIR" != "no"; then
+
+    if test "$PHP_BROTLI" != "no" || test "$PHP_BROTLI_DIR" != "no"; then
+        if test "$PHP_BROTLI_DIR" != "no"; then
+            PHP_ADD_INCLUDE("${PHP_BROTLI_DIR}/include")
+            PHP_ADD_LIBRARY_WITH_PATH(brotlienc, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
+            PHP_ADD_LIBRARY_WITH_PATH(brotlidec, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
+        fi
+        AC_DEFINE(SW_HAVE_COMPRESSION, 1, [have compression])
         AC_DEFINE(SW_HAVE_BROTLI, 1, [have brotli encoder])
-        PHP_ADD_INCLUDE("${PHP_BROTLI_DIR}/include")
-        PHP_ADD_LIBRARY_WITH_PATH(brotli, "${PHP_BROTLI_DIR}/${PHP_LIBDIR}")
+        PHP_ADD_LIBRARY(brotlienc, 1, SWOOLE_SHARED_LIBADD)
+        PHP_ADD_LIBRARY(brotlidec, 1, SWOOLE_SHARED_LIBADD)
     fi
 
     if test "$PHP_JEMALLOC_DIR" != "no"; then


### PR DESCRIPTION
默认不自动检查并添加 brotli 支持，修复 [swoole-cli](https://github.com/swoole/swoole-cli) 在 macOS 下编译时存在动态链接的问题

在 macOS下 编译 [swoole-cli](https://github.com/swoole/swoole-cli) 时，如果系统内包含 brotli，例如 brew 安装 php 时会默认安装此依赖，导致被 AC_CHECK_LIB 检查到并加入 LD 链接，编译的结果无法完全静态依赖

<img width="439" alt="image" src="https://user-images.githubusercontent.com/24957558/193066566-26596426-fa2b-41b0-a7ac-383affee5aba.png">

https://github.com/swoole/swoole-cli/blob/main/macOS.md 中提到的解决方案是先 `brew uninstall --ignore-dependencies brotli` 之后再安装，但在过程中会导致 brew 安装的 php 无法使用

所以就不让他自动链接吧，这样即使系统里存在也不会被动态链接了

<img width="503" alt="image" src="https://user-images.githubusercontent.com/24957558/193067523-05023940-acca-4a61-9cc8-3c3fffbfcc89.png">
