### PR TITLE
Fix server stats connection num

### DIFF
--- a/ext-src/swoole_admin_server.cc
+++ b/ext-src/swoole_admin_server.cc
@@ -430,7 +430,7 @@ static std::string handle_get_all_ports(Server *serv, const std::string &msg) {
             {"type", port->type},
             {"ssl", port->ssl},
             {"protocols", port->get_protocols()},
-            {"connection_num", (long) port->gs->connection_num},
+            {"connection_num", (long) port->get_connection_num()},
         });
         _list.push_back(info);
     };

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2792,7 +2792,7 @@ static PHP_METHOD(swoole_server, stats) {
 
     array_init(return_value);
     add_assoc_long_ex(return_value, ZEND_STRL("start_time"), serv->gs->start_time);
-    add_assoc_long_ex(return_value, ZEND_STRL("connection_num"), serv->gs->connection_num);
+    add_assoc_long_ex(return_value, ZEND_STRL("connection_num"), serv->get_connection_num());
     add_assoc_long_ex(return_value, ZEND_STRL("abort_count"), serv->gs->abort_count);
     add_assoc_long_ex(return_value, ZEND_STRL("accept_count"), serv->gs->accept_count);
     add_assoc_long_ex(return_value, ZEND_STRL("close_count"), serv->gs->close_count);
@@ -3882,9 +3882,9 @@ static PHP_METHOD(swoole_connection_iterator, key) {
 static PHP_METHOD(swoole_connection_iterator, count) {
     ConnectionIterator *iterator = php_swoole_connection_iterator_get_and_check_ptr(ZEND_THIS);
     if (iterator->port) {
-        RETURN_LONG(iterator->port->gs->connection_num);
+        RETURN_LONG(iterator->port->get_connection_num());
     } else {
-        RETURN_LONG(iterator->serv->gs->connection_num);
+        RETURN_LONG(iterator->serv->get_connection_num());
     }
 }
 

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -157,6 +157,7 @@ struct ReactorThread {
 
 struct ServerPortGS {
     sw_atomic_t connection_num;
+    sw_atomic_t *connection_nums = nullptr;
     sw_atomic_long_t abort_count;
     sw_atomic_long_t accept_count;
     sw_atomic_long_t close_count;
@@ -348,6 +349,8 @@ struct ListenPort {
     int get_fd() {
         return socket ? socket->fd : -1;
     }
+
+    size_t get_connection_num();
 };
 
 struct ServerGS {
@@ -364,6 +367,7 @@ struct ServerGS {
     bool called_onStart;
     time_t start_time;
     sw_atomic_t connection_num;
+    sw_atomic_t *connection_nums = nullptr;
     sw_atomic_t tasking_num;
     uint32_t max_concurrency;
     sw_atomic_t concurrency;
@@ -1321,6 +1325,18 @@ class Server {
     void destroy_http_request(Connection *conn);
 
     int schedule_worker(int fd, SendData *data);
+
+    size_t get_connection_num() {
+        if (gs->connection_nums) {
+            size_t num = 0;
+            for (uint32_t i = 0; i < worker_num; i++) {
+                num += gs->connection_nums[i];
+            }
+            return num;
+        } else {
+            return gs->connection_num;
+        }
+    }
 
     /**
      * [Manager]

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -607,8 +607,9 @@ pid_t Server::spawn_event_worker(Worker *worker) {
         worker->pid = pid;
         return pid;
     }
-
+    
     if (is_base_mode()) {
+        gs->connection_nums[worker->id] = 0;
         gs->event_workers.main_loop(&gs->event_workers, worker);
     } else {
         start_event_worker(worker);

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -607,7 +607,7 @@ pid_t Server::spawn_event_worker(Worker *worker) {
         worker->pid = pid;
         return pid;
     }
-    
+
     if (is_base_mode()) {
         gs->connection_nums[worker->id] = 0;
         gs->event_workers.main_loop(&gs->event_workers, worker);

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -780,4 +780,16 @@ const char *ListenPort::get_protocols() {
     }
 }
 
+size_t ListenPort::get_connection_num() {
+    if (gs->connection_nums) {
+        size_t num = 0;
+        for (uint32_t i = 0; i < sw_server()->worker_num; i++) {
+            num += gs->connection_nums[i];
+        }
+        return num;
+    } else {
+        return gs->connection_num;
+    }
+}
+
 }  // namespace swoole

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -187,10 +187,15 @@ int Server::close_connection(Reactor *reactor, Socket *socket) {
     }
 
     sw_atomic_fetch_add(&serv->gs->close_count, 1);
-    sw_atomic_fetch_sub(&serv->gs->connection_num, 1);
-
     sw_atomic_fetch_add(&port->gs->close_count, 1);
-    sw_atomic_fetch_sub(&port->gs->connection_num, 1);
+
+    if (serv->is_base_mode()) {
+        sw_atomic_fetch_sub(&serv->gs->connection_nums[reactor->id], 1);
+        sw_atomic_fetch_sub(&port->gs->connection_nums[reactor->id], 1);
+    } else {
+        sw_atomic_fetch_sub(&serv->gs->connection_num, 1);
+        sw_atomic_fetch_sub(&port->gs->connection_num, 1);
+    }
 
     swoole_trace("Close Event.fd=%d|from=%d", socket->fd, reactor->id);
 


### PR DESCRIPTION
`SWOOLE_BASE` 模式下 worker 进程异常崩溃后，`$server->stats()['connection_num']` 的值会变得不正确。

这个 PR 修复了这个问题