### PR TITLE
Fix potential integer overflow vulnerability in cloned function

### DIFF
--- a/thirdparty/hiredis/sds.c
+++ b/thirdparty/hiredis/sds.c
@@ -104,6 +104,7 @@ sds sdsnewlen(const void *init, size_t initlen) {
     int hdrlen = sdsHdrSize(type);
     unsigned char *fp; /* flags pointer. */
 
+    assert(initlen + hdrlen + 1 > initlen); /* Catch size_t overflow */
     sh = s_malloc(hdrlen+initlen+1);
     if (sh == NULL) return NULL;
     if (!init)


### PR DESCRIPTION
Hi Swool-src Development Team,

Our tool identified a potential integer overflow vulnerability in a clone function `sdsnewlen()` in `thirdparty/hiredis/sds.c` sourced from [redis/redis](https://github.com/redis/redis). These issues, originally reported in [CVE-2021-21309](https://nvd.nist.gov/vuln/detail/CVE-2021-21309), were resolved in the repository via this commit https://github.com/redis/redis/commit/c992857618db99776917f10bf4f2345a5fdc78b0.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.