### PR TITLE
Fix type cast for lockwait

### DIFF
--- a/ext-src/swoole_lock.cc
+++ b/ext-src/swoole_lock.cc
@@ -197,7 +197,7 @@ static PHP_METHOD(swoole_lock, lockwait) {
         zend_throw_exception(swoole_exception_ce, "wrong lock type", -3);
         RETURN_FALSE;
     }
-    SW_LOCK_CHECK_RETURN(mutex->lock_wait((int) timeout * 1000));
+    SW_LOCK_CHECK_RETURN(mutex->lock_wait((int) (timeout * 1000)));
 }
 
 static PHP_METHOD(swoole_lock, unlock) {

--- a/tests/swoole_lock/lockwait_twice.phpt
+++ b/tests/swoole_lock/lockwait_twice.phpt
@@ -16,7 +16,7 @@ Assert::false($ret);
 $end = microtime(true);
 
 Assert::eq($lock->errCode, SOCKET_ETIMEDOUT);
-Assert::lessThan($end - $start, 0.2);
+Assert::greaterThanEq($end - $start, 0.2);
 
 ?>
 --EXPECT--


### PR DESCRIPTION
The current implementation of lockwait discards the decimal portion of the input. For example, lockwait(1.2) is incorrectly converted to 1 * 1000 = 1000 milliseconds, instead of the expected 1.2 * 1000 = 1200 milliseconds.

This MR is also applicable to the master branch.