### PR TITLE
AC_PROG_CC_C99 is obsolete with autoconf >= 2.70

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -356,7 +356,8 @@ AC_COMPILE_IFELSE([
 )
 AC_MSG_RESULT([$CLANG])
 
-AC_PROG_CC_C99
+dnl AC_PROG_CC_C99 is obsolete with autoconf >= 2.70 yet necessary for <= 2.69.
+m4_version_prereq([2.70],,[AC_PROG_CC_C99])
 
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
To make sure that compiler supports C99 before Autoconf 2.69, this was needed. But with Autoconf 2.70 and later the macro is obsolete because the checks are done in AC_PROG_CC and warnings are emitted when building configure script on newer Autoconf versions.

Once PHP will require Autoconf 2.70 or newer, this can be removed. The AC_PROG_CC is added by phpize.m4 from the php-src repository.