### PR TITLE
fix: 协程环境下会打断php代码try..catch捕获E_ERROR

### DIFF
--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -380,7 +380,7 @@ zend_bool php_swoole_signal_isset_handler(int signo);
 #endif
 
 #ifndef E_FATAL_ERRORS
-#define E_FATAL_ERRORS (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE)
+#define E_FATAL_ERRORS (E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE)
 #endif
 /*}}}*/
 


### PR DESCRIPTION
swoole 协程环境下，PHP发生异常后，swoole接管可能会打断PHP代码的执行流程导致`try..catch`没有得到执行。
E_ERROR在PHP代码层面可以通过`try..catch`捕获得到，E_FATAL_ERRORS去掉`E_ERROR`是不是合理，经过测试去掉可以解决问题。见issue#4863