### PR TITLE
Upgrade to Oracle Database Free

### DIFF
--- a/examples/runtime/oci.php
+++ b/examples/runtime/oci.php
@@ -1,7 +1,7 @@
 <?php
 function test()
 {
-	$tsn = 'oci:dbname=127.0.0.1:1521/xe;charset=AL32UTF8';
+	$tsn = 'oci:dbname=127.0.0.1:1521/freepdb1;charset=AL32UTF8';
 	$username = "";
 	$password = "";
     try {

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       POSTGRES_DB: test
       POSTGRES_PASSWORD: root
   oracle:
-    image: gvenzl/oracle-xe:slim
+    image: gvenzl/oracle-free:slim
     container_name: "oracle"
     environment:
       ORACLE_PASSWORD: oracle


### PR DESCRIPTION
Hey all,

Thanks a lot for using my Oracle Database images.
I have noticed that you are still using the old Oracle Database XE version of my images.

Oracle has discontinued Oracle Database XE and instead offers Oracle Database Free as the successor, which was first released last year.

The database editions are compatible, hence nothing should break or change other than the connect string and the Docker image tag.

I have taken the liberty to provide the modifications based on what I could find in the repository.

Thanks,