### PR TITLE
Replace PHP_DEF_HAVE with AC_DEFINE_UNQUOTED

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -134,7 +134,8 @@ AC_DEFUN([PDO_ODBC_CHECK_HEADER],[
   AC_MSG_CHECKING([for $1 in $PDO_ODBC_INCDIR])
   if test -f "$PDO_ODBC_INCDIR/$1"; then
     php_pdo_have_header=yes
-    PHP_DEF_HAVE(translit($1,.,_))
+    AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), [1],
+      [Define to 1 if you have the <$1> header file.])
     AC_MSG_RESULT(yes)
   else
     AC_MSG_RESULT(no)


### PR DESCRIPTION
The upstream PHP_DEF_HAVE macro is a bit simplistic wrapper around the recommended AC_DEFINE or AC_DEFINE_UNQUOTED (when shell variables are used in arguments). This also adds some basic help texts to macros.