### PR TITLE
lock: support auto dtor options and robust for pthread_mutex

### DIFF
--- a/ext-src/stubs/php_swoole_lock.stub.php
+++ b/ext-src/stubs/php_swoole_lock.stub.php
@@ -1,7 +1,7 @@
 <?php
 namespace Swoole {
     class Lock {
-        public function __construct(int $type = SWOOLE_MUTEX, string $filename = '') {}
+        public function __construct(int $type = SWOOLE_MUTEX, string|int $opts = '') {}
         public function __destruct() {}
         public function lock(): bool {}
         public function locakwait(float $timeout = 1.0): bool {}

--- a/ext-src/stubs/php_swoole_lock_arginfo.h
+++ b/ext-src/stubs/php_swoole_lock_arginfo.h
@@ -1,9 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cacb39e88a0467e15371d94a0efc62534bb383a */
+ * Stub hash: 43407b1dd3365e2180d262662f2ae9987b83e4e7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Lock___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SWOOLE_MUTEX")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 0, "\'\'")
+	ZEND_ARG_TYPE_MASK(0, opts, MAY_BE_STRING|MAY_BE_LONG, "\'\'")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Lock___destruct, 0, 0, 0)

--- a/include/swoole_lock.h
+++ b/include/swoole_lock.h
@@ -50,8 +50,12 @@ class Lock {
         type_ = NONE;
         shared_ = false;
     }
+    bool is_auto_dtor() const {
+        return auto_dtor_;
+    }
     enum Type type_;
     bool shared_;
+    bool auto_dtor_ = true;
 };
 
 struct MutexImpl;
@@ -64,6 +68,7 @@ class Mutex : public Lock {
     enum Flag {
         PROCESS_SHARED = 1,
         ROBUST = 2,
+        NO_AUTO_DTOR = 4,
     };
 
     Mutex(int flags);

--- a/src/lock/mutex.cc
+++ b/src/lock/mutex.cc
@@ -33,6 +33,7 @@ Mutex::Mutex(int flags) : Lock() {
             throw std::bad_alloc();
         }
         shared_ = true;
+        auto_dtor_ = (flags & NO_AUTO_DTOR) == 0;
     } else {
         impl = new MutexImpl();
         shared_ = false;
@@ -61,16 +62,17 @@ Mutex::Mutex(int flags) : Lock() {
         throw std::system_error(errno, std::generic_category(), "pthread_mutex_init() failed");
     }
 }
+#if HAVE_PTHREAD_MUTEX_CONSISTENT
+#define SW_MUTEX_CHECK_ROBUST_LOCK_RC(rc) if (rc == EOWNERDEAD && (flags_ & ROBUST)) { \
+        rc = pthread_mutex_consistent(&impl->lock_); \
+    }
+#else
+#define SW_MUTEX_CHECK_ROBUST_LOCK_RC(rc)
+#endif
 
 int Mutex::lock() {
     int retval = pthread_mutex_lock(&impl->lock_);
-
-#ifdef HAVE_PTHREAD_MUTEX_CONSISTENT
-    if (retval == EOWNERDEAD && (flags_ & ROBUST)) {
-        retval = pthread_mutex_consistent(&impl->lock_);
-    }
-#endif
-
+    SW_MUTEX_CHECK_ROBUST_LOCK_RC(retval);
     return retval;
 }
 
@@ -83,7 +85,9 @@ int Mutex::unlock() {
 }
 
 int Mutex::trylock() {
-    return pthread_mutex_trylock(&impl->lock_);
+    int rc = pthread_mutex_trylock(&impl->lock_);
+    SW_MUTEX_CHECK_ROBUST_LOCK_RC(rc);
+    return rc;
 }
 
 int Mutex::trylock_rd() {
@@ -93,7 +97,9 @@ int Mutex::trylock_rd() {
 #ifdef HAVE_MUTEX_TIMEDLOCK
 int Mutex::lock_wait(int timeout_msec) {
     struct timespec timeo = swoole_time_until(timeout_msec);
-    return pthread_mutex_timedlock(&impl->lock_, &timeo);
+    int rc = pthread_mutex_timedlock(&impl->lock_, &timeo);
+    SW_MUTEX_CHECK_ROBUST_LOCK_RC(rc);
+    return rc;
 }
 #else
 int Mutex::lock_wait(int timeout_msec) {
@@ -106,18 +112,20 @@ int Mutex::lock_wait(int timeout_msec) {
     }
 
     while (timeout_msec > 0) {
-        if (pthread_mutex_trylock(&impl->lock_) == 0) {
+        int rc = pthread_mutex_trylock(&impl->lock_);
+        SW_MUTEX_CHECK_ROBUST_LOCK_RC(rc);
+        if (rc == 0) {
             return 0;
-        } else {
-            usleep(sleep_ms);
-            timeout_msec -= sub;
         }
+        usleep(sleep_ms);
+        timeout_msec -= sub;
     }
     return ETIMEDOUT;
 }
 #endif
 
 Mutex::~Mutex() {
+    if (!is_auto_dtor()) return;
     pthread_mutexattr_destroy(&impl->attr_);
     pthread_mutex_destroy(&impl->lock_);
     if (shared_) {

--- a/tests/swoole_lock/lockwait_twice.phpt
+++ b/tests/swoole_lock/lockwait_twice.phpt
@@ -16,7 +16,7 @@ Assert::false($ret);
 $end = microtime(true);
 
 Assert::eq($lock->errCode, SOCKET_ETIMEDOUT);
-Assert::lessThan($end - $start, 0.2);
+Assert::greaterThanEq($end - $start, 0.2);
 
 ?>
 --EXPECT--


### PR DESCRIPTION
After this PR, `Swoole\Lock` of type MUTEX can be safely shared across processes, even if a lock holder exits or is killed unexpectedly. The lock will automatically recover via robust mutex handling.

The newly introduced flags may need to be reconsidered and exported as constants for PHP users.