### PR TITLE
fix: worker cannot send signal to manager when running as non-root user

### DIFF
--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -25,6 +25,9 @@
 #elif defined(__FreeBSD__)
 #include <sys/procctl.h>
 #endif
+// _GNU_SOURCE already defined in swoole.h
+#include <unistd.h>
+#include <pwd.h>
 
 namespace swoole {
 /**
@@ -149,6 +152,16 @@ void Manager::wait(Server *_server) {
         procctl(P_PID, 0, PROC_PDEATHSIG_CTL, &sigid);
 #endif
         _server->gs->manager_barrier.wait();
+
+        if (_server->reload_async && !_server->user_.empty()) {
+            const auto uid = getuid();
+            if (uid == 0) {
+                const passwd *uinfo = getpwnam(_server->user_.c_str());;
+                if (uinfo && uinfo->pw_uid != uid) {
+                    setresuid(-1, -1, uinfo->pw_uid);
+                }
+            }
+        }
     }
 
     if (_server->isset_hook(Server::HOOK_MANAGER_START)) {


### PR DESCRIPTION
This PR fixes an issue where a worker process failed to send a `SIGIO ` signal to the manager process after `push_message` during the `async_reload` phase when running as a non-root user. 
Modifying the manager process’s SUID would be a simpler workaround, but it may introduce security risks.

As an alternative, [this patch](https://github.com/Appla/swoole-src/tree/fix_push_msg_signal) delegates the signal delivery to the reactor thread.