### PR TITLE
[5.1] Fix some functions that have been replaced

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -340,7 +340,18 @@ SW_API bool php_swoole_is_enable_coroutine() {
 
 SW_API zend_long php_swoole_parse_to_size(zval *zv) {
     if (ZVAL_IS_STRING(zv)) {
+#if PHP_VERSION_ID >= 80200
+        zend_string *errstr;
+        auto size = zend_ini_parse_quantity(Z_STR_P(zv), &errstr);
+        if (errstr) {
+            php_swoole_fatal_error(
+                E_ERROR, "failed to parse '%s' to size, Error: %s", Z_STRVAL_P(zv), ZSTR_VAL(errstr));
+            zend_string_release(errstr);
+        }
+        return size;
+#else
         return zend_atol(Z_STRVAL_P(zv), Z_STRLEN_P(zv));
+#endif
     } else {
         return zval_get_long(zv);
     }

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -229,6 +229,7 @@ static int coro_exit_handler(zend_execute_data *execute_data) {
     return ZEND_USER_OPCODE_DISPATCH;
 }
 #else
+SW_EXTERN_C_BEGIN
 extern ZEND_FUNCTION(exit);
 PHP_FUNCTION(swoole_exit) {
     zend_string *message = NULL;
@@ -259,6 +260,7 @@ PHP_FUNCTION(swoole_exit) {
         ZEND_FN(exit)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     }
 }
+SW_EXTERN_C_END
 #endif
 
 static int coro_begin_silence_handler(zend_execute_data *execute_data) {

--- a/ext-src/swoole_redis_server.cc
+++ b/ext-src/swoole_redis_server.cc
@@ -156,7 +156,11 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
 
     char _command[SW_REDIS_MAX_COMMAND_SIZE];
     size_t _command_len = sw_snprintf(_command, sizeof(_command), "_handler_%.*s", command_len, command);
+#if PHP_VERSION_ID >= 80400
+    zend_str_tolower(_command, _command_len);
+#else
     php_strtolower(_command, _command_len);
+#endif
 
     auto i = redis_handlers.find(std::string(_command, _command_len));
     if (i == redis_handlers.end()) {
@@ -214,7 +218,11 @@ static PHP_METHOD(swoole_redis_server, setHandler) {
 
     char _command[SW_REDIS_MAX_COMMAND_SIZE];
     size_t _command_len = sw_snprintf(_command, sizeof(_command), "_handler_%s", command);
+#if PHP_VERSION_ID >= 80400
+    zend_str_tolower(_command, _command_len);
+#else
     php_strtolower(_command, _command_len);
+#endif
 
     zend_update_property(swoole_redis_server_ce, SW_Z8_OBJ_P(ZEND_THIS), _command, _command_len, zcallback);
 
@@ -240,7 +248,11 @@ static PHP_METHOD(swoole_redis_server, getHandler) {
 
     char _command[SW_REDIS_MAX_COMMAND_SIZE];
     size_t _command_len = sw_snprintf(_command, sizeof(_command), "_handler_%s", command);
+#if PHP_VERSION_ID >= 80400
+    zend_str_tolower(_command, _command_len);
+#else
     php_strtolower(_command, _command_len);
+#endif
 
     zval rv;
     zval *handler = zend_read_property(swoole_redis_server_ce, SW_Z8_OBJ_P(ZEND_THIS), _command, _command_len, 1, &rv);

--- a/tests/swoole_server/parse_option_to_size.phpt
+++ b/tests/swoole_server/parse_option_to_size.phpt
@@ -1,7 +1,12 @@
 --TEST--
 swoole_server: parse option value to size
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+if (PHP_VERSION_ID < 80200) {
+    require __DIR__ . '/../include/skipif.inc';
+    skip('php version 8.2 or higher');
+}
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';

--- a/tests/swoole_server/parse_option_to_size.phpt
+++ b/tests/swoole_server/parse_option_to_size.phpt
@@ -1,0 +1,23 @@
+--TEST--
+swoole_server: parse option value to size
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', SWOOLE_BASE);
+$server->set([
+    'buffer_output_size' => '2M',
+]);
+$server->set([
+    'buffer_output_size' => 2 * 1024 * 1024,
+]);
+$server->set([
+    'buffer_output_size' => 'xxx--2M',
+]);
+?>
+--EXPECTF--
+Fatal error: Swoole\Server::set(): failed to parse 'xxx--2M' to size, Error: Invalid quantity "xxx--2M": no valid leading digits, interpreting as "0" for backwards compatibility in %s on line %d


### PR DESCRIPTION
The php_strtoupper(), php_string_toupper(), php_strtolower(), and php_string_tolower() functions has been removed, use zend_str_toupper(), zend_string_toupper(), zend_str_tolower(), and zend_string_tolower() respectively instead