### PR TITLE
Fix io_uring kernel version check to correctly handle major version > 6

### DIFF
--- a/src/coroutine/iouring.cc
+++ b/src/coroutine/iouring.cc
@@ -116,13 +116,13 @@ Iouring::Iouring(Reactor *_reactor) {
     parse_kernel_version(SwooleG.uname.release, &major, &minor);
 
 #ifdef HAVE_IOURING_FUTEX
-    if (!(major >= 6 && minor >= 7)) {
+    if (!((major > 6) || (major == 6 && minor >= 7))) {
         swoole_error("The Iouring::futex_wait()/Iouring::futex_wakeup() requires `6.7` or higher Linux kernel");
     }
 #endif
 
 #ifdef HAVE_IOURING_FTRUNCATE
-    if (!(major >= 6 && minor >= 9)) {
+    if (!((major > 6) || (major == 6 && minor >= 9))) {
         swoole_error("The Iouring::ftruncate() requires `6.9` or higher Linux kernel");
     }
 #endif


### PR DESCRIPTION
The condition `major >= 6 && minor >= N` incorrectly rejects kernels where the major version exceeds 6. For example, Linux 7.0 evaluates as `7 >= 6 && 0 >= 7` → `false`, triggering the error even though 7.0 is newer than 6.7.

The fix uses the standard version comparison: `(major > 6) || (major == 6 && minor >= N)`, applied to both the futex (≥ 6.7) and ftruncate (≥ 6.9) guards.

Fixes #6083