### PR TITLE
Fix Class "X" not found due to coroutine context switching in autoload

### DIFF
--- a/ext-src/php_swoole_coroutine.h
+++ b/ext-src/php_swoole_coroutine.h
@@ -92,7 +92,6 @@ struct PHPContext {
     long pcid;
     zend_object *context;
     int64_t last_msec;
-    HashTable *in_autoload;
 };
 
 class PHPCoroutine {

--- a/ext-src/php_swoole_coroutine.h
+++ b/ext-src/php_swoole_coroutine.h
@@ -92,6 +92,7 @@ struct PHPContext {
     long pcid;
     zend_object *context;
     int64_t last_msec;
+    HashTable *in_autoload;
 };
 
 class PHPCoroutine {

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -917,7 +917,7 @@ static zend_class_entry *swoole_coroutine_autoload(zend_string *name, zend_strin
     zval *z_queue = zend_hash_find(SWOOLE_G(in_autoload), lc_name);
     if (z_queue != nullptr) {
         swoole_coroutine_autoload_context_t context;
-        auto current = Coroutine::get_current();
+        auto current = Coroutine::get_current_safe();
         context.coroutine = current;
         context.ce = nullptr;
         auto queue = (std::queue<swoole_coroutine_autoload_context_s *> *) Z_PTR_P(z_queue);

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -953,7 +953,6 @@ static zend_class_entry *swoole_coroutine_autoload(zend_string *name, zend_strin
         pending_context->coroutine->resume();
     }
     delete queue.queue;
-    zend_hash_add_empty_element(EG(in_autoload), lc_name);
     return ce;
 }
 

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -662,11 +662,6 @@ void PHPCoroutine::destroy_context(PHPContext *ctx) {
         OBJ_RELEASE(context);
     }
 
-    if (ctx->in_autoload) {
-        zend_hash_destroy(ctx->in_autoload);
-        FREE_HASHTABLE(ctx->in_autoload);
-    }
-
     Z_TRY_DELREF(ctx->fci.function_name);
     ZVAL_UNDEF(&ctx->fci.function_name);
     sw_zend_fci_cache_discard(&ctx->fci_cache);

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -939,20 +939,20 @@ static zend_class_entry *swoole_coroutine_autoload(zend_string *name, zend_strin
     }
     swoole_coroutine_autoload_queue_t queue;
     queue.coroutine = current;
-    queue.queue = new std::queue<swoole_coroutine_autoload_context_t *>;
+    std::queue<swoole_coroutine_autoload_context_t *> queue_object;
+    queue.queue = &queue_object;
 
     zend_hash_add_ptr(SWOOLE_G(in_autoload), lc_name, &queue);
     zend_class_entry *ce = original_zend_autoload(name, lc_name);
     zend_hash_del(SWOOLE_G(in_autoload), lc_name);
 
     swoole_coroutine_autoload_context_t *pending_context = nullptr;
-    while (!queue.queue->empty()) {
-        pending_context = queue.queue->front();
-        queue.queue->pop();
+    while (!queue_object.empty()) {
+        pending_context = queue_object.front();
+        queue_object.pop();
         pending_context->ce = ce;
         pending_context->coroutine->resume();
     }
-    delete queue.queue;
     return ce;
 }
 

--- a/php_swoole.h
+++ b/php_swoole.h
@@ -57,6 +57,7 @@ ZEND_BEGIN_MODULE_GLOBALS(swoole)
     zend_bool enable_fiber_mock;
     long socket_buffer_size;
     int req_status;
+    HashTable *in_autoload;
 ZEND_END_MODULE_GLOBALS(swoole)
 // clang-format on
 

--- a/tests/include/api/test_classes/A2.php
+++ b/tests/include/api/test_classes/A2.php
@@ -1,0 +1,2 @@
+<?php
+new SwooleTestClassA2();

--- a/tests/swoole_coroutine/autoload.phpt
+++ b/tests/swoole_coroutine/autoload.phpt
@@ -1,0 +1,32 @@
+--TEST--
+swoole_coroutine: autoload
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+spl_autoload_register(function ($class) {
+    co::sleep(0.001); // coroutine context switch
+    if ($class == 'SwooleTestClassA') {
+        require_once TESTS_ROOT_PATH . '/include/api/test_classes/A.php';
+    }
+});
+
+Swoole\Coroutine\run(function () {
+    for ($i = 0; $i < 2; ++$i)
+    {
+        go(static function (): void {
+            var_dump(new SwooleTestClassA());
+        });
+    }
+});
+
+?>
+--EXPECTF--
+object(SwooleTestClassA)#%d (0) {
+}
+object(SwooleTestClassA)#%d (0) {
+}

--- a/tests/swoole_coroutine/autoload.phpt
+++ b/tests/swoole_coroutine/autoload.phpt
@@ -11,7 +11,7 @@ require __DIR__ . '/../include/bootstrap.php';
 spl_autoload_register(function ($class) {
     co::sleep(0.001); // coroutine context switch
     if ($class == 'SwooleTestClassA') {
-        require_once TESTS_ROOT_PATH . '/include/api/test_classes/A.php';
+        require TESTS_ROOT_PATH . '/include/api/test_classes/A.php';
     }
 });
 

--- a/tests/swoole_coroutine/autoload_not_found.phpt
+++ b/tests/swoole_coroutine/autoload_not_found.phpt
@@ -1,0 +1,28 @@
+--TEST--
+swoole_coroutine: autoload not in coroutine
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+spl_autoload_register(function ($class) {
+    if ($class == 'SwooleTestClassA2') {
+        require TESTS_ROOT_PATH . '/include/api/test_classes/A2.php';
+    }
+});
+
+Co\run( function() {
+    var_dump(new SwooleTestClassA2());
+});
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "SwooleTestClassA2" not found in %s:%d
+Stack trace:
+#0 %s(%d): %s
+#1 %s(%d): %s
+#2 [internal function]: {closure}()
+#3 {main}
+  thrown in %s on line %d

--- a/tests/swoole_coroutine/autoload_not_found.phpt
+++ b/tests/swoole_coroutine/autoload_not_found.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: autoload not in coroutine
+swoole_coroutine: autoload not found
 --SKIPIF--
 <?php
 require __DIR__ . '/../include/skipif.inc';

--- a/tests/swoole_coroutine/autoload_not_found_not_in_coroutine.phpt
+++ b/tests/swoole_coroutine/autoload_not_found_not_in_coroutine.phpt
@@ -1,0 +1,26 @@
+--TEST--
+swoole_coroutine: autoload not in coroutine
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+spl_autoload_register(function ($class) {
+    if ($class == 'SwooleTestClassA2') {
+        require TESTS_ROOT_PATH . '/include/api/test_classes/A2.php';
+    }
+});
+
+var_dump(new SwooleTestClassA2());
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "SwooleTestClassA2" not found in %s:%d
+Stack trace:
+#0 %s(%d): %s
+#1 %s(%d): %s
+#2 {main}
+  thrown in %s on line %d

--- a/tests/swoole_coroutine/autoload_not_found_not_in_coroutine.phpt
+++ b/tests/swoole_coroutine/autoload_not_found_not_in_coroutine.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_coroutine: autoload not in coroutine
+swoole_coroutine: autoload not found and not in coroutine
 --SKIPIF--
 <?php
 require __DIR__ . '/../include/skipif.inc';

--- a/tests/swoole_coroutine/autoload_not_in_coroutine.phpt
+++ b/tests/swoole_coroutine/autoload_not_in_coroutine.phpt
@@ -1,0 +1,25 @@
+--TEST--
+swoole_coroutine: autoload not in coroutine
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+spl_autoload_register(function ($class) {
+    if ($class == 'SwooleTestClassA') {
+        require TESTS_ROOT_PATH . '/include/api/test_classes/A.php';
+    }
+});
+
+var_dump(new SwooleTestClassA());
+var_dump(new SwooleTestClassA());
+
+?>
+--EXPECTF--
+object(SwooleTestClassA)#%d (0) {
+}
+object(SwooleTestClassA)#%d (0) {
+}


### PR DESCRIPTION
**问题：**

瞬间有多个协程 `new` 一个未被加载的类，如果 `autoload` 里有协程切换，就会报错 `Class "X" not found`。

**解决方案：**

hook `zend_autoload()`，当多个协程 autoload 同一个类时，协程挂起等待。

参考：<https://github.com/swow/swow/commit/beffeb4164dde2b19a81484b9740fd1b3a1bb526>