### PR TITLE
Make 'src/lock' more robust

### DIFF
--- a/include/swoole_lock.h
+++ b/include/swoole_lock.h
@@ -58,6 +58,7 @@ struct MutexImpl;
 
 class Mutex : public Lock {
     MutexImpl *impl;
+    int flags_;
 
   public:
     enum Flag {

--- a/src/lock/mutex.cc
+++ b/src/lock/mutex.cc
@@ -55,7 +55,7 @@ Mutex::Mutex(int flags) : Lock() {
 #endif
     }
 
-    if (pthread_mutex_init(&impl->lock_, &impl->attr_) < 0) {
+    if (pthread_mutex_init(&impl->lock_, &impl->attr_) != 0) {
         throw std::system_error(errno, std::generic_category(), "pthread_mutex_init() failed");
     }
 }

--- a/src/lock/mutex.cc
+++ b/src/lock/mutex.cc
@@ -25,6 +25,8 @@ struct MutexImpl {
 };
 
 Mutex::Mutex(int flags) : Lock() {
+    flags_ = flags;
+
     if (flags & PROCESS_SHARED) {
         impl = (MutexImpl *) sw_mem_pool()->alloc(sizeof(*impl));
         if (impl == nullptr) {
@@ -62,11 +64,13 @@ Mutex::Mutex(int flags) : Lock() {
 
 int Mutex::lock() {
     int retval = pthread_mutex_lock(&impl->lock_);
+
 #ifdef HAVE_PTHREAD_MUTEX_CONSISTENT
-    if (retval == EOWNERDEAD) {
+    if (retval == EOWNERDEAD && (flags_ & ROBUST)) {
         retval = pthread_mutex_consistent(&impl->lock_);
     }
 #endif
+
     return retval;
 }
 

--- a/src/lock/rw_lock.cc
+++ b/src/lock/rw_lock.cc
@@ -69,6 +69,7 @@ int RWLock::trylock() {
 }
 
 RWLock::~RWLock() {
+    pthread_rwlockattr_destroy(&impl->attr);
     pthread_rwlock_destroy(&impl->_lock);
     if (shared_) {
         sw_mem_pool()->free(impl);

--- a/src/lock/rw_lock.cc
+++ b/src/lock/rw_lock.cc
@@ -43,7 +43,7 @@ RWLock::RWLock(int use_in_process) : Lock() {
     if (use_in_process == 1) {
         pthread_rwlockattr_setpshared(&impl->attr, PTHREAD_PROCESS_SHARED);
     }
-    if (pthread_rwlock_init(&impl->_lock, &impl->attr) < 0) {
+    if (pthread_rwlock_init(&impl->_lock, &impl->attr) != 0) {
         throw std::system_error(errno, std::generic_category(), "pthread_rwlock_init() failed");
     }
 }

--- a/src/lock/spin_lock.cc
+++ b/src/lock/spin_lock.cc
@@ -34,7 +34,7 @@ SpinLock::SpinLock(int use_in_process) : Lock() {
     }
 
     type_ = SPIN_LOCK;
-    if (pthread_spin_init(impl, use_in_process) < 0) {
+    if (pthread_spin_init(impl, use_in_process) != 0) {
         throw std::system_error(errno, std::generic_category(), "pthread_spin_init() failed");
     }
 }


### PR DESCRIPTION
1. Fix using wrong way to confirm the failure return value of function `pthread_xxxlock_init()`
    > For the return value of `pthread_xxxlock_init()`:
        The only success return value is zero.
        All the failure return value is non-negative (on linux).
2. Add forgotten `pthread_rwlockattr_destroy()`
3. Robust or not is set in constructor
    > `pthread_mutex_consistent()` will return [EINVAL] when the mutex object referenced by mutex is not robust.
    > I think `Mutex::lock()` was not designed like this and [EOWNERDEAD] should not be overrided by accident if robust is not set.