### PR TITLE
Optimize thread callback

### DIFF
--- a/.github/workflows/thread.yml
+++ b/.github/workflows/thread.yml
@@ -32,7 +32,7 @@ jobs:
         pwd
         echo "`git log -20 --pretty --oneline`"
         echo "`git log -10 --stat --pretty --oneline`"
-    - name: Run Swoole test
+    - name: Run tests
       run: |
         export SWOOLE_BRANCH=${GITHUB_REF##*/}
         export SWOOLE_THREAD=1

--- a/config.m4
+++ b/config.m4
@@ -1056,7 +1056,6 @@ EOF
         thirdparty/multipart_parser.c"
 
     if test "$PHP_NGHTTP2_DIR" = "no"; then
-        PHP_ADD_INCLUDE([$ext_srcdir/thirdparty])
 	    swoole_source_file="$swoole_source_file \
 	        thirdparty/nghttp2/nghttp2_hd.c \
 	        thirdparty/nghttp2/nghttp2_rcbuf.c \

--- a/examples/thread/exit.php
+++ b/examples/thread/exit.php
@@ -1,0 +1,21 @@
+<?php
+
+use Swoole\Thread;
+use Swoole\Thread\Lock;
+
+$args = Thread::getArguments();
+
+if (empty($args)) {
+    $lock = new Lock;
+    $lock->lock();
+    $thread = new Thread(__FILE__, $lock);
+    echo "main thread\n";
+    $lock->unlock();
+    $thread->join();
+    var_dump($thread->getExitStatus());
+} else {
+    $lock = $args[0];
+    $lock->lock();
+    sleep(1);
+    exit(234);
+}

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1051,7 +1051,7 @@ PHP_RINIT_FUNCTION(swoole) {
          * This would cause php_swoole_load_library function not to execute correctly, so it must be replaced
          * with the execute_ex function.
          */
-        void (*old_zend_execute_ex)(zend_execute_data *execute_data) = nullptr;
+        void (*old_zend_execute_ex)(zend_execute_data * execute_data) = nullptr;
         if (UNEXPECTED(zend_execute_ex != execute_ex)) {
             old_zend_execute_ex = zend_execute_ex;
             zend_execute_ex = execute_ex;
@@ -1511,8 +1511,11 @@ static PHP_FUNCTION(swoole_test_fn) {
         zend_bailout();
     } else if (SW_STRCASEEQ(test_case, test_case_len, "abort")) {
         abort();
-    } else if (SW_STRCASEEQ(test_case, test_case_len, "exit")) {
+    }
+#ifdef SW_THREAD
+    else if (SW_STRCASEEQ(test_case, test_case_len, "exit")) {
         EG(exit_status) = 95;
         php_swoole_thread_bailout();
     }
+#endif
 }

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1511,5 +1511,8 @@ static PHP_FUNCTION(swoole_test_fn) {
         zend_bailout();
     } else if (SW_STRCASEEQ(test_case, test_case_len, "abort")) {
         abort();
+    } else if (SW_STRCASEEQ(test_case, test_case_len, "exit")) {
+        EG(exit_status) = 95;
+        php_swoole_thread_bailout();
     }
 }

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1508,14 +1508,13 @@ static PHP_FUNCTION(swoole_test_fn) {
         swoole_fatal_error(SW_ERROR_FOR_TEST, "test");
         php_printf("never be executed here\n");
     } else if (SW_STRCASEEQ(test_case, test_case_len, "bailout")) {
+        EG(exit_status) = 95;
+#ifdef SW_THREAD
         zend_bailout();
+#else
+        php_swoole_thread_bailout();
+#endif
     } else if (SW_STRCASEEQ(test_case, test_case_len, "abort")) {
         abort();
     }
-#ifdef SW_THREAD
-    else if (SW_STRCASEEQ(test_case, test_case_len, "exit")) {
-        EG(exit_status) = 95;
-        php_swoole_thread_bailout();
-    }
-#endif
 }

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1510,9 +1510,9 @@ static PHP_FUNCTION(swoole_test_fn) {
     } else if (SW_STRCASEEQ(test_case, test_case_len, "bailout")) {
         EG(exit_status) = 95;
 #ifdef SW_THREAD
-        zend_bailout();
-#else
         php_swoole_thread_bailout();
+#else
+        zend_bailout();
 #endif
     } else if (SW_STRCASEEQ(test_case, test_case_len, "abort")) {
         abort();

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -389,7 +389,6 @@ zend_bool php_swoole_signal_isset_handler(int signo);
 #endif
 
 #define sw_zend7_object zend_object
-#define SW_Z7_OBJ_P(object) object
 #define SW_Z8_OBJ_P(zobj) Z_OBJ_P(zobj)
 
 typedef ssize_t php_stream_size_t;

--- a/ext-src/php_swoole_thread.h
+++ b/ext-src/php_swoole_thread.h
@@ -257,7 +257,7 @@ class ZendArray : public ThreadResource {
 
     void keys(zval *return_value);
     void values(zval *return_value);
-    void toArray(zval *return_value);
+    void to_array(zval *return_value);
     void find(zval *search, zval *return_value);
 
     void intkey_offsetGet(zend_long index, zval *return_value) {

--- a/ext-src/php_swoole_thread.h
+++ b/ext-src/php_swoole_thread.h
@@ -38,6 +38,8 @@ extern zend_class_entry *swoole_thread_map_ce;
 extern zend_class_entry *swoole_thread_queue_ce;
 
 void php_swoole_thread_start(zend_string *file, ZendArray *argv);
+void php_swoole_thread_join(pthread_t ptid);
+int php_swoole_thread_get_exit_status(pthread_t ptid);
 zend_string *php_swoole_serialize(zval *zdata);
 bool php_swoole_unserialize(zend_string *data, zval *zv);
 void php_swoole_thread_bailout(void);

--- a/ext-src/stubs/php_swoole_thread.stub.php
+++ b/ext-src/stubs/php_swoole_thread.stub.php
@@ -6,6 +6,7 @@ namespace Swoole {
 
         public function join(): bool {}
         public function joinable(): bool {}
+        public function getExitStatus(): int {}
         public function detach(): bool {}
 
         public static function getArguments(): ?array {}

--- a/ext-src/stubs/php_swoole_thread_arginfo.h
+++ b/ext-src/stubs/php_swoole_thread_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 51be89a17d2714b489a0d67a927b6b3e8a1f0cff */
+ * Stub hash: d1d1e5d35cfda110527408faf9376dda24680c7f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Thread___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, script_file, IS_STRING, 0)
@@ -11,13 +11,15 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Thread_joinable arginfo_class_Swoole_Thread_join
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Thread_getExitStatus, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Swoole_Thread_detach arginfo_class_Swoole_Thread_join
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Thread_getArguments, 0, 0, IS_ARRAY, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Thread_getId, 0, 0, IS_LONG, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_Swoole_Thread_getId arginfo_class_Swoole_Thread_getExitStatus
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Thread_getInfo, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -44,4 +46,4 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Thread_getPriority arginfo_class_Swoole_Thread_getInfo
 
-#define arginfo_class_Swoole_Thread_getNativeId arginfo_class_Swoole_Thread_getId
+#define arginfo_class_Swoole_Thread_getNativeId arginfo_class_Swoole_Thread_getExitStatus

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -100,17 +100,9 @@ void php_swoole_server_rshutdown() {
     serv->drain_worker_pipe();
 
     if (serv->is_started() && serv->worker_is_running() && !serv->is_user_worker()) {
-        SwooleWG.shutdown = true;
-#ifdef SW_THREAD
-        if (serv->is_thread_mode()) {
-            sw_reactor()->destroyed = true;
-            serv->foreach_connection([serv](Connection *conn) {
-                if (conn->reactor_id == sw_worker()->id) {
-                    serv->close(conn->session_id, true);
-                }
-            });
+        if (serv->is_event_worker() && !serv->is_process_mode()) {
+            serv->clean_worker_connections(sw_worker());
         }
-#endif
         if (php_swoole_is_fatal_error()) {
             swoole_error_log(SW_LOG_ERROR,
                              SW_ERROR_PHP_FATAL_ERROR,

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -480,7 +480,7 @@ void php_swoole_thread_start(zend_string *file, ZendArray *argv) {
             zend_hash_update(&EG(symbol_table), ZSTR_KNOWN(ZEND_STR_ARGC), &global_argc);
         }
         if (argv) {
-            argv->toArray(&thread_argv);
+            argv->to_array(&thread_argv);
             argv->del_ref();
         }
         thread_register_stdio_file_handles(true);
@@ -1050,7 +1050,7 @@ void ZendArray::values(zval *return_value) {
     lock_.unlock();
 }
 
-void ZendArray::toArray(zval *return_value) {
+void ZendArray::to_array(zval *return_value) {
     lock_.lock_rd();
     zend_ulong elem_count = zend_hash_num_elements(&ht);
     array_init_size(return_value, elem_count);

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -525,8 +525,8 @@ int php_swoole_thread_get_exit_status(pthread_t ptid) {
 void php_swoole_thread_bailout(void) {
     if (thread_bailout) {
         EG(bailout) = thread_bailout;
-        zend_bailout();
     }
+    zend_bailout();
 }
 
 int php_swoole_thread_stream_cast(zval *zstream) {

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -22,22 +22,9 @@
 #include <sys/ipc.h>
 #include <sys/resource.h>
 
-#include <thread>
 #include <unordered_map>
 
-#if defined(__linux__)
-#include <sys/syscall.h> /* syscall(SYS_gettid) */
-#elif defined(__FreeBSD__)
-#include <pthread_np.h> /* pthread_getthreadid_np() */
-#elif defined(__OpenBSD__)
-#include <unistd.h> /* getthrid() */
-#elif defined(_AIX)
-#include <sys/thread.h> /* thread_self() */
-#elif defined(__NetBSD__)
-#include <lwp.h> /* _lwp_self() */
-#endif
-
-#include "swoole_lock.h"
+#include "swoole_thread.h"
 
 BEGIN_EXTERN_C()
 #include "stubs/php_swoole_thread_arginfo.h"
@@ -64,19 +51,40 @@ struct ThreadObject {
     zend_object std;
 };
 
-static void php_swoole_thread_join(zend_object *object);
-static void php_swoole_thread_register_stdio_file_handles(bool no_close);
+static void thread_register_stdio_file_handles(bool no_close);
 
 static thread_local zval thread_argv = {};
 static thread_local JMP_BUF *thread_bailout = nullptr;
 static std::atomic<size_t> thread_num(1);
+static std::unordered_map<pthread_t, int> thread_exit_status;
+static std::mutex thread_lock;
 
 static sw_inline ThreadObject *thread_fetch_object(zend_object *obj) {
     return (ThreadObject *) ((char *) obj - swoole_thread_handlers.offset);
 }
 
+static pthread_t thread_get_id(zend_object *object) {
+    zval *res, rv;
+    res = zend_read_property(swoole_thread_ce, object, ZEND_STRL("id"), 1, &rv);
+    return (pthread_t) zval_get_long(res);
+}
+
+static pthread_t thread_get_id(zval *zobj) {
+    return thread_get_id(Z_OBJ_P(zobj));
+}
+
+static void thread_join(zend_object *object) {
+    ThreadObject *to = thread_fetch_object(object);
+    if (to->thread && to->thread->joinable()) {
+        to->thread->join();
+        php_swoole_thread_join(to->thread->native_handle());
+        delete to->thread;
+        to->thread = nullptr;
+    }
+}
+
 static void thread_free_object(zend_object *object) {
-    php_swoole_thread_join(object);
+    thread_join(object);
     zend_object_std_dtor(object);
 }
 
@@ -88,19 +96,11 @@ static zend_object *thread_create_object(zend_class_entry *ce) {
     return &to->std;
 }
 
-static void php_swoole_thread_join(zend_object *object) {
-    ThreadObject *to = thread_fetch_object(object);
-    if (to->thread && to->thread->joinable()) {
-        to->thread->join();
-        delete to->thread;
-        to->thread = nullptr;
-    }
-}
-
 SW_EXTERN_C_BEGIN
 static PHP_METHOD(swoole_thread, __construct);
 static PHP_METHOD(swoole_thread, join);
 static PHP_METHOD(swoole_thread, joinable);
+static PHP_METHOD(swoole_thread, getExitStatus);
 static PHP_METHOD(swoole_thread, detach);
 static PHP_METHOD(swoole_thread, getArguments);
 static PHP_METHOD(swoole_thread, getId);
@@ -117,21 +117,22 @@ SW_EXTERN_C_END
 
 // clang-format off
 static const zend_function_entry swoole_thread_methods[] = {
-    PHP_ME(swoole_thread, __construct,  arginfo_class_Swoole_Thread___construct,  ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_thread, join,         arginfo_class_Swoole_Thread_join,         ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_thread, joinable,     arginfo_class_Swoole_Thread_joinable,     ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_thread, detach,       arginfo_class_Swoole_Thread_detach,       ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_thread, getArguments, arginfo_class_Swoole_Thread_getArguments, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, getId,        arginfo_class_Swoole_Thread_getId,        ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, getInfo,      arginfo_class_Swoole_Thread_getInfo,      ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, setName,      arginfo_class_Swoole_Thread_setName,      ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, __construct,   arginfo_class_Swoole_Thread___construct,   ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_thread, join,          arginfo_class_Swoole_Thread_join,          ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_thread, joinable,      arginfo_class_Swoole_Thread_joinable,      ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_thread, getExitStatus, arginfo_class_Swoole_Thread_getExitStatus, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_thread, detach,        arginfo_class_Swoole_Thread_detach,        ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_thread, getArguments,  arginfo_class_Swoole_Thread_getArguments,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, getId,         arginfo_class_Swoole_Thread_getId,         ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, getInfo,       arginfo_class_Swoole_Thread_getInfo,       ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, setName,       arginfo_class_Swoole_Thread_setName,       ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 #ifdef HAVE_CPU_AFFINITY
-    PHP_ME(swoole_thread, setAffinity,  arginfo_class_Swoole_Thread_setAffinity,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, getAffinity,  arginfo_class_Swoole_Thread_getAffinity,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, setAffinity,   arginfo_class_Swoole_Thread_setAffinity,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, getAffinity,   arginfo_class_Swoole_Thread_getAffinity,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 #endif
-    PHP_ME(swoole_thread, setPriority,  arginfo_class_Swoole_Thread_setPriority,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, getPriority,  arginfo_class_Swoole_Thread_getPriority,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(swoole_thread, getNativeId,  arginfo_class_Swoole_Thread_getNativeId,  ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, setPriority,   arginfo_class_Swoole_Thread_setPriority,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, getPriority,   arginfo_class_Swoole_Thread_getPriority,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(swoole_thread, getNativeId,   arginfo_class_Swoole_Thread_getNativeId,   ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_FE_END
 };
 // clang-format on
@@ -210,7 +211,7 @@ static PHP_METHOD(swoole_thread, join) {
     if (!to || !to->thread || !to->thread->joinable()) {
         RETURN_FALSE;
     }
-    php_swoole_thread_join(Z_OBJ_P(ZEND_THIS));
+    thread_join(Z_OBJ_P(ZEND_THIS));
     RETURN_TRUE;
 }
 
@@ -241,6 +242,10 @@ static PHP_METHOD(swoole_thread, getArguments) {
 
 static PHP_METHOD(swoole_thread, getId) {
     RETURN_LONG((zend_long) pthread_self());
+}
+
+static PHP_METHOD(swoole_thread, getExitStatus) {
+    RETURN_LONG(php_swoole_thread_get_exit_status(thread_get_id(ZEND_THIS)));
 }
 
 static PHP_METHOD(swoole_thread, setName) {
@@ -325,26 +330,7 @@ static PHP_METHOD(swoole_thread, getPriority) {
 }
 
 static PHP_METHOD(swoole_thread, getNativeId) {
-#ifdef __APPLE__
-    uint64_t native_id;
-    (void) pthread_threadid_np(NULL, &native_id);
-#elif defined(__linux__)
-    pid_t native_id;
-    native_id = syscall(SYS_gettid);
-#elif defined(__FreeBSD__)
-    int native_id;
-    native_id = pthread_getthreadid_np();
-#elif defined(__OpenBSD__)
-    pid_t native_id;
-    native_id = getthrid();
-#elif defined(_AIX)
-    tid_t native_id;
-    native_id = thread_self();
-#elif defined(__NetBSD__)
-    lwpid_t native_id;
-    native_id = _lwp_self();
-#endif
-    RETURN_LONG((zend_long) native_id);
+    RETURN_LONG((zend_long) swoole_thread_get_native_id());
 }
 
 zend_string *php_swoole_serialize(zval *zdata) {
@@ -412,7 +398,7 @@ void php_swoole_thread_rshutdown() {
     }
 }
 
-static void php_swoole_thread_register_stdio_file_handles(bool no_close) {
+static void thread_register_stdio_file_handles(bool no_close) {
     php_stream *s_in, *s_out, *s_err;
     php_stream_context *sc_in = NULL, *sc_out = NULL, *sc_err = NULL;
     zend_constant ic, oc, ec;
@@ -497,7 +483,7 @@ void php_swoole_thread_start(zend_string *file, ZendArray *argv) {
             argv->toArray(&thread_argv);
             argv->del_ref();
         }
-        php_swoole_thread_register_stdio_file_handles(true);
+        thread_register_stdio_file_handles(true);
         php_execute_script(&file_handle);
     }
     zend_end_try();
@@ -508,10 +494,32 @@ void php_swoole_thread_start(zend_string *file, ZendArray *argv) {
     file_handle.filename = NULL;
 
 _startup_error:
+
+    thread_lock.lock();
+    thread_exit_status[pthread_self()] = EG(exit_status);
+    thread_lock.unlock();
+
     zend_string_release(file);
     ts_free_thread();
     swoole_thread_clean();
     thread_num.fetch_sub(1);
+}
+
+void php_swoole_thread_join(pthread_t ptid) {
+    thread_lock.lock();
+    thread_exit_status.erase(ptid);
+    thread_lock.unlock();
+}
+
+int php_swoole_thread_get_exit_status(pthread_t ptid) {
+    int exit_status;
+
+    thread_lock.lock();
+    auto iter = thread_exit_status.find(ptid);
+    exit_status = iter == thread_exit_status.end() ? -1 : iter->second;
+    thread_lock.unlock();
+
+    return exit_status;
 }
 
 void php_swoole_thread_bailout(void) {

--- a/ext-src/swoole_thread_arraylist.cc
+++ b/ext-src/swoole_thread_arraylist.cc
@@ -228,6 +228,6 @@ static PHP_METHOD(swoole_thread_arraylist, clean) {
 
 static PHP_METHOD(swoole_thread_arraylist, toArray) {
     auto ao = arraylist_fetch_object_check(ZEND_THIS);
-    ao->list->toArray(return_value);
+    ao->list->to_array(return_value);
 }
 #endif

--- a/ext-src/swoole_thread_map.cc
+++ b/ext-src/swoole_thread_map.cc
@@ -260,7 +260,7 @@ static PHP_METHOD(swoole_thread_map, values) {
 
 static PHP_METHOD(swoole_thread_map, toArray) {
     auto mo = map_fetch_object_check(ZEND_THIS);
-    mo->map->toArray(return_value);
+    mo->map->to_array(return_value);
 }
 
 static PHP_METHOD(swoole_thread_map, clean) {

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -457,6 +457,7 @@ class ThreadFactory : public BaseFactory {
     Worker manager;
     template <typename _Callable>
     void create_thread(int i, _Callable fn);
+    void join_thread(std::thread &thread);
     void at_thread_exit(Worker *worker);
     void create_message_bus();
     void destroy_message_bus();
@@ -1472,7 +1473,10 @@ class Server {
     void worker_accept_event(DataHead *info);
     void worker_signal_init(void);
     bool worker_is_running();
+
     std::function<void(const WorkerFn &fn)> worker_thread_start;
+    std::function<void(pthread_t ptid)> worker_thread_join;
+    std::function<int(pthread_t ptid)> worker_thread_get_exit_status;
 
     /**
      * [Master]
@@ -1483,8 +1487,8 @@ class Server {
     bool signal_handler_read_message();
     bool signal_handler_reopen_logger();
 
-    static int worker_main_loop(ProcessPool *pool, Worker *worker);
     static void worker_signal_handler(int signo);
+    static int reactor_process_main_loop(ProcessPool *pool, Worker *worker);
     static void reactor_thread_main_loop(Server *serv, int reactor_id);
     static bool task_pack(EventData *task, const void *data, size_t data_len);
     static bool task_unpack(EventData *task, String *buffer, PacketPtr *packet);

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -1464,6 +1464,7 @@ class Server {
     static void read_worker_message(ProcessPool *pool, EventData *msg);
 
     void drain_worker_pipe();
+    void clean_worker_connections(Worker *worker);
 
     /**
      * [Worker]

--- a/include/swoole_thread.h
+++ b/include/swoole_thread.h
@@ -1,0 +1,57 @@
+/*
+  +----------------------------------------------------------------------+
+  | Swoole                                                               |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 2.0 of the Apache license,    |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
+  | to obtain it through the world-wide-web, please send a note to       |
+  | license@swoole.com so we can mail you a copy immediately.            |
+  +----------------------------------------------------------------------+
+  | Author: Tianfeng Han  <rango@swoole.com>                             |
+  +----------------------------------------------------------------------+
+*/
+
+#pragma once
+
+#include "swoole.h"
+#include "swoole_lock.h"
+
+#include <thread>
+
+#if defined(__linux__)
+#include <sys/syscall.h> /* syscall(SYS_gettid) */
+#elif defined(__FreeBSD__)
+#include <pthread_np.h> /* pthread_getthreadid_np() */
+#elif defined(__OpenBSD__)
+#include <unistd.h> /* getthrid() */
+#elif defined(_AIX)
+#include <sys/thread.h> /* thread_self() */
+#elif defined(__NetBSD__)
+#include <lwp.h> /* _lwp_self() */
+#endif
+
+static long swoole_thread_get_native_id(void) {
+#ifdef __APPLE__
+    uint64_t native_id;
+    (void) pthread_threadid_np(NULL, &native_id);
+#elif defined(__linux__)
+    pid_t native_id;
+    native_id = syscall(SYS_gettid);
+#elif defined(__FreeBSD__)
+    int native_id;
+    native_id = pthread_getthreadid_np();
+#elif defined(__OpenBSD__)
+    pid_t native_id;
+    native_id = getthrid();
+#elif defined(_AIX)
+    tid_t native_id;
+    native_id = thread_self();
+#elif defined(__NetBSD__)
+    lwpid_t native_id;
+    native_id = _lwp_self();
+#endif
+    return native_id;
+}

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -1924,13 +1924,6 @@ void Server::abort_worker(Worker *worker) {
                 session->fd = 0;
             }
         }
-    } else if (is_thread_mode()) {
-        sw_reactor()->destroyed = true;
-        foreach_connection([this, worker](Connection *conn) {
-            if (conn->reactor_id == worker->id) {
-                close(conn->session_id, true);
-            }
-        });
     }
 }
 

--- a/src/server/process.cc
+++ b/src/server/process.cc
@@ -117,7 +117,6 @@ pid_t Factory::spawn_event_worker(Worker *worker) {
     }
 
     if (server_->is_base_mode()) {
-        server_->gs->connection_nums[worker->id] = 0;
         server_->gs->event_workers.main_loop(&server_->gs->event_workers, worker);
     } else {
         server_->start_event_worker(worker);

--- a/tests/swoole_thread/exit.phpt
+++ b/tests/swoole_thread/exit.phpt
@@ -1,0 +1,39 @@
+--TEST--
+swoole_thread: lock
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Thread;
+use Swoole\Thread\Lock;
+use SwooleTest\ThreadManager;
+
+const CODE = 234;
+
+$tm = new ThreadManager();
+
+$tm->parentFunc = function () {
+    $lock = new Lock;
+    $lock->lock();
+    $thread = new Thread(__FILE__, $lock);
+    $lock->unlock();
+    $thread->join();
+    Assert::eq($thread->getExitStatus(), CODE);
+    echo 'DONE' . PHP_EOL;
+};
+
+$tm->childFunc = function ($lock) {
+    $lock->lock();
+    usleep(100_000);
+    exit(CODE);
+};
+
+$tm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_thread/server/exit.phpt
+++ b/tests/swoole_thread/server/exit.phpt
@@ -1,0 +1,78 @@
+--TEST--
+swoole_thread/server: exit
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Thread;
+use Swoole\Http\Server;
+
+const CODE = 95;
+const SIZE = 2 * 1024 * 1024;
+$port = get_constant_port(__FILE__);
+
+$serv = new Server('127.0.0.1', $port, SWOOLE_THREAD);
+$serv->set(array(
+    'worker_num' => 2,
+    'log_file' => '/dev/null',
+    'log_level' => SWOOLE_LOG_ERROR,
+    'enable_coroutine' => false,
+    'init_arguments' => function () {
+        global $queue, $atomic1, $atomic2;
+        $queue = new Swoole\Thread\Queue();
+        $atomic1 = new Swoole\Thread\Atomic(0);
+        $atomic2 = new Swoole\Thread\Atomic(0);
+        return [$queue, $atomic1, $atomic2];
+    }
+));
+$serv->on('WorkerStart', function (Server $serv, $workerId) use ($port) {
+    [$queue, $atomic1, $atomic2] = Thread::getArguments();
+    if ($atomic1->add() == 2) {
+        $queue->push("begin\n", Thread\Queue::NOTIFY_ALL);
+    }
+    echo 'worker start', PHP_EOL;
+});
+$serv->on('workerError', function (Server $serv, $workerId, $workerPid, $status, $signal) {
+    Assert::eq($status, CODE);
+    echo 'worker error', PHP_EOL;
+});
+$serv->on('WorkerStop', function (Server $serv, $workerId) {
+    [$queue, $atomic1, $atomic2] = Thread::getArguments();
+});
+$serv->on('Request', function ($req, $resp) use ($serv) {
+    if ($req->server['request_uri'] == '/exit') {
+        swoole_test_fn('exit');
+    }
+});
+$serv->on('shutdown', function () {
+    global $queue, $atomic1, $atomic2;
+    echo 'shutdown', PHP_EOL;
+    Assert::eq($atomic1->get(), 3);
+});
+$serv->addProcess(new Swoole\Process(function ($process) use ($serv) {
+    [$queue, $atomic] = Thread::getArguments();
+    global $port;
+    echo $queue->pop(-1);
+
+    $rs = @file_get_contents('http://127.0.0.1:' . $port . '/exit');
+    Assert::false($rs);
+
+    usleep(200_000);
+    echo "done\n";
+    $serv->shutdown();
+}));
+$serv->start();
+?>
+--EXPECTF--
+worker start
+worker start
+begin
+worker error
+worker start
+done
+shutdown

--- a/tests/swoole_thread/server/exit.phpt
+++ b/tests/swoole_thread/server/exit.phpt
@@ -46,7 +46,7 @@ $serv->on('WorkerStop', function (Server $serv, $workerId) {
 });
 $serv->on('Request', function ($req, $resp) use ($serv) {
     if ($req->server['request_uri'] == '/exit') {
-        swoole_test_fn('exit');
+        swoole_test_fn('bailout');
     }
 });
 $serv->on('shutdown', function () {

--- a/tests/swoole_thread/server/fatal_error.phpt
+++ b/tests/swoole_thread/server/fatal_error.phpt
@@ -1,0 +1,69 @@
+--TEST--
+swoole_thread/server: fatal error
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Thread;
+
+const SIZE = 2 * 1024 * 1024;
+$port = get_constant_port(__FILE__);
+
+$serv = new Swoole\Http\Server('127.0.0.1', $port, SWOOLE_THREAD);
+$serv->set(array(
+    'worker_num' => 2,
+    'log_level' => SWOOLE_LOG_ERROR,
+    'log_file' => '/dev/null',
+    'init_arguments' => function () {
+        global $queue, $atomic1, $atomic2;
+        $queue = new Swoole\Thread\Queue();
+        $atomic1 = new Swoole\Thread\Atomic(0);
+        $atomic2 = new Swoole\Thread\Atomic(0);
+        return [$queue, $atomic1, $atomic2];
+    }
+));
+$serv->on('WorkerStart', function (Swoole\Server $serv, $workerId) use ($port) {
+    [$queue, $atomic1, $atomic2] = Thread::getArguments();
+    if ($atomic1->add() == 2) {
+        $queue->push("begin\n", Thread\Queue::NOTIFY_ALL);
+    }
+});
+$serv->on('WorkerStop', function (Swoole\Server $serv, $workerId) {
+    [$queue, $atomic1, $atomic2] = Thread::getArguments();
+    $atomic2->add();
+});
+$serv->on('Request', function ($req, $resp) use ($serv) {
+    if ($req->server['request_uri'] == '/error') {
+        trigger_error('user fatal error', E_USER_ERROR);
+    }
+});
+$serv->on('shutdown', function () {
+    global $queue, $atomic1, $atomic2;
+    echo 'shutdown', PHP_EOL;
+    Assert::eq($atomic1->get(), 3);
+});
+$serv->addProcess(new Swoole\Process(function ($process) use ($serv) {
+    [$queue, $atomic] = Thread::getArguments();
+    global $port;
+    echo $queue->pop(-1);
+
+    $rs = @file_get_contents('http://127.0.0.1:' . $port . '/error');
+    Assert::false($rs);
+
+    usleep(100_000);
+    echo "done\n";
+    $serv->shutdown();
+}));
+$serv->start();
+?>
+--EXPECTF--
+begin
+
+Fatal error: user fatal error in %s on line %d
+done
+shutdown


### PR DESCRIPTION
- Support `onWorkerError` callback
- Close all connections within the worker process when a PHP fatal error occurs
- Only execute `Server::abort_worker()` in the worker error callback 
- Added `Thread::getExitStatus()`