### PR TITLE
docs: add `sudo` privileges to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Compile and install at the source folder:
 ```shell
 phpize && \
 ./configure && \
-make && make install
+make && sudo make install
 ```
 
 #### Enable extension in PHP

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -57,7 +57,7 @@ cd swoole-src
 phpize
 ./configure ${options}
 make -j$(nproc)
-make install
+sudo make install
 ```
 Need to configure `php.ini`, add `extension=swoole.so` to enable `ext-swoole`.
 


### PR DESCRIPTION
Add `sudo` to the build example (`make install` step) in the documentation.

The docs recommend using `sudo` privileges. This change also keeps the instructions consistent with other sections of the `Markdown` documentation where `sudo` is already specified for the installation step.