### PR TITLE
All byte length or size related options support unit character

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -307,7 +307,7 @@ void php_swoole_set_global_option(HashTable *vht) {
         swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_ENABLE_PUSH, zval_get_long(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_max_concurrent_streams", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, php_swoole_parse_to_size(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, zval_get_long(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_init_window_size", ztmp)) {
         swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_INIT_WINDOW_SIZE, php_swoole_parse_to_size(ztmp));

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -293,7 +293,7 @@ void php_swoole_set_global_option(HashTable *vht) {
         Socket::default_read_timeout = timeout_format(ztmp);
     }
     if (php_swoole_array_get_value(vht, "socket_buffer_size", ztmp)) {
-        Socket::default_buffer_size = zval_get_long(ztmp);
+        Socket::default_buffer_size = php_swoole_parse_to_size(ztmp);
     }
     if (php_swoole_array_get_value(vht, "socket_timeout", ztmp)) {
         Socket::default_read_timeout = Socket::default_write_timeout = timeout_format(ztmp);
@@ -301,22 +301,22 @@ void php_swoole_set_global_option(HashTable *vht) {
     // [HTTP2]
     // ======================================================================
     if (php_swoole_array_get_value(vht, "http2_header_table_size", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTING_HEADER_TABLE_SIZE, zval_get_long(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTING_HEADER_TABLE_SIZE, php_swoole_parse_to_size(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_enable_push", ztmp)) {
         swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_ENABLE_PUSH, zval_get_long(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_max_concurrent_streams", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, zval_get_long(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, php_swoole_parse_to_size(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_init_window_size", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_INIT_WINDOW_SIZE, zval_get_long(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_INIT_WINDOW_SIZE, php_swoole_parse_to_size(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_max_frame_size", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_FRAME_SIZE, zval_get_long(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_FRAME_SIZE, php_swoole_parse_to_size(ztmp));
     }
     if (php_swoole_array_get_value(vht, "http2_max_header_list_size", ztmp)) {
-        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, zval_get_long(ztmp));
+        swoole::http2::put_default_setting(SW_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, php_swoole_parse_to_size(ztmp));
     }
 }
 
@@ -329,6 +329,14 @@ SW_API bool php_swoole_is_enable_coroutine() {
         return sw_server()->is_enable_coroutine();
     } else {
         return SWOOLE_G(enable_coroutine);
+    }
+}
+
+SW_API zend_long php_swoole_parse_to_size(zval *zv) {
+    if (ZVAL_IS_STRING(zv)) {
+        return zend_atol(Z_STRVAL_P(zv), Z_STRLEN_P(zv));
+    } else {
+        return zval_get_long(zv);
     }
 }
 

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -135,6 +135,7 @@ static inline bool php_swoole_is_fatal_error() {
 }
 
 ssize_t php_swoole_length_func(const swoole::Protocol *, swoole::network::Socket *, swoole::PacketLength *);
+SW_API zend_long php_swoole_parse_to_size(zval *zv);
 
 #ifdef SW_HAVE_ZLIB
 #define php_swoole_websocket_frame_pack php_swoole_websocket_frame_pack_ex

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -386,7 +386,7 @@ bool php_swoole_client_check_setting(Client *cli, zval *zset) {
      * package max length
      */
     if (php_swoole_array_get_value(vht, "package_max_length", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         cli->protocol.package_max_length = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     } else {
         cli->protocol.package_max_length = SW_INPUT_BUFFER_SIZE;
@@ -395,18 +395,18 @@ bool php_swoole_client_check_setting(Client *cli, zval *zset) {
      * socket send/recv buffer size
      */
     if (php_swoole_array_get_value(vht, "socket_buffer_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         value = SW_MAX(1, SW_MIN(v, INT_MAX));
         cli->socket->set_buffer_size(value);
         cli->socket->buffer_size = value;
     }
     if (php_swoole_array_get_value(vht, "buffer_high_watermark", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         value = SW_MAX(0, SW_MIN(v, UINT32_MAX));
         cli->buffer_high_watermark = value;
     }
     if (php_swoole_array_get_value(vht, "buffer_low_watermark", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         value = SW_MAX(0, SW_MIN(v, UINT32_MAX));
         cli->buffer_low_watermark = value;
     }

--- a/ext-src/swoole_coroutine_scheduler.cc
+++ b/ext-src/swoole_coroutine_scheduler.cc
@@ -154,7 +154,7 @@ void php_swoole_set_coroutine_option(zend_array *vht) {
         PHPCoroutine::enable_preemptive_scheduler(zval_is_true(ztmp));
     }
     if (php_swoole_array_get_value(vht, "c_stack_size", ztmp) || php_swoole_array_get_value(vht, "stack_size", ztmp)) {
-        Coroutine::set_stack_size(zval_get_long(ztmp));
+        Coroutine::set_stack_size(php_swoole_parse_to_size(ztmp));
     }
     if (php_swoole_array_get_value(vht, "name_resolver", ztmp)) {
         if (!ZVAL_IS_ARRAY(ztmp)) {

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -313,7 +313,7 @@ static PHP_METHOD(swoole_process_pool, set) {
         pp->enable_message_bus = zval_is_true(ztmp);
     }
     if (php_swoole_array_get_value(vht, "max_package_size", ztmp)) {
-        pool->set_max_packet_size(zval_get_long(ztmp));
+        pool->set_max_packet_size(php_swoole_parse_to_size(ztmp));
     }
 }
 

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -1984,7 +1984,7 @@ static PHP_METHOD(swoole_server, set) {
         serv->max_wait_time = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     if (php_swoole_array_get_value(vht, "max_queued_bytes", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         serv->max_queued_bytes = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     if (php_swoole_array_get_value(vht, "max_concurrency", ztmp)) {
@@ -2216,7 +2216,7 @@ static PHP_METHOD(swoole_server, set) {
     }
     if (php_swoole_array_get_value(vht, "http_compression_min_length", ztmp) ||
         php_swoole_array_get_value(vht, "compression_min_length", ztmp)) {
-        serv->compression_min_length = zval_get_long(ztmp);
+        serv->compression_min_length = php_swoole_parse_to_size(ztmp);
     }
 #endif
 
@@ -2306,7 +2306,7 @@ static PHP_METHOD(swoole_server, set) {
      */
     if (php_swoole_array_get_value(vht, "input_buffer_size", ztmp) ||
         php_swoole_array_get_value(vht, "buffer_input_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         serv->input_buffer_size = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     /**
@@ -2314,7 +2314,7 @@ static PHP_METHOD(swoole_server, set) {
      */
     if (php_swoole_array_get_value(vht, "output_buffer_size", ztmp) ||
         php_swoole_array_get_value(vht, "buffer_output_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         serv->output_buffer_size = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     // message queue key

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2236,7 +2236,7 @@ static PHP_METHOD(swoole_server, set) {
         serv->upload_tmp_dir = str_v.to_std_string();
     }
     if (php_swoole_array_get_value(vht, "upload_max_filesize", ztmp)) {
-        serv->upload_max_filesize = zval_get_long(ztmp);
+        serv->upload_max_filesize = php_swoole_parse_to_size(ztmp);
     }
     /**
      * http static file handler

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -271,7 +271,7 @@ static PHP_METHOD(swoole_server_port, set) {
         port->backlog = SW_MAX(0, SW_MIN(v, UINT16_MAX));
     }
     if (php_swoole_array_get_value(vht, "socket_buffer_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->socket_buffer_size = SW_MAX(INT_MIN, SW_MIN(v, INT_MAX));
         if (port->socket_buffer_size <= 0) {
             port->socket_buffer_size = INT_MAX;
@@ -281,7 +281,7 @@ static PHP_METHOD(swoole_server_port, set) {
      * !!! Don't set this option, for tests only.
      */
     if (php_swoole_array_get_value(vht, "kernel_socket_recv_buffer_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->kernel_socket_recv_buffer_size = SW_MAX(INT_MIN, SW_MIN(v, INT_MAX));
         if (port->kernel_socket_recv_buffer_size <= 0) {
             port->kernel_socket_recv_buffer_size = INT_MAX;
@@ -291,7 +291,7 @@ static PHP_METHOD(swoole_server_port, set) {
      * !!! Don't set this option, for tests only.
      */
     if (php_swoole_array_get_value(vht, "kernel_socket_send_buffer_size", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->kernel_socket_send_buffer_size = SW_MAX(INT_MIN, SW_MIN(v, INT_MAX));
         if (port->kernel_socket_send_buffer_size <= 0) {
             port->kernel_socket_send_buffer_size = INT_MAX;
@@ -303,11 +303,11 @@ static PHP_METHOD(swoole_server_port, set) {
         port->heartbeat_idle_time = SW_MAX(0, SW_MIN(v, UINT16_MAX));
     }
     if (php_swoole_array_get_value(vht, "buffer_high_watermark", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->buffer_high_watermark = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     if (php_swoole_array_get_value(vht, "buffer_low_watermark", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->buffer_low_watermark = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
     // server: tcp_nodelay
@@ -487,7 +487,7 @@ static PHP_METHOD(swoole_server_port, set) {
      * package max length
      */
     if (php_swoole_array_get_value(vht, "package_max_length", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         port->protocol.package_max_length = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     }
 

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -991,7 +991,7 @@ SW_API bool php_swoole_socket_set_protocol(Socket *sock, zval *zset) {
      * package max length
      */
     if (php_swoole_array_get_value(vht, "package_max_length", ztmp)) {
-        zend_long v = zval_get_long(ztmp);
+        zend_long v = php_swoole_parse_to_size(ztmp);
         sock->protocol.package_max_length = SW_MAX(0, SW_MIN(v, UINT32_MAX));
     } else {
         sock->protocol.package_max_length = SW_INPUT_BUFFER_SIZE;
@@ -1037,7 +1037,7 @@ SW_API bool php_swoole_socket_set(Socket *cli, zval *zset) {
      * socket send/recv buffer size
      */
     if (php_swoole_array_get_value(vht, "socket_buffer_size", ztmp)) {
-        zend_long size = zval_get_long(ztmp);
+        zend_long size = php_swoole_parse_to_size(ztmp);
         if (size <= 0) {
             php_swoole_fatal_error(E_WARNING, "socket buffer size must be greater than 0, got " ZEND_LONG_FMT, size);
             ret = false;


### PR DESCRIPTION
before
---
```php
$socket->set([
      'socket_buffer_size' => 4 * 1024 *1024, 
]);
```

now
---
```php
$socket->set([
      'socket_buffer_size' => '4M', 
]);
```

