### PR TITLE
swoole v6 : fix multiple definition of _tsrm_ls_cache on swoole-cli

### DIFF
--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -44,6 +44,7 @@ static struct {
 } request_info;
 
 //TSRMLS_CACHE_DEFINE();
+TSRMLS_CACHE_EXTERN()
 
 typedef std::thread Thread;
 

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -43,7 +43,6 @@ static struct {
     int argc;
 } request_info;
 
-//TSRMLS_CACHE_DEFINE();
 TSRMLS_CACHE_EXTERN()
 
 typedef std::thread Thread;

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -43,7 +43,7 @@ static struct {
     int argc;
 } request_info;
 
-TSRMLS_CACHE_EXTERN()
+TSRMLS_CACHE_EXTERN();
 
 typedef std::thread Thread;
 

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -43,7 +43,7 @@ static struct {
     int argc;
 } request_info;
 
-TSRMLS_CACHE_DEFINE();
+//TSRMLS_CACHE_DEFINE();
 
 typedef std::thread Thread;
 


### PR DESCRIPTION
swoole v6 : fix multiple definition of _tsrm_ls_cache on swoole-cli

/usr/bin/ld: Zend/zend.o:(.tbss+0x0): multiple definition of `_tsrm_ls_cache'; ext/swoole/ext-src/swoole_thread.o:(.tbss+0x0): first defined here

<img width="1374" alt="image" src="https://github.com/swoole/swoole-src/assets/6836228/dc95087b-145f-4e33-b451-09a04552018b">


reference ：

https://github.com/php/php-src/blob/master/TSRM/TSRM.h#L179
https://github.com/php/php-src/blob/d1f14a46095571b1b6363fa7f83c6a681d1d02de/TSRM/TSRM.h#L183
https://github.com/php/php-src/blob/5a03ff4f6cb6db91ed3d393a31927065808ca991/TSRM/TSRM.h#L181
https://github.com/php/php-src/blob/d1f14a46095571b1b6363fa7f83c6a681d1d02de/TSRM/TSRM.h#L178
https://github.com/search?q=repo%3Aphp%2Fphp-src+TSRMLS_CACHE_DEFINE()&type=code&p=1

