### PR TITLE
Security Fix : CVE-2021-32756 in hiredis

### DIFF
--- a/thirdparty/hiredis/hiredis.c
+++ b/thirdparty/hiredis/hiredis.c
@@ -177,6 +177,7 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         return NULL;
 
     if (elements > 0) {
+        if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;  /* Don't overflow */
         r->element = hi_calloc(elements,sizeof(redisReply*));
         if (r->element == NULL) {
             freeReplyObject(r);


### PR DESCRIPTION
### Summary
Fixes CVE-2021-32765 integer overflow vulnerability in bundled hiredis library's createArrayObject function. 
Adds overflow check to prevent buffer overflow when parsing maliciously crafted Redis RESP multi-bulk data.
[https://nvd.nist.gov/vuln/detail/CVE-2021-32765](https://nvd.nist.gov/vuln/detail/CVE-2021-32765)
[https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)

### Vulnerability Information
- **Location**: thirdparty/hiredis/hiredis.c : createArrayObject
- **Vulnerability**: Integer overflow when parsing Redis RESP multi-bulk data
- **Impact**: Buffer overflow from count * sizeof(redisReply*) calculation exceeding SIZE_MAX → potential memory corruption
- **Risk**: Server crash or RCE when Swoole's Redis integration receives malicious data (Swoole\Coroutine\Redis, swoole_redis async client, pub/sub messaging, etc.)

### How it was fixed

- **Patch**: Added overflow check in createArrayObject function
- **Specific fix**: `if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;`
- **Source**: Applied patch from hiredis upstream commit [76a7b10](https://github.com/redis/hiredis/commit/76a7b10005c70babee357a7d0f2becf28ec7ed1e)