### PR TITLE
Add timed lock support to RWLock

### DIFF
--- a/ext-src/stubs/php_swoole_lock.stub.php
+++ b/ext-src/stubs/php_swoole_lock.stub.php
@@ -6,7 +6,7 @@ namespace Swoole {
         public function lock(): bool {}
         public function locakwait(float $timeout = 1.0): bool {}
         public function trylock(): bool {}
-        public function lock_read(): bool {}
+        public function lock_read(?float $timeout = null): bool {}
         public function trylock_read(): bool {}
         public function unlock(): bool {}
     }

--- a/ext-src/stubs/php_swoole_lock.stub.php
+++ b/ext-src/stubs/php_swoole_lock.stub.php
@@ -4,9 +4,9 @@ namespace Swoole {
         public function __construct(int $type = SWOOLE_MUTEX) {}
         public function __destruct() {}
         public function lock(): bool {}
-        public function locakwait(float $timeout = 1.0): bool {}
+        public function lockwait(float $timeout = 1.0, int $kind = 0): bool {}
         public function trylock(): bool {}
-        public function lock_read(?float $timeout = null): bool {}
+        public function lock_read(): bool {}
         public function trylock_read(): bool {}
         public function unlock(): bool {}
     }

--- a/ext-src/stubs/php_swoole_lock_arginfo.h
+++ b/ext-src/stubs/php_swoole_lock_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 078bbefb0c45cb686da54e4c700bad31710589ef */
+ * Stub hash: dbbf1e4038442388b45b12e65181de185bd485d9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Lock___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SWOOLE_MUTEX")
@@ -17,7 +17,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Lock_trylock arginfo_class_Swoole_Lock_lock
 
-#define arginfo_class_Swoole_Lock_lock_read arginfo_class_Swoole_Lock_lock
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Lock_lock_read, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 1, "null")
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Lock_trylock_read arginfo_class_Swoole_Lock_lock
 

--- a/ext-src/stubs/php_swoole_lock_arginfo.h
+++ b/ext-src/stubs/php_swoole_lock_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dbbf1e4038442388b45b12e65181de185bd485d9 */
+ * Stub hash: aa2ff16543143c6d0e8858e9900fa511cffed40c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Lock___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SWOOLE_MUTEX")
@@ -11,15 +11,14 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Lock_lock, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Lock_locakwait, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Lock_lockwait, 0, 0, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "1.0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, kind, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Lock_trylock arginfo_class_Swoole_Lock_lock
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Lock_lock_read, 0, 0, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Swoole_Lock_lock_read arginfo_class_Swoole_Lock_lock
 
 #define arginfo_class_Swoole_Lock_trylock_read arginfo_class_Swoole_Lock_lock
 

--- a/ext-src/swoole_lock.cc
+++ b/ext-src/swoole_lock.cc
@@ -88,7 +88,7 @@ static const zend_function_entry swoole_lock_methods[] =
     PHP_ME(swoole_lock, __construct,  arginfo_class_Swoole_Lock___construct,  ZEND_ACC_PUBLIC)
     PHP_ME(swoole_lock, __destruct,   arginfo_class_Swoole_Lock___destruct,   ZEND_ACC_PUBLIC)
     PHP_ME(swoole_lock, lock,         arginfo_class_Swoole_Lock_lock,         ZEND_ACC_PUBLIC)
-    PHP_ME(swoole_lock, lockwait,     arginfo_class_Swoole_Lock_locakwait,    ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_lock, lockwait,     arginfo_class_Swoole_Lock_lockwait,    ZEND_ACC_PUBLIC)
     PHP_ME(swoole_lock, trylock,      arginfo_class_Swoole_Lock_trylock,      ZEND_ACC_PUBLIC)
     PHP_ME(swoole_lock, lock_read,    arginfo_class_Swoole_Lock_lock_read,    ZEND_ACC_PUBLIC)
     PHP_ME(swoole_lock, trylock_read, arginfo_class_Swoole_Lock_trylock_read, ZEND_ACC_PUBLIC)
@@ -170,10 +170,13 @@ static PHP_METHOD(swoole_lock, lock) {
 
 static PHP_METHOD(swoole_lock, lockwait) {
     double timeout = 1.0;
+    // 0: write lock, 1: read lock(only for rwlock)
+    zend_long kind = 0;
 
-    ZEND_PARSE_PARAMETERS_START(0, 1)
+    ZEND_PARSE_PARAMETERS_START(0, 2)
     Z_PARAM_OPTIONAL
     Z_PARAM_DOUBLE(timeout)
+    Z_PARAM_LONG(kind)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     Lock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
@@ -196,6 +199,9 @@ static PHP_METHOD(swoole_lock, lockwait) {
         if (rwlock == nullptr) {
             zend_throw_exception(swoole_exception_ce, "wrong lock type", -3);
             RETURN_FALSE;
+        }
+        if (kind == 1) {
+            SW_LOCK_CHECK_RETURN(rwlock->lock_rd_wait((int) (timeout * 1000)));
         }
         SW_LOCK_CHECK_RETURN(rwlock->lock_wait((int) (timeout * 1000)));
     }
@@ -224,28 +230,6 @@ static PHP_METHOD(swoole_lock, trylock_read) {
 }
 
 static PHP_METHOD(swoole_lock, lock_read) {
-    double timeout = 0.0;
-    bool time_is_null = true;
-
-    ZEND_PARSE_PARAMETERS_START(0, 1)
-    Z_PARAM_OPTIONAL
-    Z_PARAM_DOUBLE_OR_NULL(timeout, time_is_null)
-    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
-
     Lock *lock = php_swoole_lock_get_and_check_ptr(ZEND_THIS);
-#ifdef HAVE_RWLOCK
-    if (!time_is_null) {
-        if (lock->get_type() != Lock::RW_LOCK) {
-            zend_throw_exception(swoole_exception_ce, "only rwlock supports lock_read with timeout", -2);
-            RETURN_FALSE;
-        }
-        RWLock *rwlock = dynamic_cast<RWLock *>(lock);
-        if (rwlock == nullptr) {
-            zend_throw_exception(swoole_exception_ce, "wrong lock type", -3);
-            RETURN_FALSE;
-        }
-        SW_LOCK_CHECK_RETURN(rwlock->lock_rd_wait((int) (timeout * 1000)));
-    }
-#endif
     SW_LOCK_CHECK_RETURN(lock->lock_rd());
 }

--- a/include/swoole_lock.h
+++ b/include/swoole_lock.h
@@ -88,6 +88,8 @@ class RWLock final : public Lock {
     int unlock() override;
     int trylock_rd() override;
     int trylock() override;
+    int lock_wait(int timeout_msec);
+    int lock_rd_wait(int timeout_msec);
 };
 #endif
 
@@ -103,8 +105,6 @@ class SpinLock final : public Lock {
     int unlock() override;
     int trylock_rd() override;
     int trylock() override;
-    int lock_wait(int timeout_msec);
-    int lock_rd_wait(int timeout_msec);
 };
 #endif
 

--- a/include/swoole_lock.h
+++ b/include/swoole_lock.h
@@ -103,6 +103,8 @@ class SpinLock final : public Lock {
     int unlock() override;
     int trylock_rd() override;
     int trylock() override;
+    int lock_wait(int timeout_msec);
+    int lock_rd_wait(int timeout_msec);
 };
 #endif
 

--- a/src/lock/rw_lock.cc
+++ b/src/lock/rw_lock.cc
@@ -52,6 +52,20 @@ int RWLock::lock_rd() {
     return pthread_rwlock_rdlock(&impl->_lock);
 }
 
+int RWLock::lock_rd_wait(int timeout_msec) {
+    timespec timeo;
+    realtime_get(&timeo);
+    realtime_add(&timeo, timeout_msec);
+    return pthread_rwlock_timedrdlock(&impl->_lock, &timeo);
+}
+
+int RWLock::lock_wait(int timeout_msec) {
+    timespec timeo;
+    realtime_get(&timeo);
+    realtime_add(&timeo, timeout_msec);
+    return pthread_rwlock_timedwrlock(&impl->_lock, &timeo);
+}
+
 int RWLock::lock() {
     return pthread_rwlock_wrlock(&impl->_lock);
 }


### PR DESCRIPTION
This PR introduces *timeout-based locking support* for the `RWLock` type in `Swoole\\Lock`, aligning its behavior with `Mutex` based.

Changes introduced:

- `lock_read()` → `lock_read(?float $timeout = null)`: Enables acquiring a read lock with an optional timeout.
- `lockwait(float $timeout)`: Extended to support `RWLock` in addition to `Mutex`.

These PHP-level API changes introduce new semantics around lock acquisition timing and may warrant further discussion regarding coroutine compatibility and expected behavior.
