### PR TITLE
Initialize SWOOLE_G(cli) to avoid reading an uninitialized global under threaded SAPIs

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -384,6 +384,7 @@ static void php_swoole_init_globals(zend_swoole_globals *swoole_globals) {
     swoole_globals->blocking_threshold = 100000;
     swoole_globals->profile = false;
     swoole_globals->leak_detection = false;
+    swoole_globals->cli = false;
 
     if (strcmp("cli", sapi_module.name) == 0 || strcmp("phpdbg", sapi_module.name) == 0 ||
         strcmp("embed", sapi_module.name) == 0 || strcmp("micro", sapi_module.name) == 0) {


### PR DESCRIPTION
The globals ctor `php_swoole_init_globals()` sets every module global except `cli`, relying on zero-initialized storage:

```c
static void php_swoole_init_globals(zend_swoole_globals *swoole_globals) {
    swoole_globals->enable_library = 1;
    ...
    swoole_globals->in_autoload = nullptr;
    if (strcmp("cli", sapi_module.name) == 0 || strcmp("phpdbg", sapi_module.name) == 0 ||
        strcmp("embed", sapi_module.name) == 0 || strcmp("micro", sapi_module.name) == 0) {
        swoole_globals->cli = 1;
    }
}
```

That assumption doesn't hold for frankenphp initialising with multiple threads at once:

### Backtrace (FrankenPHP, ZTS PHP 8.5, swoole 6.2.2, first HTTP request)
```
#0  swoole_set_task_tmpdir(std::string const&)
#1  zm_activate_swoole (PHP_RINIT_FUNCTION(swoole))
#2  zend_activate_modules
#3  php_request_startup      <- frankenphp worker thread
```

Fix: zero out before setting it back to 1 if the condition is true.