### PR TITLE
Fix phpunit options

### DIFF
--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -45,7 +45,7 @@ jobs:
           git clone https://github.com/laravel/octane.git --depth=1
           cd octane/
           composer update --prefer-dist --no-interaction --no-progress
-          vendor/bin/phpunit -v
+          vendor/bin/phpunit
 
       - name: Hyperf Tests
         if: matrix.framework == 'Hyperf'


### PR DESCRIPTION
The he short option `-v` (short for `--verbose`)  was still accepted by the test runner, but no longer had an effect since `--verbose` was removed in PHPUnit 10.0