### PR TITLE
fix: handle closed STDOUT/STDERR without exception

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1078,7 +1078,7 @@ PHP_RSHUTDOWN_FUNCTION(swoole) {
             return;
         }
         stream =
-            (php_stream *) zend_fetch_resource2_ex((zstream), "stream", php_file_le_stream(), php_file_le_pstream());
+            (php_stream *) zend_fetch_resource2_ex((zstream), NULL, php_file_le_stream(), php_file_le_pstream());
         if (!stream) {
             return;
         }

--- a/tests/swoole_global/closed_stdout.phpt
+++ b/tests/swoole_global/closed_stdout.phpt
@@ -1,0 +1,9 @@
+--TEST--
+swoole_global: handle closed STDOUT/STDERR without exception
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+fclose(STDERR);
+?>
+--EXPECT--


### PR DESCRIPTION
If STDOUT / STDERR was closed in PHP land, call `zend_fetch_resource2_ex` with NON-NULL value `resource_type_name` will raise type error exception.