### PR TITLE
Fix memory leaks in SWOOLE_BASE mode

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -207,7 +207,7 @@ static void server_free_object(zend_object *object) {
     delete property;
 
     zend_object_std_dtor(object);
-    if (serv && serv->is_master()) {
+    if (serv && ((serv->is_process_mode() && serv->is_master()) || serv->is_base_mode())) {
         delete serv;
     }
 }


### PR DESCRIPTION
在Swoole\Server在SWOOLE_BASE模式下执行shutdown时，出现memory leaks

在开启debug的环境下，执行以下脚本：

```php
<?php
use Swoole\Server;

$serv = new Server('127.0.0.1', '9501');
$serv->set([
  "worker_num" => 1,
  'log_file' => '/dev/null',
]);
$serv->on("start", function (Server $serv) {
  $serv->shutdown();
});
$serv->on("shutdown", function (Server $serv) {
  echo 'master shutdown' . PHP_EOL;
});
$serv->on("Receive", function (Server $serv, $fd, $reactorId, $data) {
});
$serv->start();
```

执行结果如下：

```
master shutdown
[Fri Aug 25 10:55:19 2023]  Script:  '/root/src-debug/php-test/tcpServer1.php'
/root/src-debug/php-8.0.23/include/php/Zend/zend_string.h(144) :  Freeing 0x00007f0a0a5c6000 (65576 bytes), script=/root/src-debug/php-test/tcpServer1.php
=== Total 1 memory leaks detected ===
```

经过使用`valgrind`检测发现：

```
==28326== 65,576 bytes in 1 blocks are possibly lost in loss record 120 of 121
==28326==    at 0x4C28F73: malloc (vg_replace_malloc.c:309)
==28326==    by 0x9085C0: __zend_malloc (zend_alloc.c:3056)
==28326==    by 0x907261: _malloc_custom (zend_alloc.c:2418)
==28326==    by 0x90738F: _emalloc (zend_alloc.c:2537)
==28326==    by 0xBAA4422: zend_string_alloc(unsigned long, bool) (zend_string.h:144)
==28326==    by 0xBAAC4F4: _sw_zend_string_malloc(unsigned long) (php_swoole.cc:852)
==28326==    by 0xBCA78A6: swoole::MessageBus::alloc_buffer() (swoole_server.h:231)
==28326==    by 0xBCA67BF: swoole::Server::create_pipe_buffers() (master.cc:1994)
==28326==    by 0xBCB9055: swoole::Server::start_reactor_processes() (reactor_process.cc:104)
==28326==    by 0xBC9DD0A: swoole::Server::start() (master.cc:702)
==28326==    by 0xBBD3C42: zim_swoole_server_start (swoole_server.cc:2566)
==28326==    by 0x974D9B: ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER (zend_vm_execute.h:1755)
```

MessageBus的buffer_申请的堆内存没有得到释放导致，由于MessageBus和Server拥有一致的生命周期，经检查php在销毁`Swoole\Server`对象时，有销毁server对象，由于`SWOO_BASE`模式下`process_type`不是`SW_PROCESS_MASTER`，因而该模式下没有销毁`server`。

```c++
// ext-src/swoole_server.cc
if (serv && serv->is_master()) {
  delete serv;
}
```
