### PR TITLE
Optimize runtime thread safe

### DIFF
--- a/examples/thread/hook.php
+++ b/examples/thread/hook.php
@@ -1,0 +1,24 @@
+<?php
+
+use Swoole\Thread;
+use Swoole\Thread\Lock;
+
+$args = Thread::getArguments();
+
+if (empty($args)) {
+    Swoole\Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+    $lock = new Lock;
+    $lock->lock();
+    $thread = new Thread(__FILE__, $lock);
+    echo "main thread\n";
+    $lock->unlock();
+    $thread->join();
+    var_dump($thread->getExitStatus());
+} else {
+    $lock = $args[0];
+    $lock->lock();
+    Swoole\Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+    sleep(1);
+    Swoole\Runtime::enableCoroutine(0);
+    exit(234);
+}

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -512,7 +512,13 @@ static inline bool sw_is_main_thread() {
 #endif
 }
 
-size_t sw_get_active_thread_count(void);
+#ifdef SW_THREAD
+size_t sw_active_thread_count(void);
+#else
+static inline size_t sw_active_thread_count(void) {
+    return 1;
+}
+#endif
 void sw_php_exit(int status);
 
 //----------------------------------Constant API------------------------------------

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -512,6 +512,7 @@ static inline bool sw_is_main_thread() {
 #endif
 }
 
+size_t sw_get_active_thread_count(void);
 void sw_php_exit(int status);
 
 //----------------------------------Constant API------------------------------------

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -520,7 +520,12 @@ static inline size_t sw_active_thread_count(void) {
     return 1;
 }
 #endif
+
 void sw_php_exit(int status);
+void sw_php_print_backtrace(zend_long cid = 0,
+                            zend_long options = 0,
+                            zend_long limit = 0,
+                            zval *return_value = nullptr);
 
 //----------------------------------Constant API------------------------------------
 

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -1645,7 +1645,7 @@ bool PHPCoroutine::enable_hook(uint32_t flags) {
      * the main thread can only make changes when there are no active worker threads.
      */
     if (sw_is_main_thread()) {
-        if (sw_get_active_thread_count() > 1) {
+        if (sw_active_thread_count() > 1) {
             zend_throw_exception(swoole_exception_ce,
                                  "The stream runtime hook must be enabled or disabled only when "
                                  "there are no active threads.",

--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -1148,7 +1148,7 @@ static php_stream *socket_create_original(const char *proto,
         return factory(
             proto, protolen, resourcename, resourcenamelen, persistent_id, options, flags, timeout, context STREAMS_CC);
     } else {
-        php_swoole_error(E_WARNING, "unknown protocol '%s'", proto);
+        php_swoole_fatal_error(E_WARNING, "unknown protocol '%s'", proto);
         return nullptr;
     }
 }
@@ -1190,8 +1190,8 @@ static php_stream *socket_create(const char *proto,
     } else if (SW_STREQ(proto, protolen, "udg")) {
         sock = new Socket(SW_SOCK_UNIX_DGRAM);
     } else {
-        /* abort? */
-        goto _tcp;
+        php_swoole_fatal_error(E_WARNING, "unknown protocol '%s'", proto);
+        return nullptr;
     }
 
     if (UNEXPECTED(sock->get_fd() < 0)) {

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2669,6 +2669,15 @@ static PHP_METHOD(swoole_server, start) {
         };
 
         serv->worker_thread_join = [](pthread_t ptid) { php_swoole_thread_join(ptid); };
+
+        /**
+         *The hook must be enabled before creating child threads.
+         *The stream factory and ops are global variables, not thread-local resources.
+         *These runtime hooks must be modified in a single-threaded environment.
+         */
+        if (PHPCoroutine::get_hook_flags() > 0) {
+            PHPCoroutine::enable_hook(PHPCoroutine::get_hook_flags());
+        }
     }
 #endif
 

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -380,8 +380,9 @@ void php_swoole_thread_rshutdown() {
     if (!tsrm_is_main_thread()) {
         return;
     }
-    if (thread_num.load() > 1) {
-        swoole_warning("Fatal Error: %zu active threads are running, cannot exit safely.", thread_num.load());
+    if (sw_get_active_thread_count() > 1) {
+        swoole_warning("Fatal Error: %zu active threads are running, cannot exit safely.",
+                       sw_get_active_thread_count());
         exit(200);
     }
     if (request_info.path_translated) {
@@ -504,6 +505,10 @@ void php_swoole_thread_join(pthread_t ptid) {
 
 int php_swoole_thread_get_exit_status(pthread_t ptid) {
     return thread_exit_status.get(ptid);
+}
+
+size_t sw_get_active_thread_count(void) {
+    return thread_num.load();
 }
 
 void php_swoole_thread_bailout(void) {

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -380,9 +380,9 @@ void php_swoole_thread_rshutdown() {
     if (!tsrm_is_main_thread()) {
         return;
     }
-    if (sw_get_active_thread_count() > 1) {
+    if (sw_active_thread_count() > 1) {
         swoole_warning("Fatal Error: %zu active threads are running, cannot exit safely.",
-                       sw_get_active_thread_count());
+                       sw_active_thread_count());
         exit(200);
     }
     if (request_info.path_translated) {
@@ -507,7 +507,7 @@ int php_swoole_thread_get_exit_status(pthread_t ptid) {
     return thread_exit_status.get(ptid);
 }
 
-size_t sw_get_active_thread_count(void) {
+size_t sw_active_thread_count(void) {
     return thread_num.load();
 }
 

--- a/tests/swoole_runtime/out_of_coroutine.phpt
+++ b/tests/swoole_runtime/out_of_coroutine.phpt
@@ -1,0 +1,16 @@
+--TEST--
+swoole_runtime: out of coroutine
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+Swoole\Runtime::enableCoroutine(SWOOLE_HOOK_TCP);
+
+$out = file_get_contents('http://www.baidu.com/');
+Assert::contains($out, 'About Baidu');
+?>
+--EXPECT--

--- a/tests/swoole_thread/fatal_error_1.inc
+++ b/tests/swoole_thread/fatal_error_1.inc
@@ -1,0 +1,18 @@
+<?php
+
+use Swoole\Thread;
+
+$args = Thread::getArguments();
+if (empty($args)) {
+    echo "start child thread\n";
+    $threads[] = new Thread(__FILE__, 'error');
+    $threads[0]->join();
+    echo "stop child thread\n";
+} else {
+    Co\run(function () {
+        (function () {
+            swoole_implicit_fn('fatal_error');
+        })();
+    });
+}
+echo "DONE\n";

--- a/tests/swoole_thread/fatal_error_1.phpt
+++ b/tests/swoole_thread/fatal_error_1.phpt
@@ -9,23 +9,8 @@ skip_if_nts();
 <?php
 require __DIR__ . '/../include/bootstrap.php';
 
-use Swoole\Thread;
-
 $pm = ProcessManager::exec(function () {
-    $args = Thread::getArguments();
-    if (empty($args)) {
-        echo "start child thread\n";
-        $threads[] = new Thread(__FILE__, 'error');
-        $threads[0]->join();
-        echo "stop thread exited\n";
-    } else {
-        Co\run(function () {
-            (function () {
-                swoole_implicit_fn('fatal_error');
-            })();
-        });
-    }
-    echo "DONE\n";
+    include __DIR__ . '/fatal_error_1.inc';
 });
 $output = $pm->getChildOutput();
 Assert::contains($output, "start child thread\n");

--- a/tests/swoole_thread/fatal_error_2.inc
+++ b/tests/swoole_thread/fatal_error_2.inc
@@ -1,0 +1,16 @@
+<?php
+
+use Swoole\Thread;
+
+$args = Thread::getArguments();
+if (empty($args)) {
+    echo "start child thread\n";
+    $threads[] = new Thread(__FILE__, 'error');
+    $threads[0]->join();
+    echo "stop child thread\n";
+} else {
+    (function () {
+        swoole_implicit_fn('fatal_error');
+    })();
+}
+echo "DONE\n";

--- a/tests/swoole_thread/fatal_error_2.phpt
+++ b/tests/swoole_thread/fatal_error_2.phpt
@@ -11,18 +11,7 @@ require __DIR__ . '/../include/bootstrap.php';
 use Swoole\Thread;
 
 $pm = ProcessManager::exec(function () {
-    $args = Thread::getArguments();
-    if (empty($args)) {
-        echo "start child thread\n";
-        $threads[] = new Thread(__FILE__, 'error');
-        $threads[0]->join();
-        echo "stop thread exited\n";
-    } else {
-        (function () {
-            swoole_implicit_fn('fatal_error');
-        })();
-    }
-    echo "DONE\n";
+    include __DIR__ . '/fatal_error_2.inc';
 });
 $output = $pm->getChildOutput();
 Assert::contains($output, "start child thread\n");

--- a/tests/swoole_thread/fatal_error_3.phpt
+++ b/tests/swoole_thread/fatal_error_3.phpt
@@ -38,4 +38,5 @@ $tm->run();
 child thread
 main thread
 shutdown
+[%s]	WARNING	PHPCoroutine::enable_hook(): The stream runtime hook must be enabled or disabled only when there are no active threads.
 [%s]	WARNING	php_swoole_thread_rshutdown(): Fatal Error: 2 active threads are running, cannot exit safely.

--- a/tests/swoole_thread/server/hook_flags.phpt
+++ b/tests/swoole_thread/server/hook_flags.phpt
@@ -1,0 +1,59 @@
+--TEST--
+swoole_thread/server: base
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Thread;
+use Swoole\Thread\Queue;
+use Swoole\Thread\Atomic;
+
+$port = get_constant_port(__FILE__);
+
+$serv = new Swoole\Http\Server('127.0.0.1', $port, SWOOLE_THREAD);
+$serv->set(array(
+    'worker_num' => 4,
+    'log_level' => SWOOLE_LOG_ERROR,
+    'hook_flags' => SWOOLE_HOOK_ALL,
+    'init_arguments' => function () {
+        global $queue, $atomic;
+        $queue = new Queue();
+        $atomic = new Atomic(0);
+        return [$queue, $atomic];
+    }
+));
+$serv->on('WorkerStart', function (Swoole\Server $serv, $workerId) use ($port) {
+    [$queue, $atomic] = Thread::getArguments();
+    $output = file_get_contents("http://127.0.0.1:$port/");
+    $queue->push($output, Queue::NOTIFY_ALL);
+});
+$serv->on('Request', function ($req, $resp) {
+    usleep(100000);
+    $resp->end('DONE');
+});
+$serv->on('shutdown', function ($server) {
+    global $queue, $atomic;
+    echo 'shutdown', PHP_EOL;
+    Assert::eq($atomic->get(), $server->setting['worker_num']);
+});
+$serv->addProcess(new Swoole\Process(function ($process) use ($serv) {
+    [$queue, $atomic] = Thread::getArguments();
+    for ($i = 0; $i < 4; $i++) {
+        echo $queue->pop(-1), PHP_EOL;
+        $atomic->add(1);
+    }
+    $serv->shutdown();
+}));
+$serv->start();
+?>
+--EXPECT--
+DONE
+DONE
+DONE
+DONE
+shutdown


### PR DESCRIPTION
The Stream factory and ops use global static variables instead of thread-local resources. Therefore, enabling the hook can only occur in a single-threaded mode.

Stream Factory has added a compatibility mode, which will automatically use the original synchronous blocking Stream Factory as an alternative in non-coroutine environments.