### PR TITLE
Fix out of sources tree build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1009,14 +1009,19 @@ EOF
         AC_DEFINE(SW_USE_MYSQLND, 1, [use mysqlnd])
     fi
 
-    if test -f "ext-src/php_swoole.cc"; then
+    AC_MSG_CHECKING([for sources])
+    if test -f "$abs_srcdir/ext-src/php_swoole.cc"; then
+        swoole_source_dir=$abs_srcdir
+    elif test -f "ext-src/php_swoole.cc"; then
         swoole_source_dir=$(pwd)
     else
         swoole_source_dir="ext/swoole"
     fi
+    AC_MSG_RESULT([$swoole_source_dir])
 
     ext_src_files=$(cd $swoole_source_dir && find ext-src/ -name *.cc)
     lib_src_files=$(cd $swoole_source_dir && find src/ -name *.cc)
+
     swoole_source_file="${ext_src_files} ${lib_src_files}"
 
     swoole_source_file="$swoole_source_file \

--- a/scripts/pecl-install.sh
+++ b/scripts/pecl-install.sh
@@ -7,5 +7,6 @@ pecl config-show && \
 php tools/pecl-package.php && package_file="`ls | grep swoole-*tgz`" && \
 echo "\n" | pecl install -f ${package_file} | tee pecl.log && \
 cat pecl.log | grep "successfully" && \
+php -d extension=swoole --ri swoole && \
 pecl uninstall swoole && \
 rm -f pecl.log


### PR DESCRIPTION
Broken by eb9a16ea613429f473b833b3ea302aefa50656d3 and 03b263900c

Notice: **pecl** build use out of sources tree build

So tagged version 5.1.2 will be unusable there
