### PR TITLE
Add missing field declaration from PipeMessage object for "worker_id"

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -515,6 +515,7 @@ void php_swoole_server_minit(int module_number) {
     // ---------------------------------------PipeMessage-------------------------------------
     SW_INIT_CLASS_ENTRY_DATA_OBJECT(swoole_server_pipe_message, "Swoole\\Server\\PipeMessage");
     zend_declare_property_long(swoole_server_pipe_message_ce, ZEND_STRL("source_worker_id"), 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(swoole_server_pipe_message_ce, ZEND_STRL("worker_id"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_double(swoole_server_pipe_message_ce, ZEND_STRL("dispatch_time"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_null(swoole_server_pipe_message_ce, ZEND_STRL("data"), ZEND_ACC_PUBLIC);
     // ---------------------------------------StatusInfo-------------------------------------


### PR DESCRIPTION
In swoole-5.1.3 and most likely all newer versions (6.0.0 included) when using the object api for the PipeMessage callback, the code sets the field "worker_id" that is not declared on the object structure leading to a deprecation warning being triggered for PHP 8.2 and beyond. 