### PR TITLE
Fix function usage errors in PHP 8.5.

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -243,7 +243,15 @@ static void php_swoole_init_globals(zend_swoole_globals *swoole_globals) {
 
 void php_swoole_register_shutdown_function(const char *function) {
     php_shutdown_function_entry shutdown_function_entry;
-#if PHP_VERSION_ID >= 80100
+#if PHP_VERSION_ID >= 80500
+    zval function_name;
+    memset(&shutdown_function_entry, 0, sizeof(php_shutdown_function_entry));
+    ZVAL_STRING(&function_name, function);
+    shutdown_function_entry.params = NULL;
+    shutdown_function_entry.param_count = 0;
+    register_user_shutdown_function(Z_STRVAL(function_name), Z_STRLEN(function_name), &shutdown_function_entry);
+    zval_ptr_dtor(&function_name);
+#elif PHP_VERSION_ID >= 80100
     zval function_name;
     ZVAL_STRING(&function_name, function);
     zend_fcall_info_init(


### PR DESCRIPTION
In PHP 8.5, the `shutdown_function_entry` has been modified.