### PR TITLE
[5.1.3] Fix broken build with GCC 14

### DIFF
--- a/ext-src/php_swoole_call_stack.h
+++ b/ext-src/php_swoole_call_stack.h
@@ -18,8 +18,8 @@
 
 #ifdef ZEND_CHECK_STACK_LIMIT
 #define HOOK_PHP_CALL_STACK(callback)                                                                                  \
-    auto __stack_limit = EG(stack_limit);                                                                              \
-    auto __stack_base = EG(stack_base);                                                                                \
+    void *__stack_limit = EG(stack_limit);                                                                              \
+    void *__stack_base = EG(stack_base);                                                                                \
     EG(stack_base) = (void *) 0;                                                                                       \
     EG(stack_limit) = (void *) 0;                                                                                      \
     callback EG(stack_limit) = __stack_limit;                                                                          \

--- a/thirdparty/php83/pdo_odbc/odbc_driver.c
+++ b/thirdparty/php83/pdo_odbc/odbc_driver.c
@@ -25,6 +25,7 @@
 #include "pdo/php_pdo.h"
 #include "pdo/php_pdo_driver.h"
 #include "zend_exceptions.h"
+#include <php_odbc_utils.h>
 
 static void pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) {
     pdo_odbc_db_handle *H = (pdo_odbc_db_handle *) dbh->driver_data;


### PR DESCRIPTION
**1/  [-Wimplicit-function-declaration]**

```
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_odbc/odbc_driver.c: In function 'pdo_odbc_handle_factory':
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_odbc/odbc_driver.c:536:18: error: implicit declaration of function 'php_odbc_connstr_is_quoted' [-Wimplicit-function-declaration]
  536 |                 !php_odbc_connstr_is_quoted(dbh->username) && php_odbc_connstr_should_quote(dbh->username);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_odbc/odbc_driver.c:536:63: error: implicit declaration of function 'php_odbc_connstr_should_quote' [-Wimplicit-function-declaration]
  536 |                 !php_odbc_connstr_is_quoted(dbh->username) && php_odbc_connstr_should_quote(dbh->username);
      |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_odbc/odbc_driver.c:540:43: error: implicit declaration of function 'php_odbc_connstr_estimate_quote_length' [-Wimplicit-function-declaration]
  540 |                 size_t estimated_length = php_odbc_connstr_estimate_quote_length(dbh->username);
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_odbc/odbc_driver.c:542:17: error: implicit declaration of function 'php_odbc_connstr_quote' [-Wimplicit-function-declaration]
  542 |                 php_odbc_connstr_quote(uid, dbh->username, estimated_length);
      |                 ^~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:618: thirdparty/php83/pdo_odbc/odbc_driver.lo] Error 1
```

**2/ [-Wimplicit-int]**

```
In file included from /builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_sqlite/sqlite_driver.c:18:
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/thirdparty/php83/pdo_sqlite/sqlite_driver.c: In function 'do_callback':
/builddir/build/BUILD/php83-php-pecl-swoole5-5.1.3/swoole-5.1.3/ext-src/php_swoole_call_stack.h:21:10: error: type defaults to 'int' in declaration of '__stack_limit' [-Wimplicit-int]
   21 |     auto __stack_limit = EG(stack_limit);                                                                              \
      |          ^~~~~~~~~~~~~

```