### PR TITLE
Fix #6004 drop broken conditionals, PHP_VERSION_ID not defined

### DIFF
--- a/thirdparty/php84/pdo_firebird/pdo_firebird_utils.cpp
+++ b/thirdparty/php84/pdo_firebird/pdo_firebird_utils.cpp
@@ -18,7 +18,6 @@
 #include <firebird/Interface.h>
 #include <cstring>
 
-#if PHP_VERSION_ID < 80500
 /* Returns the client version. 0 bytes are minor version, 1 bytes are major version. */
 extern "C" unsigned fb_get_client_version(void)
 {
@@ -89,5 +88,4 @@ extern "C" ISC_STATUS fb_decode_timestamp_tz(ISC_STATUS* isc_status, const ISC_T
 	return isc_status[1];
 }
 
-#endif
 #endif

--- a/thirdparty/php85/pdo_firebird/pdo_firebird_utils.cpp
+++ b/thirdparty/php85/pdo_firebird/pdo_firebird_utils.cpp
@@ -18,8 +18,6 @@
 #include <firebird/Interface.h>
 #include <cstring>
 
-#if PHP_VERSION_ID >= 80500
-
 /* Returns the client version. 0 bytes are minor version, 1 bytes are major version. */
 extern "C" unsigned fb_get_client_version(void)
 {
@@ -90,5 +88,4 @@ extern "C" ISC_STATUS fb_decode_timestamp_tz(ISC_STATUS* isc_status, const ISC_T
 	return isc_status[1];
 }
 
-#endif
 #endif


### PR DESCRIPTION
There is nothing related to PHP in the include stack, so PHP_VERSION is never defined