### PR TITLE
Fixing errno after wait

### DIFF
--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -230,7 +230,7 @@ void Manager::wait(Server *_server) {
 
     while (_server->running) {
         ExitStatus exit_status = wait_process();
-
+        const auto errnoAfterWait = errno;
         if (pool->read_message) {
             EventData msg;
             while (pool->pop_message(&msg, sizeof(msg)) > 0) {
@@ -261,7 +261,7 @@ void Manager::wait(Server *_server) {
         if (exit_status.get_pid() < 0) {
             if (!pool->reloading) {
             _error:
-                if (errno > 0 && errno != EINTR) {
+                if (errnoAfterWait > 0 && errnoAfterWait != EINTR) {
                     swoole_sys_warning("wait() failed");
                 }
                 continue;


### PR DESCRIPTION
There is a bug in Swoole's event loop that causes warning messages for things that shouldn't be warnings. The line "if (errno > 0 && errno != EINTR)" is expecting the global variable "errno" to be set by wait system call in the inline function "wait_process", but instead errno is getting overwritten by the "spawn_task_worker" or "spawn_event_worker methods" of the server.

https://github.com/swoole/swoole-src/issues/5217