### PR TITLE
Remove unused Autoconf checks for socket structs

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -274,36 +274,9 @@ AC_DEFUN([AC_SWOOLE_HAVE_BOOST_STACKTRACE],
 ])
 
 AC_DEFUN([AC_SWOOLE_CHECK_SOCKETS], [
-    dnl Check for struct cmsghdr
-    AC_CACHE_CHECK([for struct cmsghdr], ac_cv_cmsghdr,
-    [
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/types.h>
-#include <sys/socket.h>]], [[struct cmsghdr s; s]])], [ac_cv_cmsghdr=yes], [ac_cv_cmsghdr=no])
-    ])
-
-    if test "$ac_cv_cmsghdr" = yes; then
-        AC_DEFINE(HAVE_CMSGHDR,1,[Whether you have struct cmsghdr])
-    fi
-
     AC_CHECK_FUNCS([hstrerror socketpair if_nametoindex if_indextoname])
     AC_CHECK_HEADERS([netdb.h netinet/tcp.h sys/un.h sys/sockio.h])
     AC_DEFINE([HAVE_SOCKETS], 1, [ ])
-
-    dnl Check for fied ss_family in sockaddr_storage (missing in AIX until 5.3)
-    AC_CACHE_CHECK([for field ss_family in struct sockaddr_storage], ac_cv_ss_family,
-    [
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netdb.h>
-    ]], [[struct sockaddr_storage sa_store; sa_store.ss_family = AF_INET6;]])],
-        [ac_cv_ss_family=yes], [ac_cv_ss_family=no])
-    ])
-
-    if test "$ac_cv_ss_family" = yes; then
-        AC_DEFINE(HAVE_SA_SS_FAMILY,1,[Whether you have sockaddr_storage.ss_family])
-    fi
 
     dnl Check for AI_V4MAPPED flag
     AC_CACHE_CHECK([if getaddrinfo supports AI_V4MAPPED],[ac_cv_gai_ai_v4mapped],


### PR DESCRIPTION
- struct cmsghdr is not used in the Swoole code
- the sockaddr_storage.ss_family used to be checked for AIX versions 5.3 and older, which contained __ss_family instead. On AIX 6 and later the ss_family field is available.