### PR TITLE
Refactor client, enhanced memory security

### DIFF
--- a/ext-src/php_swoole_cxx.cc
+++ b/ext-src/php_swoole_cxx.cc
@@ -50,10 +50,10 @@ bool call(zend_fcall_info_cache *fci_cache, uint32_t argc, zval *argv, zval *ret
     return success;
 }
 
-ReturnValue call(const std::string &func_name, int argc, zval *argv) {
+Variable call(const std::string &func_name, int argc, zval *argv) {
     zval function_name;
     ZVAL_STRINGL(&function_name, func_name.c_str(), func_name.length());
-    ReturnValue retval;
+    Variable retval;
     if (call_user_function(EG(function_table), NULL, &function_name, &retval.value, argc, argv) != SUCCESS) {
         ZVAL_NULL(&retval.value);
     }

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -91,8 +91,14 @@ extern zend_string **sw_zend_known_strings;
 #define SW_CLIENT_GET_SOCKET_SAFE(__sock, __zsocket)                                                                   \
     Socket *__sock = nullptr;                                                                                          \
     zend::Variable tmp_socket;                                                                                         \
-    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                     \
+    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                    \
         __sock = php_swoole_get_socket(__zsocket);                                                                     \
+        tmp_socket.assign(__zsocket);                                                                                  \
+    }
+
+#define SW_CLIENT_PRESERVE_SOCKET(__zsocket)                                                                           \
+    zend::Variable tmp_socket;                                                                                         \
+    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                    \
         tmp_socket.assign(__zsocket);                                                                                  \
     }
 

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -91,14 +91,14 @@ extern zend_string **sw_zend_known_strings;
 #define SW_CLIENT_GET_SOCKET_SAFE(__sock, __zsocket)                                                                   \
     Socket *__sock = nullptr;                                                                                          \
     zend::Variable tmp_socket;                                                                                         \
-    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                    \
+    if (ZVAL_IS_OBJECT(__zsocket)) {                                                                                   \
         __sock = php_swoole_get_socket(__zsocket);                                                                     \
         tmp_socket.assign(__zsocket);                                                                                  \
     }
 
 #define SW_CLIENT_PRESERVE_SOCKET(__zsocket)                                                                           \
     zend::Variable tmp_socket;                                                                                         \
-    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                    \
+    if (ZVAL_IS_OBJECT(__zsocket)) {                                                                                   \
         tmp_socket.assign(__zsocket);                                                                                  \
     }
 

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -84,6 +84,18 @@ extern zend_string **sw_zend_known_strings;
 #define SW_SET_CLASS_CREATE_WITH_ITS_OWN_HANDLERS(module)                                                              \
     module##_ce->create_object = [](zend_class_entry *ce) { return sw_zend_create_object(ce, &module##_handlers); }
 
+/**
+ * It is safe across coroutines,
+ * add reference count, prevent the socket pointer being released
+ */
+#define SW_CLIENT_GET_SOCKET_SAFE(__sock, __zsocket)                                                                   \
+    Socket *__sock = nullptr;                                                                                          \
+    zend::Variable tmp_socket;                                                                                         \
+    if (!ZVAL_IS_NULL(__zsocket)) {                                                                                     \
+        __sock = php_swoole_get_socket(__zsocket);                                                                     \
+        tmp_socket.assign(__zsocket);                                                                                  \
+    }
+
 SW_API bool php_swoole_is_enable_coroutine();
 SW_API zend_object *php_swoole_create_socket(enum swSocketType type);
 SW_API zend_object *php_swoole_create_socket_from_fd(int fd, enum swSocketType type);
@@ -97,6 +109,7 @@ SW_API bool php_swoole_socket_set_ssl(swoole::coroutine::Socket *sock, zval *zse
 #endif
 SW_API bool php_swoole_socket_set_protocol(swoole::coroutine::Socket *sock, zval *zset);
 SW_API bool php_swoole_socket_set(swoole::coroutine::Socket *cli, zval *zset);
+SW_API void php_swoole_socket_set_error_properties(zval *zobject, int code);
 SW_API void php_swoole_socket_set_error_properties(zval *zobject, int code, const char *msg);
 SW_API void php_swoole_socket_set_error_properties(zval *zobject, swoole::coroutine::Socket *socket);
 #define php_swoole_client_set php_swoole_socket_set
@@ -398,22 +411,31 @@ class Process {
     }
 };
 
-namespace function {
-/* must use this API to call event callbacks to ensure that exceptions are handled correctly */
-bool call(zend_fcall_info_cache *fci_cache, uint32_t argc, zval *argv, zval *retval, const bool enable_coroutine);
-
-class ReturnValue {
+class Variable {
   public:
     zval value;
-    ReturnValue() {
+    Variable() {
         value = {};
     }
-    ~ReturnValue() {
-        zval_dtor(&value);
+    Variable(zval *zvalue) {
+        assign(zvalue);
+    }
+    void operator=(zval *zvalue) {
+        assign(zvalue);
+    }
+    void assign(zval *zvalue) {
+        value = *zvalue;
+        zval_add_ref(zvalue);
+    }
+    ~Variable() {
+        zval_ptr_dtor(&value);
     }
 };
 
-ReturnValue call(const std::string &func_name, int argc, zval *argv);
+namespace function {
+/* must use this API to call event callbacks to ensure that exceptions are handled correctly */
+bool call(zend_fcall_info_cache *fci_cache, uint32_t argc, zval *argv, zval *retval, const bool enable_coroutine);
+Variable call(const std::string &func_name, int argc, zval *argv);
 }  // namespace function
 
 struct Function {

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -345,6 +345,12 @@ static sw_inline zend_bool ZVAL_IS_TRUE(zval *v) {
 }
 #endif
 
+#ifndef ZVAL_IS_UNDEF
+static sw_inline zend_bool ZVAL_IS_UNDEF(zval *v) {
+    return Z_TYPE_P(v) == IS_UNDEF;
+}
+#endif
+
 #ifndef ZVAL_IS_FALSE
 static sw_inline zend_bool ZVAL_IS_FALSE(zval *v) {
     return Z_TYPE_P(v) == IS_FALSE;

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -92,14 +92,6 @@ static const zend_function_entry swoole_client_coro_methods[] =
 };
 // clang-format on
 
-#define CLIENT_CORO_GET_SOCKET_SAFE(__sock)                                                                            \
-    SW_CLIENT_GET_SOCKET_SAFE(__sock, ZEND_THIS);                                                                      \
-    if (!__sock) {                                                                                                     \
-        php_swoole_socket_set_error_properties(                                                                        \
-            ZEND_THIS, SW_ERROR_CLIENT_NO_CONNECTION, swoole_strerror(SW_ERROR_CLIENT_NO_CONNECTION));                 \
-        RETURN_FALSE;                                                                                                  \
-    }
-
 static sw_inline ClientCoroObject *client_coro_fetch_object(zend_object *obj) {
     return (ClientCoroObject *) ((char *) obj - swoole_client_coro_handlers.offset);
 }
@@ -119,6 +111,14 @@ static void client_coro_free_object(zend_object *object) {
     }
     zend_object_std_dtor(&client->std);
 }
+
+#define CLIENT_CORO_GET_SOCKET_SAFE(__sock)                                                                            \
+    SW_CLIENT_GET_SOCKET_SAFE(__sock, &client_coro_get_client(ZEND_THIS)->zsocket);                                                                      \
+    if (!__sock) {                                                                                                     \
+        php_swoole_socket_set_error_properties(                                                                        \
+            ZEND_THIS, SW_ERROR_CLIENT_NO_CONNECTION, swoole_strerror(SW_ERROR_CLIENT_NO_CONNECTION));                 \
+        RETURN_FALSE;                                                                                                  \
+    }
 
 static zend_object *client_coro_create_object(zend_class_entry *ce) {
     ClientCoroObject *object = (ClientCoroObject *) zend_object_alloc(sizeof(ClientCoroObject), ce);

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -36,7 +36,7 @@ static zend_object_handlers swoole_client_coro_handlers;
 
 struct ClientCoroObject {
     Socket *socket;
-    zval socket_object;
+    zval zsocket;
     /* safety zval */
     zval zobject;
     zend_object std;
@@ -92,15 +92,13 @@ static const zend_function_entry swoole_client_coro_methods[] =
 };
 // clang-format on
 
-#define CLIENT_CORO_GET_SOCKET(__sock)                                                                                 \
-    zval tmp_socket;                                                                                                   \
-    Socket *__sock = client_coro_get_socket_check_liveness(ZEND_THIS, &tmp_socket);                                    \
+#define CLIENT_CORO_GET_SOCKET_SAFE(__sock)                                                                            \
+    SW_CLIENT_GET_SOCKET_SAFE(__sock, ZEND_THIS);                                                                      \
     if (!__sock) {                                                                                                     \
+        php_swoole_socket_set_error_properties(                                                                        \
+            ZEND_THIS, SW_ERROR_CLIENT_NO_CONNECTION, swoole_strerror(SW_ERROR_CLIENT_NO_CONNECTION));                 \
         RETURN_FALSE;                                                                                                  \
-    }                                                                                                                  \
-    ON_SCOPE_EXIT {                                                                                                    \
-        zval_ptr_dtor(&tmp_socket);                                                                                    \
-    };
+    }
 
 static sw_inline ClientCoroObject *client_coro_fetch_object(zend_object *obj) {
     return (ClientCoroObject *) ((char *) obj - swoole_client_coro_handlers.offset);
@@ -123,12 +121,13 @@ static void client_coro_free_object(zend_object *object) {
 }
 
 static zend_object *client_coro_create_object(zend_class_entry *ce) {
-    ClientCoroObject *sock = (ClientCoroObject *) zend_object_alloc(sizeof(ClientCoroObject), ce);
-    zend_object_std_init(&sock->std, ce);
-    object_properties_init(&sock->std, ce);
-    sock->std.handlers = &swoole_client_coro_handlers;
-    ZVAL_OBJ(&sock->zobject, &sock->std);
-    return &sock->std;
+    ClientCoroObject *object = (ClientCoroObject *) zend_object_alloc(sizeof(ClientCoroObject), ce);
+    zend_object_std_init(&object->std, ce);
+    object_properties_init(&object->std, ce);
+    object->std.handlers = &swoole_client_coro_handlers;
+    ZVAL_OBJ(&object->zobject, &object->std);
+    ZVAL_NULL(&object->zsocket);
+    return &object->std;
 }
 
 static void client_coro_socket_dtor(ClientCoroObject *client) {
@@ -140,35 +139,39 @@ static void client_coro_socket_dtor(ClientCoroObject *client) {
     client->socket = nullptr;
     zend_update_property_null(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("socket"));
     zend_update_property_bool(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("connected"), 0);
-    zval_ptr_dtor(&client->socket_object);
+    zval_ptr_dtor(&client->zsocket);
+    ZVAL_NULL(&client->zsocket);
 }
 
-static bool client_coro_create_socket(zval *zobject, zend_long type) {
+static Socket *client_coro_create_socket(zval *zobject, zend_long type) {
     enum swSocketType socket_type = (enum swSocketType) php_swoole_get_socket_type(type);
     auto object = php_swoole_create_socket(socket_type);
     if (UNEXPECTED(!object)) {
         php_swoole_socket_set_error_properties(zobject, errno, strerror(errno));
-        return false;
+        return nullptr;
     }
     auto client = client_coro_get_client(zobject);
-    ZVAL_OBJ(&client->socket_object, object);
-    client->socket = php_swoole_get_socket(&client->socket_object);
+    ZVAL_OBJ(&client->zsocket, object);
+    auto *socket = php_swoole_get_socket(&client->zsocket);
 
-    client->socket->set_dtor([client](Socket *_socket) { client_coro_socket_dtor(client); });
+    socket->set_dtor([client](Socket *_socket) { client_coro_socket_dtor(client); });
 
-    zend_update_property_long(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("fd"), client->socket->get_fd());
-    zend_update_property(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("socket"), &client->socket_object);
+    zend_update_property_long(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("fd"), socket->get_fd());
+    zend_update_property(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("socket"), &client->zsocket);
 
-    client->socket->set_buffer_allocator(sw_zend_string_allocator());
-    client->socket->set_zero_copy(true);
+    socket->set_buffer_allocator(sw_zend_string_allocator());
+    socket->set_zero_copy(true);
 
 #ifdef SW_USE_OPENSSL
     if (type & SW_SOCK_SSL) {
-        client->socket->enable_ssl_encrypt();
+        if (!socket->enable_ssl_encrypt()) {
+            client_coro_socket_dtor(client);
+            return nullptr;
+        }
     }
 #endif
 
-    return true;
+    return socket;
 }
 
 void php_swoole_client_coro_minit(int module_number) {
@@ -193,19 +196,6 @@ void php_swoole_client_coro_minit(int module_number) {
     zend_declare_class_constant_long(swoole_client_coro_ce, ZEND_STRL("MSG_WAITALL"), MSG_WAITALL);
 }
 
-static sw_inline Socket *client_coro_get_socket_check_liveness(zval *zobject, zval *tmp_socket) {
-    auto client = client_coro_get_client(zobject);
-    if (client->socket) {
-        *tmp_socket = client->socket_object;
-        zval_add_ref(tmp_socket);
-        return php_swoole_get_socket(tmp_socket);
-    } else {
-        php_swoole_socket_set_error_properties(
-            zobject, SW_ERROR_CLIENT_NO_CONNECTION, swoole_strerror(SW_ERROR_CLIENT_NO_CONNECTION));
-        return nullptr;
-    }
-}
-
 static sw_inline Socket *client_coro_get_socket_for_connect(zval *zobject, int port) {
     auto client = client_coro_get_client(zobject);
     if (client->socket) {
@@ -220,24 +210,19 @@ static sw_inline Socket *client_coro_get_socket_for_connect(zval *zobject, int p
         return nullptr;
     }
 
-    if (!client_coro_create_socket(zobject, zval_get_long(ztype))) {
+    auto sock = client_coro_create_socket(zobject, zval_get_long(ztype));
+    if (!sock) {
         return nullptr;
     }
-
+    client->socket = sock;
     zval *zset = sw_zend_read_property_ex(swoole_client_coro_ce, zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
     if (zset && ZVAL_IS_ARRAY(zset)) {
-        php_swoole_socket_set(client->socket, zset);
+        php_swoole_socket_set(sock, zset);
     }
-
-    return client->socket;
+    return sock;
 }
 
 static PHP_METHOD(swoole_client_coro, __construct) {
-    if (client_coro_get_client(ZEND_THIS)->socket) {
-        zend_throw_error(NULL, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zend_long type = 0;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
@@ -333,7 +318,7 @@ static PHP_METHOD(swoole_client_coro, send) {
         RETURN_FALSE;
     }
 
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     Socket::TimeoutSetter ts(cli, timeout, Socket::TIMEOUT_WRITE);
     ssize_t ret = cli->send_all(data, data_len);
@@ -447,7 +432,7 @@ static PHP_METHOD(swoole_client_coro, sendfile) {
         RETURN_FALSE;
     }
 
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     // only stream socket can sendfile
     if (!(cli->get_type() == SW_SOCK_TCP || cli->get_type() == SW_SOCK_TCP6 ||
@@ -473,7 +458,7 @@ static PHP_METHOD(swoole_client_coro, recv) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     ssize_t retval;
     zend_string *result = nullptr;
@@ -519,7 +504,7 @@ static PHP_METHOD(swoole_client_coro, peek) {
     Z_PARAM_LONG(buf_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     buf = (char *) emalloc(buf_len + 1);
     ret = cli->peek(buf, buf_len);
@@ -544,7 +529,7 @@ static PHP_METHOD(swoole_client_coro, isConnected) {
 }
 
 static PHP_METHOD(swoole_client_coro, getsockname) {
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     Address sa;
     if (!cli->getsockname(&sa)) {
@@ -566,11 +551,11 @@ static PHP_METHOD(swoole_client_coro, getsockname) {
  */
 static PHP_METHOD(swoole_client_coro, exportSocket) {
     auto cli = client_coro_get_client(ZEND_THIS);
-    RETURN_ZVAL(&cli->socket_object, 1, 0);
+    RETURN_ZVAL(&cli->zsocket, 1, 0);
 }
 
 static PHP_METHOD(swoole_client_coro, getpeername) {
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
 
     Address sa;
     if (!cli->getpeername(&sa)) {
@@ -588,18 +573,8 @@ static PHP_METHOD(swoole_client_coro, getpeername) {
 }
 
 static PHP_METHOD(swoole_client_coro, close) {
-    auto client = client_coro_get_client(ZEND_THIS);
-    if (client->socket == nullptr) {
-        php_swoole_socket_set_error_properties(ZEND_THIS, EBADF, strerror(EBADF));
-        RETURN_FALSE;
-    }
+    CLIENT_CORO_GET_SOCKET_SAFE(_socket);
     zend_update_property_bool(Z_OBJCE_P(ZEND_THIS), SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("connected"), 0);
-    zval tmp_socket = client->socket_object;
-    zval_add_ref(&tmp_socket);
-    ON_SCOPE_EXIT {
-        zval_ptr_dtor(&tmp_socket);
-    };
-    Socket *_socket = php_swoole_get_socket(&tmp_socket);
     if (!_socket->close()) {
         php_swoole_socket_set_error_properties(ZEND_THIS, _socket);
         RETURN_FALSE;
@@ -609,29 +584,34 @@ static PHP_METHOD(swoole_client_coro, close) {
 
 #ifdef SW_USE_OPENSSL
 static PHP_METHOD(swoole_client_coro, enableSSL) {
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
     if (cli->get_type() != SW_SOCK_TCP && cli->get_type() != SW_SOCK_TCP6) {
-        php_swoole_fatal_error(E_WARNING, "cannot use enableSSL");
+        php_swoole_socket_set_error_properties(ZEND_THIS, ESOCKTNOSUPPORT);
         RETURN_FALSE;
     }
     if (cli->get_ssl()) {
-        php_swoole_fatal_error(E_WARNING, "SSL has been enabled");
+        php_swoole_socket_set_error_properties(ZEND_THIS, EISCONN);
         RETURN_FALSE;
     }
-
-    cli->enable_ssl_encrypt();
-
+    if (!cli->enable_ssl_encrypt()) {
+        php_swoole_socket_set_error_properties(ZEND_THIS, EISCONN);
+        RETURN_FALSE;
+    }
     zval *zset = sw_zend_read_property_ex(swoole_client_coro_ce, ZEND_THIS, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
     if (php_swoole_array_length_safe(zset) > 0) {
         php_swoole_socket_set_ssl(cli, zset);
     }
-    RETURN_BOOL(cli->ssl_handshake());
+    if (!cli->ssl_handshake()) {
+        php_swoole_socket_set_error_properties(ZEND_THIS, cli);
+        RETURN_FALSE;
+    }
+    RETURN_TRUE;
 }
 
 static PHP_METHOD(swoole_client_coro, getPeerCert) {
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
     if (!cli->get_ssl()) {
-        php_swoole_fatal_error(E_WARNING, "SSL is not ready");
+        php_swoole_socket_set_error_properties(ZEND_THIS, EISCONN);
         RETURN_FALSE;
     }
     if (!cli->get_socket()->ssl_get_peer_certificate(sw_tg_buffer())) {
@@ -641,9 +621,9 @@ static PHP_METHOD(swoole_client_coro, getPeerCert) {
 }
 
 static PHP_METHOD(swoole_client_coro, verifyPeerCert) {
-    CLIENT_CORO_GET_SOCKET(cli);
+    CLIENT_CORO_GET_SOCKET_SAFE(cli);
     if (!cli->get_ssl()) {
-        php_swoole_fatal_error(E_WARNING, "SSL is not ready");
+        php_swoole_socket_set_error_properties(ZEND_THIS, ENOTCONN);
         RETURN_FALSE;
     }
     zend_bool allow_self_signed = 0;

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -61,8 +61,7 @@ static int http_parser_on_body(swoole_http_parser *parser, const char *at, size_
 static int http_parser_on_message_complete(swoole_http_parser *parser);
 
 // clang-format off
-static const swoole_http_parser_settings http_parser_settings =
-{
+static const swoole_http_parser_settings http_parser_settings = {
     nullptr,
     nullptr,
     nullptr,
@@ -268,7 +267,7 @@ class Client {
     NameResolver::Context resolve_context_ = {};
     SocketType socket_type = SW_SOCK_TCP;
     swoole_http_parser parser = {};
-    bool wait = false;
+    bool wait_response = false;
 };
 
 }  // namespace http
@@ -1252,7 +1251,7 @@ bool Client::send_request() {
         if (socket->send_all(header_buf, n) != n) {
             goto _send_fail;
         }
-        wait = true;
+        wait_response = true;
         return true;
     }
     // ============ x-www-form-urlencoded or raw ============
@@ -1306,7 +1305,7 @@ bool Client::send_request() {
         close();
         return false;
     }
-    wait = true;
+    wait_response = true;
     return true;
 }
 
@@ -1338,7 +1337,7 @@ bool Client::exec(std::string _path) {
 }
 
 bool Client::recv_response(double timeout) {
-    if (!wait) {
+    if (!wait_response) {
         return false;
     }
     ssize_t retval = 0;
@@ -1531,7 +1530,7 @@ bool Client::push(zval *zdata, zend_long opcode, uint8_t flags) {
 }
 
 void Client::reset() {
-    wait = false;
+    wait_response = false;
 #ifdef SW_HAVE_COMPRESSION
     compress_method = HTTP_COMPRESS_NONE;
     compression_error = false;

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -847,6 +847,11 @@ bool Client::send_request() {
     zend_update_property_null(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("headers"));
     zend_update_property_null(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("set_cookie_headers"));
     zend_update_property_string(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("body"), "");
+
+    if (!keep_liveness()) {
+        return false;
+    }
+
     zend_update_property_long(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("errCode"), 0);
     zend_update_property_string(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("errMsg"), "");
     zend_update_property_long(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("statusCode"), 0);
@@ -1313,9 +1318,6 @@ bool Client::exec(std::string _path) {
         resolve_context_.with_port = true;
     }
     SW_LOOP_N(max_retries + 1) {
-        if (!keep_liveness()) {
-            return false;
-        }
         if (send_request() == false) {
             return false;
         }

--- a/ext-src/swoole_mysql_coro.cc
+++ b/ext-src/swoole_mysql_coro.cc
@@ -62,7 +62,7 @@ class MysqlClient {
   public:
     /* session related {{{ */
     Socket *socket = nullptr;
-    zval socket_object;
+    zval zsocket;
     zval zobject;
     Socket::timeout_controller *tc = nullptr;
 
@@ -579,10 +579,10 @@ bool Client::connect(std::string host, uint16_t port, bool ssl) {
         non_sql_error(MYSQLND_CR_CONNECTION_ERROR, strerror(errno));
         return false;
     }
-    ZVAL_OBJ(&socket_object, object);
-    zend_update_property(Z_OBJCE_P(&zobject), SW_Z8_OBJ_P(&zobject), ZEND_STRL("socket"), &socket_object);
+    ZVAL_OBJ(&zsocket, object);
+    zend_update_property(Z_OBJCE_P(&zobject), SW_Z8_OBJ_P(&zobject), ZEND_STRL("socket"), &zsocket);
 
-    socket = php_swoole_get_socket(&socket_object);
+    socket = php_swoole_get_socket(&zsocket);
     socket->set_zero_copy(true);
     socket->set_dtor([this](Socket *) { socket_dtor(); });
 #ifdef SW_USE_OPENSSL
@@ -1103,7 +1103,7 @@ bool Client::send_prepare_request(const char *statement, size_t statement_length
 void Client::socket_dtor() {
     zend_update_property_null(Z_OBJCE_P(&zobject), SW_Z8_OBJ_P(&zobject), ZEND_STRL("socket"));
     socket = nullptr;
-    zval_ptr_dtor(&socket_object);
+    zval_ptr_dtor(&zsocket);
 }
 
 Statement *Client::recv_prepare_response() {
@@ -1125,11 +1125,6 @@ void Client::close() {
     state = SW_MYSQL_STATE_CLOSED;
     Socket *_socket = socket;
     if (_socket) {
-        zval tmp_socket = socket_object;
-        zval_add_ref(&tmp_socket);
-        ON_SCOPE_EXIT {
-            zval_ptr_dtor(&tmp_socket);
-        };
         del_timeout_controller();
         if (!quit && is_writable()) {
             send_command_without_check(SW_MYSQL_COM_QUIT);
@@ -1918,6 +1913,7 @@ static PHP_METHOD(swoole_mysql_coro, query) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     mc->query(return_value, sql, sql_length);
     mc->del_timeout_controller();
@@ -1933,6 +1929,7 @@ static PHP_METHOD(swoole_mysql_coro, fetch) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     mc->fetch(return_value);
     mc->del_timeout_controller();
@@ -1950,6 +1947,7 @@ static PHP_METHOD(swoole_mysql_coro, fetchAll) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     mc->fetch_all(return_value);
     mc->del_timeout_controller();
@@ -1967,6 +1965,7 @@ static PHP_METHOD(swoole_mysql_coro, nextResult) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     mc->next_result(return_value);
     mc->del_timeout_controller();
@@ -1991,6 +1990,7 @@ static PHP_METHOD(swoole_mysql_coro, prepare) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     if (UNEXPECTED(!mc->send_prepare_request(statement, statement_length))) {
     _failed:
@@ -2021,6 +2021,7 @@ static PHP_METHOD(swoole_mysql_coro, recv) {
         mysql_coro_sync_error_properties(ZEND_THIS, mc->get_error_code(), mc->get_error_msg(), false);
         RETURN_FALSE;
     }
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_READ);
     switch (mc->state) {
     case SW_MYSQL_STATE_IDLE:
@@ -2069,7 +2070,7 @@ static void swoole_mysql_coro_query_transcation(INTERNAL_FUNCTION_PARAMETERS,
             command);
         RETURN_FALSE;
     }
-
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     mc->query(return_value, command, command_length);
     mc->del_timeout_controller();
@@ -2120,6 +2121,7 @@ static PHP_METHOD(swoole_mysql_coro, escape) {
 
 static PHP_METHOD(swoole_mysql_coro, close) {
     Client *mc = mysql_coro_get_client(ZEND_THIS);
+    SW_CLIENT_PRESERVE_SOCKET(&mc->zsocket);
     mc->close();
     zend_update_property_bool(swoole_mysql_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("connected"), 0);
     RETURN_TRUE;
@@ -2136,6 +2138,13 @@ static PHP_METHOD(swoole_mysql_coro_statement, execute) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (UNEXPECTED(!ms->is_available())) {
+        swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
+        RETURN_FALSE;
+    }
+
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
+
     ms->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     ms->execute(return_value, params);
     ms->del_timeout_controller();
@@ -2150,6 +2159,13 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetch) {
     Z_PARAM_OPTIONAL
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    if (UNEXPECTED(!ms->is_available())) {
+        swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
+        RETURN_FALSE;
+    }
+
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
 
     ms->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     ms->fetch(return_value);
@@ -2168,6 +2184,13 @@ static PHP_METHOD(swoole_mysql_coro_statement, fetchAll) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (UNEXPECTED(!ms->is_available())) {
+        swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
+        RETURN_FALSE;
+    }
+
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
+
     ms->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     ms->fetch_all(return_value);
     ms->del_timeout_controller();
@@ -2184,6 +2207,13 @@ static PHP_METHOD(swoole_mysql_coro_statement, nextResult) {
     Z_PARAM_OPTIONAL
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    if (UNEXPECTED(!ms->is_available())) {
+        swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
+        RETURN_FALSE;
+    }
+
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
 
     ms->add_timeout_controller(timeout, Socket::TIMEOUT_RDWR);
     ms->next_result(return_value);
@@ -2212,6 +2242,9 @@ static PHP_METHOD(swoole_mysql_coro_statement, recv) {
         swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
         RETURN_FALSE;
     }
+
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
+
     ms->add_timeout_controller(timeout, Socket::TIMEOUT_READ);
     switch ((state = ms->get_client()->state)) {
     case SW_MYSQL_STATE_IDLE:
@@ -2235,6 +2268,11 @@ static PHP_METHOD(swoole_mysql_coro_statement, recv) {
 
 static PHP_METHOD(swoole_mysql_coro_statement, close) {
     Statement *ms = mysql_coro_get_statement(ZEND_THIS);
+    if (UNEXPECTED(!ms->is_available())) {
+        swoole_mysql_coro_sync_execute_error_properties(ZEND_THIS, ms->get_error_code(), ms->get_error_msg(), false);
+        RETURN_FALSE;
+    }
+    SW_CLIENT_PRESERVE_SOCKET(&ms->get_client()->zsocket);
     ms->close();
     RETURN_TRUE;
 }

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -691,7 +691,7 @@ static bool php_openssl_capture_peer_certs(php_stream *stream, Socket *sslsock) 
 
     zval argv[1];
     ZVAL_STRINGL(&argv[0], peer_cert.c_str(), peer_cert.length());
-    zend::function::ReturnValue retval = zend::function::call("openssl_x509_read", 1, argv);
+    auto retval = zend::function::call("openssl_x509_read", 1, argv);
     php_stream_context_set_option(PHP_STREAM_CONTEXT(stream), "ssl", "peer_certificate", &retval.value);
     zval_dtor(&argv[0]);
 
@@ -705,7 +705,7 @@ static bool php_openssl_capture_peer_certs(php_stream *stream, Socket *sslsock) 
             for (auto &cert : chain) {
                 zval argv[1];
                 ZVAL_STRINGL(&argv[0], cert.c_str(), cert.length());
-                zend::function::ReturnValue retval = zend::function::call("openssl_x509_read", 1, argv);
+                auto retval = zend::function::call("openssl_x509_read", 1, argv);
                 zval_add_ref(&retval.value);
                 add_next_index_zval(&arr, &retval.value);
                 zval_dtor(&argv[0]);

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -801,8 +801,13 @@ SW_API zend_object *php_swoole_create_socket(enum swSocketType type) {
 }
 
 SW_API void php_swoole_socket_set_error_properties(zval *zobject, int code, const char *msg) {
+    swoole_set_last_error(code);
     zend_update_property_long(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("errCode"), code);
     zend_update_property_string(Z_OBJCE_P(zobject), SW_Z8_OBJ_P(zobject), ZEND_STRL("errMsg"), msg);
+}
+
+SW_API void php_swoole_socket_set_error_properties(zval *zobject, int code) {
+    php_swoole_socket_set_error_properties(zobject, code, swoole_strerror(code));
 }
 
 SW_API void php_swoole_socket_set_error_properties(zval *zobject, Socket *socket) {

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1347,6 +1347,7 @@ bool Socket::ssl_verify(bool allow_self_signed) {
 
 std::string Socket::ssl_get_peer_cert() {
     if (!socket->ssl_get_peer_certificate(sw_tg_buffer())) {
+        set_err(SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE);
         return "";
     } else {
         return sw_tg_buffer()->to_std_string();

--- a/tests/swoole_client_coro/close_socket_property.phpt
+++ b/tests/swoole_client_coro/close_socket_property.phpt
@@ -11,7 +11,7 @@ go(function () {
     Assert::true($cli->connected);
     Assert::true($cli->socket->close());
     Assert::false($cli->close());
-    Assert::eq($cli->errCode, SOCKET_EBADF);
+    Assert::eq($cli->errCode, SWOOLE_ERROR_CLIENT_NO_CONNECTION);
     Assert::false($cli->connected);
     Assert::null($cli->socket);
     Assert::true($cli->connect('www.baidu.com', 80));

--- a/tests/swoole_client_coro/close_twice.phpt
+++ b/tests/swoole_client_coro/close_twice.phpt
@@ -10,7 +10,7 @@ go(function () {
     $cli->connect('www.baidu.com', 80);
     Assert::true($cli->close());
     Assert::false($cli->close());
-    Assert::eq($cli->errCode, SOCKET_EBADF);
+    Assert::eq($cli->errCode, SWOOLE_ERROR_CLIENT_NO_CONNECTION);
 });
 Swoole\Event::wait();
 ?>

--- a/tests/swoole_http_client_coro/disable_keep_alive.phpt
+++ b/tests/swoole_http_client_coro/disable_keep_alive.phpt
@@ -7,7 +7,7 @@ skip_if_offline();
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';
-go(function () {
+Co\run(function () {
     $host = 'www.qq.com';
     $cli = new Swoole\Coroutine\Http\Client($host, 443, true);
     $cli->set([

--- a/tests/swoole_websocket_server/close_frame_full.phpt
+++ b/tests/swoole_websocket_server/close_frame_full.phpt
@@ -38,7 +38,7 @@ $pm->childFunc = function () use ($pm) {
     $serv = new Swoole\WebSocket\Server('127.0.0.1', $pm->getFreePort(), SERVER_MODE_RANDOM);
     $serv->set([
         // 'worker_num' => 1,
-//        'log_file' => '/dev/null'
+        'log_file' => '/dev/null'
     ]);
     $serv->on('WorkerStart', function () use ($pm) {
         $pm->wakeup();

--- a/tests/swoole_websocket_server/close_frame_full.phpt
+++ b/tests/swoole_websocket_server/close_frame_full.phpt
@@ -38,7 +38,7 @@ $pm->childFunc = function () use ($pm) {
     $serv = new Swoole\WebSocket\Server('127.0.0.1', $pm->getFreePort(), SERVER_MODE_RANDOM);
     $serv->set([
         // 'worker_num' => 1,
-        'log_file' => '/dev/null'
+//        'log_file' => '/dev/null'
     ]);
     $serv->on('WorkerStart', function () use ($pm) {
         $pm->wakeup();


### PR DESCRIPTION
Preserve the socket object at the entry of the extension function to prevent the socket pointer being released early in other coroutines