### PR TITLE
Feature: Export zend_autoload original handler function pointer

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1549,7 +1549,7 @@ EOF
         AC_MSG_RESULT([disabled])
     fi
 
-    PHP_INSTALL_HEADERS([ext/swoole], [ext-src/*.h config.h php_swoole.h \
+    PHP_INSTALL_HEADERS([ext/swoole], [ext-src/*.h config.h php_swoole.h php_swoole_api.h \
         include/*.h \
         stubs/*.h \
         thirdparty/*.h \

--- a/ext-src/php_swoole_private.h
+++ b/ext-src/php_swoole_private.h
@@ -190,6 +190,9 @@ extern zend_class_entry *swoole_error_ce;
 extern zend_class_entry *swoole_resolve_context_ce;
 extern zend_object_handlers swoole_resolve_context_handlers;
 
+// Export zend_autoload hook
+extern zend_class_entry *(*swoole_hook_zend_autoload)(zend_string *name, zend_string *lc_name);
+
 PHP_FUNCTION(swoole_clear_dns_cache);
 PHP_FUNCTION(swoole_last_error);
 PHP_FUNCTION(swoole_set_process_name);

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -953,8 +953,7 @@ void *PHPCoroutine::stack_base(PHPContext *ctx) {
 #endif /* ZEND_CHECK_STACK_LIMIT */
 
 /* hook autoload */
-
-static zend_class_entry *(*original_zend_autoload)(zend_string *name, zend_string *lc_name);
+zend_class_entry *(*swoole_hook_zend_autoload)(zend_string *name, zend_string *lc_name) = nullptr;
 
 struct AutoloadContext {
     Coroutine *coroutine;
@@ -969,7 +968,7 @@ struct AutoloadQueue {
 static zend_class_entry *swoole_coroutine_autoload(zend_string *name, zend_string *lc_name) {
     auto current = Coroutine::get_current();
     if (!current) {
-        return original_zend_autoload(name, lc_name);
+        return swoole_hook_zend_autoload(name, lc_name);
     }
 
     ZEND_ASSERT(EG(in_autoload) != nullptr);
@@ -998,7 +997,7 @@ static zend_class_entry *swoole_coroutine_autoload(zend_string *name, zend_strin
     queue.queue = &queue_object;
 
     zend_hash_add_ptr(SWOOLE_G(in_autoload), lc_name, &queue);
-    zend_class_entry *ce = original_zend_autoload(name, lc_name);
+    zend_class_entry *ce = swoole_hook_zend_autoload(name, lc_name);
     zend_hash_del(SWOOLE_G(in_autoload), lc_name);
 
     AutoloadContext *pending_context = nullptr;
@@ -1066,7 +1065,7 @@ void php_swoole_coroutine_minit(int module_number) {
     }
 
     /* hook autoload */
-    original_zend_autoload = zend_autoload;
+    swoole_hook_zend_autoload = zend_autoload;
     zend_autoload = swoole_coroutine_autoload;
     SWOOLE_G(in_autoload) = nullptr;
 }


### PR DESCRIPTION
Allow modules that depends on swoole module, hook zend_autoload function.