### PR TITLE
Fix: Update tsrm local storage cache on swoole globals ctor

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -373,6 +373,10 @@ PHP_INI_END()
 // clang-format on
 
 static void php_swoole_init_globals(zend_swoole_globals *swoole_globals) {
+    #if defined(COMPILE_DL_SWOOLE) && defined(ZTS)
+	ZEND_TSRMLS_CACHE_UPDATE();
+    #endif
+
     swoole_globals->enable_library = true;
     swoole_globals->enable_fiber_mock = false;
     swoole_globals->enable_preemptive_scheduler = false;


### PR DESCRIPTION
Update local storage cache when TSRM is configured with enabled static local cache ZEND_ENABLE_STATIC_TSRMLS_CACHE

This enables to module function faster due each access to CG/EG/... globals access variable instead making call.
https://github.com/php/php-src/blob/master/TSRM/TSRM.h#L182
