### PR TITLE
Detect additional error message "Broken Pipe" as Lost Connection

### DIFF
--- a/ext-src/php_swoole_library.h
+++ b/ext-src/php_swoole_library.h
@@ -2768,6 +2768,7 @@ static const char* swoole_library_source_core_database_detects_lost_connections 
     "        'SQLSTATE[08006] [7] SSL error: sslv3 alert unexpected message',\n"
     "        'SQLSTATE[08006] [7] unrecognized SSL error code:',\n"
     "        'SQLSTATE[HY000] [2002] No connection could be made because the target machine actively refused it',\n"
+    "        'Broken pipe',\n"
     "    ];\n"
     "\n"
     "    public static function causedByLostConnection(\\Throwable $e): bool\n"


### PR DESCRIPTION
Example fatal error trying to use database connection from PDOPool after a long time of not using them
```log
Fatal error: Uncaught ErrorException: PDOStatement::execute(): Send of 2109 bytes failed with errno=32 Broken pipe in @swoole/library/core/Database/PDOStatementProxy.php:53
Stack trace:
#0 [internal function]: Hyperf\ExceptionHandler\Listener\ErrorExceptionHandler::Hyperf\ExceptionHandler\Listener\{closure}(8, 'PDOStatement::e...', '@swoole/library...', 53)
#1 @swoole/library/core/Database/PDOStatementProxy.php(53): PDOStatement->execute(Array)
#2 /home/dev/project/app/Tasks/SomethingTask.php(1921): Swoole\Database\PDOStatementProxy->__call('execute', Array)
#3 [internal function]: App\Tasks\SomethingTask::batch('1', NULL, Array, 93, false)
#4 {main}
  thrown in @swoole/library/core/Database/PDOStatementProxy.php on line 53
```

#### Candidate strings
- `"Broken pipe"` ✅ selected based on Hyperf framework - see below
- `"errno=32 Broken pipe"`
- `"bytes failed with errno=32 Broken pipe"`

#### See also
- Already merged in [swoole/library](https://github.com/swoole/library/pull/172)
- Hyperf project version of [DetectsLostConnections.php](https://github.com/hyperf/hyperf/blob/master/src/database/src/DetectsLostConnections.php)
```php
...
'Broken pipe',
...
```
- Swoole IDE Helper should also be updated? [swoole/ide-helper • DetectsLostConnections.php](https://github.com/swoole/ide-helper/blob/master/src/swoole_library/src/core/Database/DetectsLostConnections.php)
