### PR TITLE
use system headers for system libnghttp2

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -744,6 +744,7 @@ EOF
         thirdparty/hiredis/sds.c"
 
     if test "$PHP_NGHTTP2_DIR" = "no"; then
+        PHP_ADD_INCLUDE([$ext_srcdir/thirdparty])
 	    swoole_source_file="$swoole_source_file \
 	        thirdparty/nghttp2/nghttp2_hd.c \
 	        thirdparty/nghttp2/nghttp2_rcbuf.c \

--- a/ext-src/php_swoole_http.h
+++ b/ext-src/php_swoole_http.h
@@ -34,7 +34,7 @@
 #define SW_ZLIB_ENCODING_ANY 0x2f
 #endif
 
-#include "thirdparty/nghttp2/nghttp2.h"
+#include <nghttp2/nghttp2.h>
 
 enum swHttpHeaderFlag {
     HTTP_HEADER_SERVER = 1u << 1,


### PR DESCRIPTION
Affects **5.0.3**, removing `thirdparty/nghttp2` (to ensure bundled copy is not used) and using `--with-nghttp2-dir=/usr`

```
In file included from /dev/shm/BUILD/php-pecl-swoole5-5.0.3/NTS/ext-src/swoole_admin_server.cc:19:
/dev/shm/BUILD/php-pecl-swoole5-5.0.3/NTS/ext-src/php_swoole_http.h:37:10: fatal error: thirdparty/nghttp2/nghttp2.h: No such file or directory
   37 | #include "thirdparty/nghttp2/nghttp2.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

```

This may raise strange issue using bundled headers with system library (API may differ)