### PR TITLE
[4.8] Mark parameters as sensitive (PHP 8.2)

### DIFF
--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -1728,6 +1728,9 @@ void php_swoole_http_client_coro_minit(int module_number) {
                                php_swoole_http_client_coro_free_object,
                                HttpClientObject,
                                std);
+#if PHP_VERSION_ID >= 80200
+	zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(&swoole_http_client_coro_ce->function_table, SW_STRL("setBasicAuth")), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
 
     // client status
     zend_declare_property_long(swoole_http_client_coro_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -1697,6 +1697,9 @@ void php_swoole_mysql_coro_minit(int module_number) {
     SW_SET_CLASS_UNSET_PROPERTY_HANDLER(swoole_mysql_coro, sw_zend_class_unset_property_deny);
     SW_SET_CLASS_CUSTOM_OBJECT(
         swoole_mysql_coro, php_swoole_mysql_coro_create_object, php_swoole_mysql_coro_free_object, mysql_coro_t, std);
+#if PHP_VERSION_ID >= 80200
+	zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(&swoole_mysql_coro_ce->function_table, SW_STRL("connect")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
 
     SW_INIT_CLASS_ENTRY(swoole_mysql_coro_statement,
                         "Swoole\\Coroutine\\MySQL\\Statement",

--- a/ext-src/swoole_redis_coro.cc
+++ b/ext-src/swoole_redis_coro.cc
@@ -2110,6 +2110,9 @@ void php_swoole_redis_coro_minit(int module_number) {
     SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(swoole_redis_coro);
     SW_SET_CLASS_CUSTOM_OBJECT(
         swoole_redis_coro, php_swoole_redis_coro_create_object, php_swoole_redis_coro_free_object, RedisClient, std);
+#if PHP_VERSION_ID >= 80200
+	zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(&swoole_redis_coro_ce->function_table, SW_STRL("auth")), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
 
     zend_declare_property_string(swoole_redis_coro_ce, ZEND_STRL("host"), "", ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_redis_coro_ce, ZEND_STRL("port"), 0, ZEND_ACC_PUBLIC);

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -29,6 +29,9 @@
 #include "zend_interfaces.h"
 #include "zend_closures.h"
 #include "zend_exceptions.h"
+#if PHP_VERSION_ID >= 80200
+#include "zend_attributes.h"
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
https://wiki.php.net/rfc/redact_parameters_in_back_traces