### PR TITLE
Optimize the implementation of callbacks and callables.

### DIFF
--- a/core-tests/src/core/base.cpp
+++ b/core-tests/src/core/base.cpp
@@ -223,17 +223,6 @@ static std::string test_func(std::string test_data_2) {
     return test_data + test_data_2;
 }
 
-TEST(base, add_function) {
-    typedef std::string (*_func_t)(std::string);
-    swoole_add_function("test_func", (void *) test_func);
-    ASSERT_EQ(swoole_add_function("test_func", (void *) test_func), SW_ERR);
-    _func_t _func = (_func_t) swoole_get_function(SW_STRL("test_func"));
-    std::string b = ", swoole is best";
-    auto rs = _func(", swoole is best");
-    ASSERT_EQ(rs, test_data + b);
-    ASSERT_EQ(swoole_get_function(SW_STRL("test_func31")), nullptr);
-}
-
 TEST(base, hook) {
     int count = 0;
     swoole_add_hook(

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -615,6 +615,10 @@ namespace function {
 /* must use this API to call event callbacks to ensure that exceptions are handled correctly */
 bool call(zend_fcall_info_cache *fci_cache, uint32_t argc, zval *argv, zval *retval, const bool enable_coroutine);
 Variable call(const std::string &func_name, int argc, zval *argv);
+
+static inline bool call(Callable *cb, uint32_t argc, zval *argv, zval *retval, const bool enable_coroutine) {
+    return call(cb->ptr(), argc, argv, retval, enable_coroutine);
+}
 }  // namespace function
 
 struct Function {

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -709,11 +709,11 @@ static inline void print_error(zend_object *exception, int severity) {
 }  // namespace zend
 
 /* use void* to match some C callback function pointers */
-static sw_inline void sw_callable_free(void *fci_cache) {
-    delete (zend::Callable *) fci_cache;
+static inline void sw_callable_free(void *ptr) {
+    delete (zend::Callable *) ptr;
 }
 
-static zend::Callable *sw_callable_create(zval *zfn) {
+static inline zend::Callable *sw_callable_create(zval *zfn) {
     auto fn = new zend::Callable(zfn);
     if (fn->ready()) {
         return fn;
@@ -721,9 +721,4 @@ static zend::Callable *sw_callable_create(zval *zfn) {
         delete fn;
         return nullptr;
     }
-}
-
-static inline void php_swoole_callable_free(void *ptr) {
-    zend::Callable *cb = (zend::Callable *) ptr;
-    delete cb;
 }

--- a/ext-src/php_swoole_cxx.h
+++ b/ext-src/php_swoole_cxx.h
@@ -605,6 +605,7 @@ class Callable {
         auto copy = new Callable();
         copy->fcc = fcc;
         copy->zfn = zfn;
+        zval_add_ref(&copy->zfn);
         if (fn_name) {
             copy->fn_name = estrdup(fn_name);
         }

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -978,6 +978,20 @@ static sw_inline void sw_zend_fci_cache_free(void *fci_cache) {
     efree((zend_fcall_info_cache *) fci_cache);
 }
 
+static zend_fcall_info_cache *sw_zend_fci_cache_create(zval *zfn) {
+    char *func_name = nullptr;
+    zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
+    if (!sw_zend_is_callable_ex(zfn, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
+        php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
+        efree(fci_cache);
+        efree(func_name);
+        return nullptr;
+    }
+    efree(func_name);
+    sw_zend_fci_cache_persist(fci_cache);
+    return fci_cache;
+}
+
 #if PHP_VERSION_ID >= 80100
 #define sw_php_spl_object_hash(o) php_spl_object_hash(Z_OBJ_P(o))
 #else

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -979,10 +979,14 @@ static sw_inline void sw_zend_fci_cache_free(void *fci_cache) {
 }
 
 static zend_fcall_info_cache *sw_zend_fci_cache_create(zval *zfn) {
+    if (!zval_is_true(zfn)) {
+        php_swoole_fatal_error(E_WARNING, "illegal callback function");
+        return nullptr;
+    }
     char *func_name = nullptr;
     zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
     if (!sw_zend_is_callable_ex(zfn, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-        php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
+        php_swoole_fatal_error(E_WARNING, "function '%s' is not callable", func_name);
         efree(fci_cache);
         efree(func_name);
         return nullptr;

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -972,30 +972,6 @@ static sw_inline void sw_zend_fci_cache_discard(zend_fcall_info_cache *fci_cache
     }
 }
 
-/* use void* to match some C callback function pointers */
-static sw_inline void sw_zend_fci_cache_free(void *fci_cache) {
-    sw_zend_fci_cache_discard((zend_fcall_info_cache *) fci_cache);
-    efree((zend_fcall_info_cache *) fci_cache);
-}
-
-static zend_fcall_info_cache *sw_zend_fci_cache_create(zval *zfn) {
-    if (!zval_is_true(zfn)) {
-        php_swoole_fatal_error(E_WARNING, "illegal callback function");
-        return nullptr;
-    }
-    char *func_name = nullptr;
-    zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
-    if (!sw_zend_is_callable_ex(zfn, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-        php_swoole_fatal_error(E_WARNING, "function '%s' is not callable", func_name);
-        efree(fci_cache);
-        efree(func_name);
-        return nullptr;
-    }
-    efree(func_name);
-    sw_zend_fci_cache_persist(fci_cache);
-    return fci_cache;
-}
-
 #if PHP_VERSION_ID >= 80100
 #define sw_php_spl_object_hash(o) php_spl_object_hash(Z_OBJ_P(o))
 #else

--- a/ext-src/php_swoole_server.h
+++ b/ext-src/php_swoole_server.h
@@ -86,7 +86,7 @@ struct ServerProperty {
     std::unordered_map<TaskId, zend::Callable *> task_callbacks;
     std::unordered_map<TaskId, TaskCo *> task_coroutine_map;
     std::unordered_map<SessionId, std::list<Coroutine *> *> send_coroutine_map;
-    std::vector<zend_fcall_info_cache *> command_callbacks;
+    std::vector<zend::Callable *> command_callbacks;
 };
 
 struct ServerObject {
@@ -108,8 +108,8 @@ struct ServerObject {
         return property->callbacks[event_type] != nullptr;
     }
 
-    zend_fcall_info_cache *get_callback(int event_type) {
-        return property->callbacks[event_type]->ptr();
+    zend::Callable *get_callback(int event_type) {
+        return property->callbacks[event_type];
     }
 
     zend_bool is_websocket_server() {
@@ -138,7 +138,7 @@ void register_admin_server_commands(Server *serv);
 }  // namespace swoole
 
 void php_swoole_server_register_callbacks(swServer *serv);
-zend_fcall_info_cache *php_swoole_server_get_fci_cache(swServer *serv, int server_fd, int event_type);
+zend::Callable *php_swoole_server_get_callback(swServer *serv, int server_fd, int event_type);
 int php_swoole_create_dir(const char *path, size_t length);
 void php_swoole_server_before_start(swServer *serv, zval *zobject);
 bool php_swoole_server_isset_callback(swServer *serv, swListenPort *port, int event_type);

--- a/ext-src/php_swoole_server.h
+++ b/ext-src/php_swoole_server.h
@@ -73,9 +73,7 @@ void php_swoole_server_set_port_property(swoole::ListenPort *port, swoole::Serve
 namespace swoole {
 
 struct ServerPortProperty {
-    zval *callbacks[PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM];
-    zend_fcall_info_cache *caches[PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM];
-    zval _callbacks[PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM];
+    zend::Callable *callbacks[PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM];
     Server *serv;
     ListenPort *port;
     zval *zsetting;
@@ -84,8 +82,8 @@ struct ServerPortProperty {
 struct ServerProperty {
     std::vector<zval *> ports;
     std::vector<zval *> user_processes;
-    zend_fcall_info_cache *callbacks[PHP_SWOOLE_SERVER_CALLBACK_NUM];
-    std::unordered_map<TaskId, zend_fcall_info_cache> task_callbacks;
+    zend::Callable *callbacks[PHP_SWOOLE_SERVER_CALLBACK_NUM];
+    std::unordered_map<TaskId, zend::Callable *> task_callbacks;
     std::unordered_map<TaskId, TaskCo *> task_coroutine_map;
     std::unordered_map<SessionId, std::list<Coroutine *> *> send_coroutine_map;
     std::vector<zend_fcall_info_cache *> command_callbacks;
@@ -104,6 +102,14 @@ struct ServerObject {
     bool isset_callback(ListenPort *port, int event_type) {
         return (php_swoole_server_get_port_property(port)->callbacks[event_type] ||
                 php_swoole_server_get_port_property(serv->get_primary_port())->callbacks[event_type]);
+    }
+
+    bool isset_callback(int event_type) {
+        return property->callbacks[event_type] != nullptr;
+    }
+
+    zend_fcall_info_cache *get_callback(int event_type) {
+        return property->callbacks[event_type]->ptr();
     }
 
     zend_bool is_websocket_server() {

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -335,10 +335,10 @@ bool php_swoole_client_check_setting(Client *cli, zval *zset) {
             return false;
         }
         cli->protocol.get_package_length = php_swoole_length_func;
-        if (cli->protocol.cb) {
-            sw_callable_free(cli->protocol.cb);
+        if (cli->protocol.private_data_1) {
+            sw_callable_free(cli->protocol.private_data_1);
         }
-        cli->protocol.cb = fci_cache;
+        cli->protocol.private_data_1 = fci_cache;
         cli->protocol.package_length_size = 0;
         cli->protocol.package_length_type = '\0';
         cli->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
@@ -487,9 +487,9 @@ static void php_swoole_client_free(zval *zobject, Client *cli) {
         swoole_timer_del(cli->timer);
         cli->timer = nullptr;
     }
-    if (cli->protocol.cb) {
-        sw_callable_free(cli->protocol.cb);
-        cli->protocol.cb = nullptr;
+    if (cli->protocol.private_data_1) {
+        sw_callable_free(cli->protocol.private_data_1);
+        cli->protocol.private_data_1 = nullptr;
     }
     // long tcp connection, delete from php_sw_long_connections
     if (cli->keep) {
@@ -518,7 +518,7 @@ static void php_swoole_client_free(zval *zobject, Client *cli) {
 }
 
 ssize_t php_swoole_length_func(const Protocol *protocol, Socket *_socket, PacketLength *pl) {
-    zend::Callable *cb = (zend::Callable *) protocol->cb;
+    zend::Callable *cb = (zend::Callable *) protocol->private_data_1;
     zval zdata;
     zval retval;
     ssize_t ret = -1;

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -34,19 +34,6 @@ using swoole::String;
 using swoole::network::Client;
 using swoole::network::Socket;
 
-struct ClientCallback {
-    zend_fcall_info_cache cache_onConnect;
-    zend_fcall_info_cache cache_onReceive;
-    zend_fcall_info_cache cache_onClose;
-    zend_fcall_info_cache cache_onError;
-    zend_fcall_info_cache cache_onBufferFull;
-    zend_fcall_info_cache cache_onBufferEmpty;
-#ifdef SW_USE_OPENSSL
-    zend_fcall_info_cache cache_onSSLReady;
-#endif
-    zval _object;
-};
-
 static std::unordered_map<std::string, std::queue<Client *> *> long_connections;
 
 zend_class_entry *swoole_client_ce;
@@ -58,7 +45,6 @@ static zend_object_handlers swoole_client_exception_handlers;
 struct ClientObject {
     Client *cli;
     zval *zsocket;
-    ClientCallback *cb;
     zend_object std;
 };
 
@@ -86,14 +72,6 @@ static sw_inline void php_swoole_client_set_zsocket(zval *zobject, zval *zsocket
     php_swoole_client_fetch_object(Z_OBJ_P(zobject))->zsocket = zsocket;
 }
 #endif
-
-static sw_inline ClientCallback *php_swoole_client_get_cb(zval *zobject) {
-    return php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cb;
-}
-
-static sw_inline void php_swoole_client_set_cb(zval *zobject, ClientCallback *cb) {
-    php_swoole_client_fetch_object(Z_OBJ_P(zobject))->cb = cb;
-}
 
 static void php_swoole_client_free_object(zend_object *object) {
     zend_object_std_dtor(object);
@@ -357,10 +335,10 @@ bool php_swoole_client_check_setting(Client *cli, zval *zset) {
             return false;
         }
         cli->protocol.get_package_length = php_swoole_length_func;
-        if (cli->protocol.private_data) {
-            sw_callable_free(cli->protocol.private_data);
+        if (cli->protocol.cb) {
+            sw_callable_free(cli->protocol.cb);
         }
-        cli->protocol.private_data = fci_cache;
+        cli->protocol.cb = fci_cache;
         cli->protocol.package_length_size = 0;
         cli->protocol.package_length_type = '\0';
         cli->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
@@ -509,9 +487,9 @@ static void php_swoole_client_free(zval *zobject, Client *cli) {
         swoole_timer_del(cli->timer);
         cli->timer = nullptr;
     }
-    if (cli->protocol.private_data) {
-        sw_callable_free(cli->protocol.private_data);
-        cli->protocol.private_data = nullptr;
+    if (cli->protocol.cb) {
+        sw_callable_free(cli->protocol.cb);
+        cli->protocol.cb = nullptr;
     }
     // long tcp connection, delete from php_sw_long_connections
     if (cli->keep) {
@@ -540,14 +518,14 @@ static void php_swoole_client_free(zval *zobject, Client *cli) {
 }
 
 ssize_t php_swoole_length_func(const Protocol *protocol, Socket *_socket, PacketLength *pl) {
-    zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) protocol->private_data;
+    zend::Callable *cb = (zend::Callable *) protocol->cb;
     zval zdata;
     zval retval;
     ssize_t ret = -1;
 
     // TODO: reduce memory copy
     ZVAL_STRINGL(&zdata, pl->buf, pl->buf_size);
-    if (UNEXPECTED(sw_zend_call_function_ex2(nullptr, fci_cache, 1, &zdata, &retval) != SUCCESS)) {
+    if (UNEXPECTED(sw_zend_call_function_ex2(nullptr, cb->ptr(), 1, &zdata, &retval) != SUCCESS)) {
         php_swoole_fatal_error(E_WARNING, "length function handler error");
     } else {
         ret = zval_get_long(&retval);
@@ -667,7 +645,6 @@ static PHP_METHOD(swoole_client, __construct) {
     }
     // init
     php_swoole_client_set_cli(ZEND_THIS, nullptr);
-    php_swoole_client_set_cb(ZEND_THIS, nullptr);
 #ifdef SWOOLE_SOCKETS_SUPPORT
     php_swoole_client_set_zsocket(ZEND_THIS, nullptr);
 #endif
@@ -681,12 +658,6 @@ static PHP_METHOD(swoole_client, __destruct) {
     // no keep connection
     if (cli) {
         sw_zend_call_method_with_0_params(ZEND_THIS, swoole_client_ce, nullptr, "close", nullptr);
-    }
-    // free memory
-    ClientCallback *cb = php_swoole_client_get_cb(ZEND_THIS);
-    if (cb) {
-        efree(cb);
-        php_swoole_client_set_cb(ZEND_THIS, nullptr);
     }
 }
 

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -352,13 +352,13 @@ bool php_swoole_client_check_setting(Client *cli, zval *zset) {
     }
     // length function
     if (php_swoole_array_get_value(vht, "package_length_func", ztmp)) {
-        auto fci_cache = sw_zend_fci_cache_create(ztmp);
+        auto fci_cache = sw_callable_create(ztmp);
         if (!fci_cache) {
             return false;
         }
         cli->protocol.get_package_length = php_swoole_length_func;
         if (cli->protocol.private_data) {
-            sw_zend_fci_cache_free((zend_fcall_info_cache *) cli->protocol.private_data);
+            sw_callable_free(cli->protocol.private_data);
         }
         cli->protocol.private_data = fci_cache;
         cli->protocol.package_length_size = 0;
@@ -510,7 +510,7 @@ static void php_swoole_client_free(zval *zobject, Client *cli) {
         cli->timer = nullptr;
     }
     if (cli->protocol.private_data) {
-        sw_zend_fci_cache_free((zend_fcall_info_cache *) cli->protocol.private_data);
+        sw_callable_free(cli->protocol.private_data);
         cli->protocol.private_data = nullptr;
     }
     // long tcp connection, delete from php_sw_long_connections

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -131,9 +131,9 @@ static zend_object *client_coro_create_object(zend_class_entry *ce) {
 }
 
 static void client_coro_socket_dtor(ClientCoroObject *client) {
-    if (client->socket->protocol.cb) {
-        sw_callable_free(client->socket->protocol.cb);
-        client->socket->protocol.cb = nullptr;
+    if (client->socket->protocol.private_data_1) {
+        sw_callable_free(client->socket->protocol.private_data_1);
+        client->socket->protocol.private_data_1 = nullptr;
     }
     client->socket = nullptr;
     zend_update_property_null(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("socket"));

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -132,7 +132,7 @@ static zend_object *client_coro_create_object(zend_class_entry *ce) {
 
 static void client_coro_socket_dtor(ClientCoroObject *client) {
     if (client->socket->protocol.private_data) {
-        sw_zend_fci_cache_free((zend_fcall_info_cache *) client->socket->protocol.private_data);
+        sw_callable_free(client->socket->protocol.private_data);
         client->socket->protocol.private_data = nullptr;
     }
     client->socket = nullptr;

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -131,9 +131,9 @@ static zend_object *client_coro_create_object(zend_class_entry *ce) {
 }
 
 static void client_coro_socket_dtor(ClientCoroObject *client) {
-    if (client->socket->protocol.private_data) {
-        sw_callable_free(client->socket->protocol.private_data);
-        client->socket->protocol.private_data = nullptr;
+    if (client->socket->protocol.cb) {
+        sw_callable_free(client->socket->protocol.cb);
+        client->socket->protocol.cb = nullptr;
     }
     client->socket = nullptr;
     zend_update_property_null(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("socket"));

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -132,8 +132,7 @@ static zend_object *client_coro_create_object(zend_class_entry *ce) {
 
 static void client_coro_socket_dtor(ClientCoroObject *client) {
     if (client->socket->protocol.private_data) {
-        sw_zend_fci_cache_discard((zend_fcall_info_cache *) client->socket->protocol.private_data);
-        efree(client->socket->protocol.private_data);
+        sw_zend_fci_cache_free((zend_fcall_info_cache *) client->socket->protocol.private_data);
         client->socket->protocol.private_data = nullptr;
     }
     client->socket = nullptr;

--- a/ext-src/swoole_coroutine_scheduler.cc
+++ b/ext-src/swoole_coroutine_scheduler.cc
@@ -136,8 +136,8 @@ void php_swoole_coroutine_scheduler_rshutdown() {
     });
 
     if (exit_condition_fci_cache) {
-        exit_condition_fci_cache = nullptr;
         sw_zend_fci_cache_free(exit_condition_fci_cache);
+        exit_condition_fci_cache = nullptr;
     }
 }
 

--- a/ext-src/swoole_coroutine_scheduler.cc
+++ b/ext-src/swoole_coroutine_scheduler.cc
@@ -106,16 +106,15 @@ void php_swoole_coroutine_scheduler_minit(int module_number) {
     swoole_coroutine_scheduler_ce->ce_flags |= ZEND_ACC_FINAL;
 }
 
-static zend_fcall_info_cache exit_condition_fci_cache;
-static bool exit_condition_cleaner;
+static zend_fcall_info_cache *exit_condition_fci_cache = nullptr;
 
 static bool php_swoole_coroutine_reactor_can_exit(Reactor *reactor, size_t &event_num) {
     zval retval;
     int success;
 
-    SW_ASSERT(exit_condition_fci_cache.function_handler);
+    SW_ASSERT(exit_condition_fci_cache);
     ZVAL_NULL(&retval);
-    success = sw_zend_call_function_ex(nullptr, &exit_condition_fci_cache, 0, nullptr, &retval);
+    success = sw_zend_call_function_ex(nullptr, exit_condition_fci_cache, 0, nullptr, &retval);
     if (UNEXPECTED(success != SUCCESS)) {
         php_swoole_fatal_error(E_ERROR, "Coroutine can_exit callback handler error");
     }
@@ -135,6 +134,11 @@ void php_swoole_coroutine_scheduler_rshutdown() {
             return SW_TRAVERSE_KEEP;
         }
     });
+
+    if (exit_condition_fci_cache) {
+        exit_condition_fci_cache = nullptr;
+        sw_zend_fci_cache_free(exit_condition_fci_cache);
+    }
 }
 
 void php_swoole_set_coroutine_option(zend_array *vht) {
@@ -194,33 +198,16 @@ PHP_METHOD(swoole_coroutine_scheduler, set) {
     }
     /* Reactor can exit */
     if ((ztmp = zend_hash_str_find(vht, ZEND_STRL("exit_condition")))) {
-        char *func_name;
-        if (exit_condition_fci_cache.function_handler) {
-            sw_zend_fci_cache_discard(&exit_condition_fci_cache);
-            exit_condition_fci_cache.function_handler = nullptr;
+        if (exit_condition_fci_cache) {
+            sw_zend_fci_cache_free(&exit_condition_fci_cache);
         }
-        if (!ZVAL_IS_NULL(ztmp)) {
-            if (!sw_zend_is_callable_ex(ztmp, nullptr, 0, &func_name, nullptr, &exit_condition_fci_cache, nullptr)) {
-                php_swoole_fatal_error(E_ERROR, "exit_condition '%s' is not callable", func_name);
-            } else {
-                efree(func_name);
-                sw_zend_fci_cache_persist(&exit_condition_fci_cache);
-                if (!exit_condition_cleaner) {
-                    php_swoole_register_rshutdown_callback(
-                        [](void *data) {
-                            if (exit_condition_fci_cache.function_handler) {
-                                sw_zend_fci_cache_discard(&exit_condition_fci_cache);
-                                exit_condition_fci_cache.function_handler = nullptr;
-                            }
-                        },
-                        nullptr);
-                    exit_condition_cleaner = true;
-                }
-                SwooleG.user_exit_condition = php_swoole_coroutine_reactor_can_exit;
-                if (sw_reactor()) {
-                    sw_reactor()->set_exit_condition(Reactor::EXIT_CONDITION_USER_AFTER_DEFAULT,
-                                                     SwooleG.user_exit_condition);
-                }
+
+        exit_condition_fci_cache = sw_zend_fci_cache_create(ztmp);
+        if (exit_condition_fci_cache) {
+            SwooleG.user_exit_condition = php_swoole_coroutine_reactor_can_exit;
+            if (sw_reactor()) {
+                sw_reactor()->set_exit_condition(Reactor::EXIT_CONDITION_USER_AFTER_DEFAULT,
+                                                 SwooleG.user_exit_condition);
             }
         } else {
             if (sw_reactor()) {

--- a/ext-src/swoole_event.cc
+++ b/ext-src/swoole_event.cc
@@ -434,14 +434,14 @@ static PHP_FUNCTION(swoole_event_add) {
         RETURN_FALSE;
     }
 
-    auto readable_callback = sw_callable_create(zreadable_callback);
+    auto readable_callback = zreadable_callback ? sw_callable_create(zreadable_callback) : nullptr;
     if ((events & SW_EVENT_READ) && readable_callback == nullptr) {
         php_swoole_fatal_error(
             E_WARNING, "%s: unable to find readable callback of fd [%d]", ZSTR_VAL(swoole_event_ce->name), socket_fd);
         RETURN_FALSE;
     }
 
-    auto writable_callback = sw_callable_create(zwritable_callback);
+    auto writable_callback = zwritable_callback ? sw_callable_create(zwritable_callback) : nullptr;
     if ((events & SW_EVENT_WRITE) && writable_callback == nullptr) {
         php_swoole_fatal_error(
             E_WARNING, "%s: unable to find writable callback of fd [%d]", ZSTR_VAL(swoole_event_ce->name), socket_fd);

--- a/ext-src/swoole_event.cc
+++ b/ext-src/swoole_event.cc
@@ -543,13 +543,13 @@ static PHP_FUNCTION(swoole_event_set) {
     auto writable_callback = sw_callable_create(zwritable_callback);
     if (readable_callback) {
         if (peo->readable_callback) {
-            swoole_event_defer(php_swoole_callable_free, peo->readable_callback);
+            swoole_event_defer(sw_callable_free, peo->readable_callback);
         }
         peo->readable_callback = readable_callback;
     }
     if (writable_callback) {
         if (peo->writable_callback) {
-            swoole_event_defer(php_swoole_callable_free, peo->writable_callback);
+            swoole_event_defer(sw_callable_free, peo->writable_callback);
         }
         peo->writable_callback = writable_callback;
     }
@@ -633,7 +633,7 @@ static PHP_FUNCTION(swoole_event_cycle) {
         if (sw_reactor()->idle_task.callback == nullptr) {
             RETURN_FALSE;
         } else {
-            swoole_event_defer(php_swoole_callable_free, sw_reactor()->idle_task.data);
+            swoole_event_defer(sw_callable_free, sw_reactor()->idle_task.data);
             sw_reactor()->idle_task.callback = nullptr;
             sw_reactor()->idle_task.data = nullptr;
             RETURN_TRUE;
@@ -642,14 +642,14 @@ static PHP_FUNCTION(swoole_event_cycle) {
 
     if (!before) {
         if (sw_reactor()->idle_task.data != nullptr) {
-            swoole_event_defer(php_swoole_callable_free, sw_reactor()->idle_task.data);
+            swoole_event_defer(sw_callable_free, sw_reactor()->idle_task.data);
         }
 
         sw_reactor()->idle_task.callback = event_end_callback;
         sw_reactor()->idle_task.data = callback;
     } else {
         if (sw_reactor()->future_task.data != nullptr) {
-            swoole_event_defer(php_swoole_callable_free, sw_reactor()->future_task.data);
+            swoole_event_defer(sw_callable_free, sw_reactor()->future_task.data);
         }
 
         sw_reactor()->future_task.callback = event_end_callback;

--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -247,9 +247,9 @@ static void http2_server_onRequest(Http2Session *client, Http2Stream *stream) {
     Server *serv = (Server *) ctx->private_data;
     zval args[2];
     Connection *serv_sock = nullptr;
+    zend::Callable *cb = nullptr;
     int server_fd = 0;
 
-    zend::Callable *cb = php_swoole_server_get_callback(serv, server_fd, SW_SERVER_CB_onRequest);
     Connection *conn = serv->get_connection_by_session_id(ctx->fd);
     if (!conn) {
         goto _destroy;
@@ -274,6 +274,7 @@ static void http2_server_onRequest(Http2Session *client, Http2Stream *stream) {
     add_assoc_long(zserver, "master_time", conn->last_recv_time);
     add_assoc_string(zserver, "server_protocol", (char *) "HTTP/2");
 
+    cb = php_swoole_server_get_callback(serv, server_fd, SW_SERVER_CB_onRequest);
     ctx->private_data_2 = cb;
 
     if (ctx->onBeforeRequest && !ctx->onBeforeRequest(ctx)) {

--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -246,10 +246,10 @@ static void http2_server_onRequest(Http2Session *client, Http2Stream *stream) {
     zval *zserver = ctx->request.zserver;
     Server *serv = (Server *) ctx->private_data;
     zval args[2];
-    zend_fcall_info_cache *fci_cache = nullptr;
     Connection *serv_sock = nullptr;
     int server_fd = 0;
 
+    zend::Callable *cb = php_swoole_server_get_callback(serv, server_fd, SW_SERVER_CB_onRequest);
     Connection *conn = serv->get_connection_by_session_id(ctx->fd);
     if (!conn) {
         goto _destroy;
@@ -274,8 +274,7 @@ static void http2_server_onRequest(Http2Session *client, Http2Stream *stream) {
     add_assoc_long(zserver, "master_time", conn->last_recv_time);
     add_assoc_string(zserver, "server_protocol", (char *) "HTTP/2");
 
-    fci_cache = php_swoole_server_get_fci_cache(serv, server_fd, SW_SERVER_CB_onRequest);
-    ctx->private_data_2 = fci_cache;
+    ctx->private_data_2 = cb;
 
     if (ctx->onBeforeRequest && !ctx->onBeforeRequest(ctx)) {
         return;
@@ -283,7 +282,7 @@ static void http2_server_onRequest(Http2Session *client, Http2Stream *stream) {
 
     args[0] = *ctx->request.zobject;
     args[1] = *ctx->response.zobject;
-    if (UNEXPECTED(!zend::function::call(fci_cache, 2, args, nullptr, serv->is_enable_coroutine()))) {
+    if (UNEXPECTED(!zend::function::call(cb, 2, args, nullptr, serv->is_enable_coroutine()))) {
         stream->reset(SW_HTTP2_ERROR_INTERNAL_ERROR);
         php_swoole_error(E_WARNING, "%s->onRequest[v2] handler error", ZSTR_VAL(swoole_http_server_ce->name));
     }

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -740,7 +740,7 @@ void Client::apply_setting(zval *zset, const bool check_all) {
             if (write_func) {
                 delete write_func;
             }
-            write_func = php_swoole_zval_to_callable(ztmp, "write_func");
+            write_func = sw_callable_create(ztmp);
         }
     }
     if (socket) {

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -75,20 +75,16 @@ static void process_pool_free_object(zend_object *object) {
     }
 
     if (pp->onWorkerStart) {
-        sw_zend_fci_cache_discard(pp->onWorkerStart);
-        efree(pp->onWorkerStart);
+        sw_zend_fci_cache_free(pp->onWorkerStart);
     }
     if (pp->onMessage) {
-        sw_zend_fci_cache_discard(pp->onMessage);
-        efree(pp->onMessage);
+        sw_zend_fci_cache_free(pp->onMessage);
     }
     if (pp->onWorkerStop) {
-        sw_zend_fci_cache_discard(pp->onWorkerStop);
-        efree(pp->onWorkerStop);
+        sw_zend_fci_cache_free(pp->onWorkerStop);
     }
     if (pp->onStart) {
-        sw_zend_fci_cache_discard(pp->onStart);
-        efree(pp->onStart);
+        sw_zend_fci_cache_free(pp->onStart);
     }
 
     zend_object_std_dtor(object);
@@ -344,8 +340,7 @@ static PHP_METHOD(swoole_process_pool, on) {
 
     if (SW_STRCASEEQ(name, l_name, "WorkerStart")) {
         if (pp->onWorkerStart) {
-            sw_zend_fci_cache_discard(pp->onWorkerStart);
-            efree(pp->onWorkerStart);
+            sw_zend_fci_cache_free(pp->onWorkerStart);
         } else {
             pp->onWorkerStart = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
         }
@@ -358,8 +353,7 @@ static PHP_METHOD(swoole_process_pool, on) {
             RETURN_FALSE;
         }
         if (pp->onMessage) {
-            sw_zend_fci_cache_discard(pp->onMessage);
-            efree(pp->onMessage);
+            sw_zend_fci_cache_free(pp->onMessage);
         } else {
             pp->onMessage = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
         }
@@ -368,8 +362,7 @@ static PHP_METHOD(swoole_process_pool, on) {
         RETURN_TRUE;
     } else if (SW_STRCASEEQ(name, l_name, "WorkerStop")) {
         if (pp->onWorkerStop) {
-            sw_zend_fci_cache_discard(pp->onWorkerStop);
-            efree(pp->onWorkerStop);
+            sw_zend_fci_cache_free(pp->onWorkerStop);
         } else {
             pp->onWorkerStop = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
         }
@@ -378,8 +371,7 @@ static PHP_METHOD(swoole_process_pool, on) {
         RETURN_TRUE;
     } else if (SW_STRCASEEQ(name, l_name, "Start")) {
         if (pp->onStart) {
-            sw_zend_fci_cache_discard(pp->onStart);
-            efree(pp->onStart);
+            sw_zend_fci_cache_free(pp->onStart);
         } else {
             pp->onStart = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
         }

--- a/ext-src/swoole_redis_server.cc
+++ b/ext-src/swoole_redis_server.cc
@@ -35,7 +35,7 @@ namespace Redis = swoole::redis;
 zend_class_entry *swoole_redis_server_ce;
 zend_object_handlers swoole_redis_server_handlers;
 
-static SW_THREAD_LOCAL std::unordered_map<std::string, zend_fcall_info_cache> redis_handlers;
+static SW_THREAD_LOCAL std::unordered_map<std::string, zend_fcall_info_cache *> redis_handlers;
 
 SW_EXTERN_C_BEGIN
 static PHP_METHOD(swoole_redis_server, setHandler);
@@ -71,7 +71,7 @@ void php_swoole_redis_server_minit(int module_number) {
 
 void php_swoole_redis_server_rshutdown() {
     for (auto i = redis_handlers.begin(); i != redis_handlers.end(); i++) {
-        sw_zend_fci_cache_discard(&i->second);
+        sw_zend_fci_cache_free(i->second);
     }
     redis_handlers.clear();
 }
@@ -169,7 +169,7 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
         return serv->send(fd, err_msg, length) ? SW_OK : SW_ERR;
     }
 
-    zend_fcall_info_cache *fci_cache = &i->second;
+    zend_fcall_info_cache *fci_cache = i->second;
     zval args[2];
     zval retval;
 
@@ -209,13 +209,10 @@ static PHP_METHOD(swoole_redis_server, setHandler) {
         RETURN_FALSE;
     }
 
-    char *func_name;
-    zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
-    if (!sw_zend_is_callable_ex(zcallback, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-        php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
+    auto fci_cache = sw_zend_fci_cache_create(zcallback);
+    if (!fci_cache) {
         return;
     }
-    efree(func_name);
 
     char _command[SW_REDIS_MAX_COMMAND_SIZE];
     size_t _command_len = sw_snprintf(_command, sizeof(_command), "_handler_%s", command);
@@ -230,11 +227,10 @@ static PHP_METHOD(swoole_redis_server, setHandler) {
     std::string key(_command, _command_len);
     auto i = redis_handlers.find(key);
     if (i != redis_handlers.end()) {
-        sw_zend_fci_cache_discard(&i->second);
+        sw_zend_fci_cache_free(i->second);
     }
 
-    sw_zend_fci_cache_persist(fci_cache);
-    redis_handlers[key] = *fci_cache;
+    redis_handlers[key] = fci_cache;
 
     RETURN_TRUE;
 }

--- a/ext-src/swoole_redis_server.cc
+++ b/ext-src/swoole_redis_server.cc
@@ -35,7 +35,7 @@ namespace Redis = swoole::redis;
 zend_class_entry *swoole_redis_server_ce;
 zend_object_handlers swoole_redis_server_handlers;
 
-static SW_THREAD_LOCAL std::unordered_map<std::string, zend_fcall_info_cache *> redis_handlers;
+static SW_THREAD_LOCAL std::unordered_map<std::string, zend::Callable *> redis_handlers;
 
 SW_EXTERN_C_BEGIN
 static PHP_METHOD(swoole_redis_server, setHandler);
@@ -71,7 +71,7 @@ void php_swoole_redis_server_minit(int module_number) {
 
 void php_swoole_redis_server_rshutdown() {
     for (auto i = redis_handlers.begin(); i != redis_handlers.end(); i++) {
-        sw_zend_fci_cache_free(i->second);
+        sw_callable_free(i->second);
     }
     redis_handlers.clear();
 }
@@ -169,14 +169,14 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
         return serv->send(fd, err_msg, length) ? SW_OK : SW_ERR;
     }
 
-    zend_fcall_info_cache *fci_cache = i->second;
+    auto fci_cache = i->second;
     zval args[2];
     zval retval;
 
     ZVAL_LONG(&args[0], fd);
     args[1] = zparams;
 
-    if (UNEXPECTED(!zend::function::call(fci_cache, 2, args, &retval, serv->is_enable_coroutine()))) {
+    if (UNEXPECTED(!zend::function::call(fci_cache->ptr(), 2, args, &retval, serv->is_enable_coroutine()))) {
         php_swoole_error(E_WARNING,
                          "%s->onRequest with command '%.*s' handler error",
                          ZSTR_VAL(swoole_redis_server_ce->name),
@@ -209,7 +209,7 @@ static PHP_METHOD(swoole_redis_server, setHandler) {
         RETURN_FALSE;
     }
 
-    auto fci_cache = sw_zend_fci_cache_create(zcallback);
+    auto fci_cache = sw_callable_create(zcallback);
     if (!fci_cache) {
         return;
     }
@@ -227,7 +227,7 @@ static PHP_METHOD(swoole_redis_server, setHandler) {
     std::string key(_command, _command_len);
     auto i = redis_handlers.find(key);
     if (i != redis_handlers.end()) {
-        sw_zend_fci_cache_free(i->second);
+        sw_callable_free(i->second);
     }
 
     redis_handlers[key] = fci_cache;

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -234,7 +234,7 @@ struct real_func {
     zend_internal_arg_info *ori_arg_info;
     uint32_t ori_fn_flags;
     uint32_t ori_num_args;
-    zend_fcall_info_cache *fci_cache;
+    zend::Callable *fci_cache;
     zval name;
 };
 
@@ -262,7 +262,7 @@ void php_swoole_runtime_rshutdown() {
          */
         if (rf->fci_cache) {
             zval_dtor(&rf->name);
-            sw_zend_fci_cache_free(rf->fci_cache);
+            sw_callable_free(rf->fci_cache);
         }
         rf->function->internal_function.handler = rf->ori_handler;
         rf->function->internal_function.arg_info = rf->ori_arg_info;
@@ -2000,7 +2000,7 @@ static void hook_func(const char *name, size_t l_name, zif_handler handler, zend
         memcpy(func + 7, fn_str->val, fn_str->len);
 
         ZVAL_STRINGL(&rf->name, func, fn_str->len + 7);
-        auto fci_cache = sw_zend_fci_cache_create(&rf->name);
+        auto fci_cache = sw_callable_create(&rf->name);
         if (!fci_cache) {
             return;
         }
@@ -2111,7 +2111,7 @@ static PHP_FUNCTION(swoole_user_func_handler) {
     fci.params = ZEND_CALL_ARG(execute_data, 1);
     fci.named_params = NULL;
     ZVAL_UNDEF(&fci.function_name);
-    zend_call_function(&fci, rf->fci_cache);
+    zend_call_function(&fci, rf->fci_cache->ptr());
 }
 
 zend_class_entry *find_class_entry(const char *name, size_t length) {

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -3339,13 +3339,13 @@ static PHP_METHOD(swoole_server, task) {
 
     if (!serv->is_worker()) {
         buf.info.ext_flags |= SW_TASK_NOREPLY;
-    } else if (zfn) {
+    } else if (zfn && zval_is_true(zfn)) {
         buf.info.ext_flags |= SW_TASK_CALLBACK;
-        auto fci_cache = sw_callable_create(zfn);
-        if (!fci_cache) {
+        auto cb = sw_callable_create(zfn);
+        if (!cb) {
             RETURN_FALSE;
         }
-        server_object->property->task_callbacks[task_id] = fci_cache;
+        server_object->property->task_callbacks[task_id] = cb;
     }
 
     buf.info.ext_flags |= SW_TASK_NONBLOCK;

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -209,7 +209,7 @@ static void server_free_object(zend_object *object) {
         for (int i = 0; i < PHP_SWOOLE_SERVER_CALLBACK_NUM; i++) {
             zend_fcall_info_cache *fci_cache = property->callbacks[i];
             if (fci_cache) {
-                efree(fci_cache);
+                sw_zend_fci_cache_free(fci_cache);
                 property->callbacks[i] = nullptr;
             }
         }
@@ -2424,7 +2424,7 @@ static PHP_METHOD(swoole_server, on) {
             swoole_server_ce, SW_Z8_OBJ_P(ZEND_THIS), property_name.c_str(), property_name.length(), cb);
 
         if (server_object->property->callbacks[event_type]) {
-            efree(server_object->property->callbacks[event_type]);
+            sw_zend_fci_cache_free(server_object->property->callbacks[event_type]);
         }
 
         auto fci_cache = sw_zend_fci_cache_create(cb);

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -634,13 +634,13 @@ void php_swoole_server_minit(int module_number) {
 zend::Callable *php_swoole_server_get_callback(Server *serv, int server_fd, int event_type) {
     ListenPort *port = serv->get_port_by_server_fd(server_fd);
     ServerPortProperty *property = php_swoole_server_get_port_property(port);
-    zend::Callable *fci_cache;
+    zend::Callable *cb;
 
     if (sw_unlikely(!port)) {
         return nullptr;
     }
-    if (property && (fci_cache = property->callbacks[event_type])) {
-        return fci_cache;
+    if (property && (cb = property->callbacks[event_type])) {
+        return cb;
     } else {
         return php_swoole_server_get_port_property(serv->get_primary_port())->callbacks[event_type];
     }

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -104,8 +104,7 @@ void php_swoole_server_port_deref(zend_object *object) {
     ListenPort *port = server_port->port;
     if (port) {
         if (port->protocol.private_data) {
-            sw_zend_fci_cache_discard((zend_fcall_info_cache *) port->protocol.private_data);
-            efree(port->protocol.private_data);
+            sw_zend_fci_cache_free((zend_fcall_info_cache *) port->protocol.private_data);
             port->protocol.private_data = nullptr;
         }
         server_port->port = nullptr;
@@ -193,7 +192,6 @@ void php_swoole_server_port_minit(int module_number) {
  */
 static ssize_t php_swoole_server_length_func(const Protocol *protocol, network::Socket *conn, PacketLength *pl) {
     Server *serv = (Server *) protocol->private_data_2;
-    serv->lock();
 
     zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) protocol->private_data;
     zval zdata;
@@ -209,8 +207,6 @@ static ssize_t php_swoole_server_length_func(const Protocol *protocol, network::
         zval_ptr_dtor(&retval);
     }
     zval_ptr_dtor(&zdata);
-
-    serv->unlock();
 
     /* the exception should only be thrown after unlocked */
     if (UNEXPECTED(EG(exception))) {
@@ -452,40 +448,18 @@ static PHP_METHOD(swoole_server_port, set) {
     }
     // length function
     if (php_swoole_array_get_value(vht, "package_length_func", ztmp)) {
-        while (1) {
-            if (Z_TYPE_P(ztmp) == IS_STRING) {
-                Protocol::LengthFunc func = Protocol::get_function(std::string(Z_STRVAL_P(ztmp), Z_STRLEN_P(ztmp)));
-                if (func != nullptr) {
-                    port->protocol.get_package_length = func;
-                    break;
-                }
-            }
-#ifdef ZTS
-            Server *serv = property->serv;
-            if (serv->is_process_mode() && !serv->single_thread) {
-                php_swoole_fatal_error(E_ERROR, "option [package_length_func] does not support with ZTS");
-            }
-#endif
-            char *func_name;
-            zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) ecalloc(1, sizeof(zend_fcall_info_cache));
-            if (!sw_zend_is_callable_ex(ztmp, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-                php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
-                return;
-            }
-            efree(func_name);
+        auto fci_cache = sw_zend_fci_cache_create(ztmp);
+        if (fci_cache) {
             port->protocol.get_package_length = php_swoole_server_length_func;
             if (port->protocol.private_data) {
-                sw_zend_fci_cache_discard((zend_fcall_info_cache *) port->protocol.private_data);
-                efree(port->protocol.private_data);
+                sw_zend_fci_cache_free((zend_fcall_info_cache *) port->protocol.private_data);
             }
-            sw_zend_fci_cache_persist(fci_cache);
             port->protocol.private_data = fci_cache;
-            break;
+            port->protocol.package_length_size = 0;
+            port->protocol.package_length_type = '\0';
+            port->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
+            property->serv->single_thread = true;
         }
-
-        port->protocol.package_length_size = 0;
-        port->protocol.package_length_type = '\0';
-        port->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
     }
     /**
      * package max length
@@ -632,13 +606,6 @@ static PHP_METHOD(swoole_server_port, on) {
     Z_PARAM_ZVAL(cb)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    char *func_name = nullptr;
-    zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) emalloc(sizeof(zend_fcall_info_cache));
-    if (!sw_zend_is_callable_ex(cb, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-        php_swoole_fatal_error(E_ERROR, "function '%s' is not callable", func_name);
-        return;
-    }
-    efree(func_name);
 
     bool found = false;
     for (auto i = server_port_event_map.begin(); i != server_port_event_map.end(); i++) {
@@ -656,6 +623,11 @@ static PHP_METHOD(swoole_server_port, on) {
         sw_copy_to_stack(property->callbacks[index], property->_callbacks[index]);
         if (property->caches[index]) {
             efree(property->caches[index]);
+        }
+
+        auto fci_cache = sw_zend_fci_cache_create(cb);
+        if (!fci_cache) {
+            RETURN_FALSE;
         }
         property->caches[index] = fci_cache;
 
@@ -675,7 +647,6 @@ static PHP_METHOD(swoole_server_port, on) {
 
     if (!found) {
         php_swoole_error(E_WARNING, "unknown event types[%s]", name);
-        efree(fci_cache);
         RETURN_FALSE;
     }
     RETURN_TRUE;

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -94,7 +94,7 @@ void php_swoole_server_port_deref(zend_object *object) {
     if (property->serv) {
         for (int j = 0; j < PHP_SWOOLE_SERVER_PORT_CALLBACK_NUM; j++) {
             if (property->caches[j]) {
-                efree(property->caches[j]);
+                sw_zend_fci_cache_free(property->caches[j]);
                 property->caches[j] = nullptr;
             }
         }
@@ -191,8 +191,6 @@ void php_swoole_server_port_minit(int module_number) {
  * [Master/Worker]
  */
 static ssize_t php_swoole_server_length_func(const Protocol *protocol, network::Socket *conn, PacketLength *pl) {
-    Server *serv = (Server *) protocol->private_data_2;
-
     zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) protocol->private_data;
     zval zdata;
     zval retval;
@@ -622,7 +620,7 @@ static PHP_METHOD(swoole_server_port, on) {
             sw_zend_read_property(swoole_server_port_ce, ZEND_THIS, property_name.c_str(), property_name.length(), 0);
         sw_copy_to_stack(property->callbacks[index], property->_callbacks[index]);
         if (property->caches[index]) {
-            efree(property->caches[index]);
+            sw_zend_fci_cache_free(property->caches[index]);
         }
 
         auto fci_cache = sw_zend_fci_cache_create(cb);

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -976,10 +976,10 @@ SW_API bool php_swoole_socket_set_protocol(Socket *sock, zval *zset) {
         auto cb = sw_callable_create(ztmp);
         if (cb) {
             sock->protocol.get_package_length = php_swoole_length_func;
-            if (sock->protocol.cb) {
-                sw_callable_free(sock->protocol.cb);
+            if (sock->protocol.private_data_1) {
+                sw_callable_free(sock->protocol.private_data_1);
             }
-            sock->protocol.cb = cb;
+            sock->protocol.private_data_1 = cb;
             sock->protocol.package_length_size = 0;
             sock->protocol.package_length_type = '\0';
             sock->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
@@ -1829,9 +1829,9 @@ static PHP_METHOD(swoole_socket_coro, close) {
         php_swoole_error(E_WARNING, "cannot close the referenced resource");
         RETURN_FALSE;
     }
-    if (sock->socket->protocol.cb) {
-        sw_callable_free(sock->socket->protocol.cb);
-        sock->socket->protocol.cb = nullptr;
+    if (sock->socket->protocol.private_data_1) {
+        sw_callable_free(sock->socket->protocol.private_data_1);
+        sock->socket->protocol.private_data_1 = nullptr;
     }
     if (!Z_ISUNDEF(sock->zstream)) {
         php_stream *stream = NULL;

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -1328,6 +1328,11 @@ static PHP_METHOD(swoole_socket_coro, accept) {
         client_sock->socket = conn;
         ZVAL_OBJ(return_value, &client_sock->std);
         socket_coro_init(return_value, client_sock);
+        // It must be copied once to avoid destroying the function when the connection closes.
+        if (sock->socket->protocol.private_data_1) {
+            zend::Callable *cb = (zend::Callable *) sock->socket->protocol.private_data_1;
+            conn->protocol.private_data_1 = cb->dup();
+        }
     } else {
         socket_coro_sync_properties(ZEND_THIS, sock);
         RETURN_FALSE;

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -973,11 +973,11 @@ SW_API bool php_swoole_socket_set_protocol(Socket *sock, zval *zset) {
     }
     // length function
     if (php_swoole_array_get_value(vht, "package_length_func", ztmp)) {
-        auto fci_cache = sw_zend_fci_cache_create(ztmp);
+        auto fci_cache = sw_callable_create(ztmp);
         if (fci_cache) {
             sock->protocol.get_package_length = php_swoole_length_func;
             if (sock->protocol.private_data) {
-                sw_zend_fci_cache_free((zend_fcall_info_cache *) sock->protocol.private_data);
+                sw_callable_free(sock->protocol.private_data);
             }
             sock->protocol.private_data = fci_cache;
             sock->protocol.package_length_size = 0;
@@ -1836,7 +1836,7 @@ static PHP_METHOD(swoole_socket_coro, close) {
         RETURN_FALSE;
     }
     if (sock->socket->protocol.private_data) {
-        sw_zend_fci_cache_free((zend_fcall_info_cache *) sock->socket->protocol.private_data);
+        sw_callable_free(sock->socket->protocol.private_data);
         sock->socket->protocol.private_data = nullptr;
     }
     if (!Z_ISUNDEF(sock->zstream)) {

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -973,34 +973,17 @@ SW_API bool php_swoole_socket_set_protocol(Socket *sock, zval *zset) {
     }
     // length function
     if (php_swoole_array_get_value(vht, "package_length_func", ztmp)) {
-        do {
-            Protocol::LengthFunc func;
-            if (Z_TYPE_P(ztmp) == IS_STRING &&
-                (func = Protocol::get_function(std::string(Z_STRVAL_P(ztmp), Z_STRLEN_P(ztmp))))) {
-                sock->protocol.get_package_length = func;
-            } else {
-                char *func_name;
-                zend_fcall_info_cache *fci_cache = (zend_fcall_info_cache *) ecalloc(1, sizeof(zend_fcall_info_cache));
-                if (!sw_zend_is_callable_ex(ztmp, nullptr, 0, &func_name, nullptr, fci_cache, nullptr)) {
-                    php_swoole_fatal_error(E_WARNING, "function '%s' is not callable", func_name);
-                    efree(func_name);
-                    efree(fci_cache);
-                    ret = false;
-                    break;
-                }
-                efree(func_name);
-                sock->protocol.get_package_length = php_swoole_length_func;
-                if (sock->protocol.private_data) {
-                    sw_zend_fci_cache_discard((zend_fcall_info_cache *) sock->protocol.private_data);
-                    efree(sock->protocol.private_data);
-                }
-                sw_zend_fci_cache_persist(fci_cache);
-                sock->protocol.private_data = fci_cache;
+        auto fci_cache = sw_zend_fci_cache_create(ztmp);
+        if (fci_cache) {
+            sock->protocol.get_package_length = php_swoole_length_func;
+            if (sock->protocol.private_data) {
+                sw_zend_fci_cache_free((zend_fcall_info_cache *) sock->protocol.private_data);
             }
+            sock->protocol.private_data = fci_cache;
             sock->protocol.package_length_size = 0;
             sock->protocol.package_length_type = '\0';
             sock->protocol.package_length_offset = SW_IPC_BUFFER_SIZE;
-        } while (0);
+        }
     }
     /**
      * package max length
@@ -1853,9 +1836,8 @@ static PHP_METHOD(swoole_socket_coro, close) {
         RETURN_FALSE;
     }
     if (sock->socket->protocol.private_data) {
-        zend_fcall_info_cache *package_length_func = (zend_fcall_info_cache *) sock->socket->protocol.private_data;
-        sw_zend_fci_cache_discard(package_length_func);
-        efree(package_length_func);
+        sw_zend_fci_cache_free((zend_fcall_info_cache *) sock->socket->protocol.private_data);
+        sock->socket->protocol.private_data = nullptr;
     }
     if (!Z_ISUNDEF(sock->zstream)) {
         php_stream *stream = NULL;

--- a/include/swoole_c_api.h
+++ b/include/swoole_c_api.h
@@ -45,9 +45,6 @@ enum swGlobalHookType {
 
 typedef void (*swHookFunc)(void *data);
 
-int swoole_add_function(const char *name, void *func);
-void *swoole_get_function(const char *name, uint32_t length);
-
 int swoole_add_hook(enum swGlobalHookType type, swHookFunc cb, int push_back);
 void swoole_call_hook(enum swGlobalHookType type, void *arg);
 bool swoole_isset_hook(enum swGlobalHookType type);

--- a/include/swoole_protocol.h
+++ b/include/swoole_protocol.h
@@ -67,10 +67,6 @@ struct Protocol {
     int recv_split_by_eof(network::Socket *socket, String *buffer);
 
     static ssize_t default_length_func(const Protocol *protocol, network::Socket *socket, PacketLength *pl);
-
-    static inline LengthFunc get_function(const std::string &name) {
-        return (LengthFunc) swoole_get_function(name.c_str(), name.length());
-    }
 };
 }  // namespace swoole
 

--- a/include/swoole_protocol.h
+++ b/include/swoole_protocol.h
@@ -46,7 +46,7 @@ struct Protocol {
     uint16_t package_body_offset;
     uint32_t package_max_length;
 
-    void *cb;
+    void *private_data_1;
     void *private_data_2;
 
     /**

--- a/include/swoole_protocol.h
+++ b/include/swoole_protocol.h
@@ -46,7 +46,7 @@ struct Protocol {
     uint16_t package_body_offset;
     uint32_t package_max_length;
 
-    void *private_data;
+    void *cb;
     void *private_data_2;
 
     /**

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -1337,14 +1337,6 @@ class Server {
         return &session_list[session_id % SW_SESSION_LIST_SIZE];
     }
 
-    void lock() {
-        lock_.lock();
-    }
-
-    void unlock() {
-        lock_.unlock();
-    }
-
     void clear_timer();
     static void timer_callback(Timer *timer, TimerNode *tnode);
 
@@ -1576,6 +1568,14 @@ class Server {
         }
         swoole_trace_log(SW_TRACE_SERVER, "schedule=%d, round=%d", key, worker_round_id);
         return key;
+    }
+
+    void lock() {
+        lock_.lock();
+    }
+
+    void unlock() {
+        lock_.unlock();
     }
 };
 

--- a/src/core/base.cc
+++ b/src/core/base.cc
@@ -100,7 +100,6 @@ swoole::Global SwooleG = {};
 __thread swoole::ThreadGlobal SwooleTG = {};
 std::mutex sw_thread_lock;
 
-static std::unordered_map<std::string, void *> functions;
 static swoole::Logger *g_logger_instance = nullptr;
 
 #ifdef __MACH__
@@ -216,27 +215,6 @@ void swoole_init(void) {
 }
 
 SW_EXTERN_C_BEGIN
-
-SW_API int swoole_add_function(const char *name, void *func) {
-    std::string _name(name);
-    auto iter = functions.find(_name);
-    if (iter != functions.end()) {
-        swoole_warning("Function '%s' has already been added", name);
-        return SW_ERR;
-    } else {
-        functions.emplace(std::make_pair(_name, func));
-        return SW_OK;
-    }
-}
-
-SW_API void *swoole_get_function(const char *name, uint32_t length) {
-    auto iter = functions.find(std::string(name, length));
-    if (iter != functions.end()) {
-        return iter->second;
-    } else {
-        return nullptr;
-    }
-}
 
 SW_API int swoole_add_hook(enum swGlobalHookType type, swHookFunc func, int push_back) {
     assert(type <= SW_GLOBAL_HOOK_END);

--- a/tests/swoole_http_server/callback_with_private.phpt
+++ b/tests/swoole_http_server/callback_with_private.phpt
@@ -38,10 +38,6 @@ $pm->run(true);
 //Fatal Error
 $pm->expectExitCode(255);
 $output = $pm->getChildOutput();
-if (PHP_VERSION_ID < 80000) {
-    Assert::contains($output, 'Swoole\Server::on() must be callable');
-} else {
-    Assert::contains($output, 'Swoole\Server::on(): function \'TestCo_9::foo\' is not callable');
-}
+Assert::contains($output, "Swoole\Server\Port::on(): function 'TestCo_9::foo' is not callable");
 ?>
 --EXPECT--

--- a/tests/swoole_http_server/callback_with_protected.phpt
+++ b/tests/swoole_http_server/callback_with_protected.phpt
@@ -34,10 +34,6 @@ $pm = ProcessManager::exec(function ($pm) {
 //Fatal Error
 $pm->expectExitCode(255);
 $output = $pm->getChildOutput();
-if (PHP_VERSION_ID < 80000) {
-    Assert::contains($output, 'Swoole\Server::on() must be callable');
-} else {
-    Assert::contains($output, 'Swoole\Server::on(): function \'TestCo::foo\' is not callable');
-}
+Assert::contains($output, 'Swoole\Server\Port::on(): function \'TestCo::foo\' is not callable');
 ?>
 --EXPECT--

--- a/tests/swoole_process/null_callback.phpt
+++ b/tests/swoole_process/null_callback.phpt
@@ -14,4 +14,4 @@ $process->start();
 
 ?>
 --EXPECTF--
-Fatal error: Swoole\Process::start(): Illegal callback function of Swoole\Process in %s
+Warning: Swoole\Process::start(): illegal callback function in %s


### PR DESCRIPTION
1. Directly use the zval reference count management for the callback function, instead of zend_func_info_cache.
2. Allow the use of dispatch_func and package_length_func under ZTS.
3. In Process mode, the server enforces single-threading when enabling dispatch_func and package_length_func.
4. The event callback function of the main thread no longer requires locking.