### PR TITLE
fix: `run-tests` script with xdebug version `>=` `3.0.0`

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -922,7 +922,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         'session' => array('session.auto_start=0'),
         'tidy' => array('tidy.clean_output=0'),
         'zlib' => array('zlib.output_compression=Off'),
-        'xdebug' => array('xdebug.default_enable=0'),
+        'xdebug' => version_compare(phpversion('xdebug'), '3.0.0', '>=') ? array('xdebug.mode=off') : array('xdebug.default_enable=0'),
         'mbstring' => array('mbstring.func_overload=0'),
     );
 


### PR DESCRIPTION
### Fix Xdebug configuration for versions 3.0+

When running `./start.sh` with Xdebug 3 or higher, the test suite fails with the following error:
```bash
[BORK] Xdebug: [Config] The setting 'xdebug.default_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.default_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
```

According to the Xdebug upgrade guide:
https://xdebug.org/docs/upgrade_guide#Changed-Configuration-Settings

The configuration setting has changed in Xdebug 3.

This PR updates the configuration used by the test environment so that when Xdebug version 3.0.0 or higher is detected, `xdebug.mode=off` is used instead of `xdebug.default_enable=0`.

This prevents the configuration warning and allows the test suite to run normally.