### PR TITLE
Fix compiler error

### DIFF
--- a/src/coroutine/hook.cc
+++ b/src/coroutine/hook.cc
@@ -255,11 +255,10 @@ ssize_t swoole_coroutine_read(int sockfd, void *buf, size_t count) {
     }
 
     ssize_t ret = -1;
-    NetSocket sock{
-        .fd = sockfd,
-        .nonblock = 1,
-        .read_timeout = -1,
-    };
+    NetSocket sock = {};
+    sock.fd = sockfd;
+    sock.nonblock = 1;
+    sock.read_timeout = -1;
     async([&]() { ret = sock.read_sync(buf, count); });
     return ret;
 }
@@ -275,11 +274,10 @@ ssize_t swoole_coroutine_write(int sockfd, const void *buf, size_t count) {
     }
 
     ssize_t ret = -1;
-    NetSocket sock{
-        .fd = sockfd,
-        .nonblock = 1,
-        .write_timeout = -1,
-    };
+    NetSocket sock = {};
+    sock.fd = sockfd;
+    sock.nonblock = 1;
+    sock.write_timeout = -1;
     async([&]() { ret = sock.write_sync(buf, count); });
     return ret;
 }


### PR DESCRIPTION
```shell
/home/swoole-src/src/coroutine/hook.cc: 在函数‘ssize_t swoole_coroutine_read(int, void*, size_t)’中:
/home/swoole-src/src/coroutine/hook.cc:262:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
     };
     ^
/home/swoole-src/src/coroutine/hook.cc:262:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
/home/swoole-src/src/coroutine/hook.cc:262:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
/home/swoole-src/src/coroutine/hook.cc:262:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
/home/swoole-src/src/coroutine/hook.cc: 在函数‘ssize_t swoole_coroutine_write(int, const void*, size_t)’中:
/home/swoole-src/src/coroutine/hook.cc:282:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
     };
     ^
/home/swoole-src/src/coroutine/hook.cc:282:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
/home/swoole-src/src/coroutine/hook.cc:282:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
/home/swoole-src/src/coroutine/hook.cc:282:5: 对不起，尚未实现：不平凡的代理初始值设定不受支持
```

```shell
gcc 版本 7.3.0 (GCC)
内核：Linux localhost.localdomain 4.19.90-17.5.ky10.aarch64 #1 SMP Fri Aug 7 13:35:33 CST 2020 aarch64 aarch64 aarch64 GNU/Linux
```