### PR TITLE
[5.1] fix MR swoole/swoole-src#5597 for Swoole 5.1.x

### DIFF
--- a/ext-src/swoole_http2_client_coro.cc
+++ b/ext-src/swoole_http2_client_coro.cc
@@ -339,6 +339,7 @@ void php_swoole_http2_client_coro_minit(int module_number) {
     zend_declare_property_null(swoole_http2_client_coro_ce, ZEND_STRL("host"), ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_http2_client_coro_ce, ZEND_STRL("port"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_bool(swoole_http2_client_coro_ce, ZEND_STRL("ssl"), 0, ZEND_ACC_PUBLIC);
+    zend_declare_property_long(swoole_http2_client_coro_ce, ZEND_STRL("serverLastStreamId"), 0, ZEND_ACC_PUBLIC);
 
     zend_declare_property_string(swoole_http2_request_ce, ZEND_STRL("path"), "/", ZEND_ACC_PUBLIC);
     zend_declare_property_string(swoole_http2_request_ce, ZEND_STRL("method"), "GET", ZEND_ACC_PUBLIC);
@@ -349,7 +350,6 @@ void php_swoole_http2_client_coro_minit(int module_number) {
     zend_declare_property_bool(swoole_http2_request_ce, ZEND_STRL("usePipelineRead"), 0, ZEND_ACC_PUBLIC);
 
     zend_declare_property_long(swoole_http2_response_ce, ZEND_STRL("streamId"), 0, ZEND_ACC_PUBLIC);
-    zend_declare_property_long(swoole_http2_response_ce, ZEND_STRL("serverLastStreamId"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_http2_response_ce, ZEND_STRL("errCode"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_long(swoole_http2_response_ce, ZEND_STRL("statusCode"), 0, ZEND_ACC_PUBLIC);
     zend_declare_property_bool(swoole_http2_response_ce, ZEND_STRL("pipeline"), 0, ZEND_ACC_PUBLIC);


### PR DESCRIPTION
The following MRs don't work as should:

* #5383: For the master branch. @matyhtf had fixed it via Git commit e0295f5516b91625fe48743b015cef28bed49453.
* #5597: For Swoole 5.1.x. Here I'm fixing this broken MR.

Test code:

```php
<?php

declare(strict_types=1);

/**
 * How to run this script:
 *    docker run --rm -v "$(pwd):/var/www" -ti phpswoole/swoole:6.0.2-php8.3 php ./test.php
 *    docker run --rm -v "$(pwd):/var/www" -ti phpswoole/swoole:5.1.7-php8.3 php ./test.php
 */

use Swoole\Constant;
use Swoole\Coroutine\Http2\Client;
use Swoole\Http\Request;
use Swoole\Http\Response;
use Swoole\Http\Server;
use Swoole\Http2\Request as Http2Request;

use function Swoole\Coroutine\go;

$server = new Server('127.0.0.1', 9501, SWOOLE_BASE);
$server->set(
    [
        Constant::OPTION_WORKER_NUM          => 1,
        Constant::OPTION_LOG_FILE            => STDOUT,
        Constant::OPTION_OPEN_HTTP2_PROTOCOL => true,
    ]
);
$server->on('workerStart', function (Server $server): void {
    go(function () use ($server): void {
        sleep(2);

        $client = new Client('127.0.0.1', 9501);
        $client->connect();
        $streamId = $client->send(new Http2Request());
        $client->recv();

        assert($client->serverLastStreamId === $streamId);

        $server->shutdown();
    });
});
$server->on(
    'request',
    function (Request $request, Response $response): void {
        $response->goaway();
        $response->end();
    }
);
$server->start();
```
