### PR TITLE
fix cpu affinity check

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -183,6 +183,7 @@ AC_DEFUN([AC_SWOOLE_CPU_AFFINITY],
         #include <sys/cpuset.h>
         typedef cpuset_t cpu_set_t;
         #else
+        #define _GNU_SOURCE 1
         #include <sched.h>
         #endif
     ]], [[


### PR DESCRIPTION
Without _GNU_SOURCE, 

```
configure:13553: checking for cpu affinity
configure:13577: cc -c  -O2 -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64   -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer   conftest.c >&5
conftest.c: In function 'main':
conftest.c:50:9: error: implicit declaration of function 'CPU_ZERO' [-Wimplicit-function-declaration]
   50 |         CPU_ZERO(&cpu_set);
      |         ^~~~~~~~
configure:13577: $? = 1

```

Fix happen with recent GCC version 14.2 when implicit-function-declaration is now an error.