### PR TITLE
Fix partial writes in hooked streams

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -506,29 +506,32 @@ static php_stream_size_t socket_write(php_stream *stream, const char *buf, size_
         sock->set_err(errno);
     }
 
-    if (didwrite < 0 || (size_t) didwrite != count) {
-        /* we do not expect the outer layer to continue to call the `send` syscall in a loop
-         * and `didwrite` is meaningless if it failed */
-        didwrite = -1;
-        abstract->stream.timeout_event = (sock->errCode == ETIMEDOUT);
-        php_error_docref(nullptr,
-                         E_NOTICE,
-                         "Send of " ZEND_LONG_FMT " bytes failed with errno=%d %s",
-                         (zend_long) count,
-                         sock->errCode,
-                         sock->errMsg);
-    } else {
-        php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), didwrite, 0);
-    }
-
+    // Preserve positive partial counts so PHP can retry the unwritten remainder.
     if (didwrite < 0) {
-        if (sock->errCode == ETIMEDOUT || sock->get_socket()->catch_write_error(sock->errCode) == SW_WAIT) {
+        abstract->stream.timeout_event = (sock->errCode == ETIMEDOUT);
+
+        if (sock->errCode != ETIMEDOUT && sock->get_socket()->catch_write_error(sock->errCode) == SW_WAIT) {
             didwrite = 0;
         } else {
+            php_error_docref(nullptr,
+                             E_NOTICE,
+                             "Send of " ZEND_LONG_FMT " bytes failed with errno=%d %s",
+                             (zend_long) count,
+                             sock->errCode,
+                             sock->errMsg);
+
+            if (sock->errCode == ETIMEDOUT) {
+                didwrite = 0;
+            } else {
+                stream->eof = 1;
+            }
+        }
+    } else {
+        php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), didwrite, 0);
+
+        if (didwrite == 0) {
             stream->eof = 1;
         }
-    } else if (didwrite == 0) {
-        stream->eof = 1;
     }
 
 _exit:

--- a/tests/swoole_runtime/stream_socket_partial_write.phpt
+++ b/tests/swoole_runtime/stream_socket_partial_write.phpt
@@ -1,0 +1,82 @@
+--TEST--
+swoole_runtime: nonblocking stream writes preserve partial byte counts
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--INI--
+error_reporting=E_ALL
+display_errors=1
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$server   = null;
+$sender   = null;
+$receiver = null;
+
+Co\run(function () use (&$server, &$sender, &$receiver): void {
+    try {
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+
+        if ($server === false) {
+            throw new RuntimeException('Failed to create the loopback server.');
+        }
+
+        $address = stream_socket_get_name($server, false);
+
+        if (!is_string($address)) {
+            throw new RuntimeException('Failed to resolve the loopback server address.');
+        }
+
+        $sender   = stream_socket_client("tcp://{$address}");
+        $receiver = stream_socket_accept($server, 1);
+
+        if ($sender === false || $receiver === false) {
+            throw new RuntimeException('Failed to create the loopback connection.');
+        }
+
+        $senderSocket   = socket_import_stream($sender);
+        $receiverSocket = socket_import_stream($receiver);
+
+        if ($senderSocket === false || $receiverSocket === false) {
+            throw new RuntimeException('Failed to import the loopback sockets.');
+        }
+
+        if (!socket_set_option($senderSocket, SOL_SOCKET, SO_SNDBUF, 4096)
+            || !socket_set_option($receiverSocket, SOL_SOCKET, SO_RCVBUF, 4096)) {
+            throw new RuntimeException('Failed to reduce the loopback socket buffers.');
+        }
+
+        stream_set_blocking($sender, false);
+
+        $payload                     = str_repeat('partial-write:', 65536);
+        $firstWrite                  = fwrite($sender, $payload);
+        $secondWrite                 = fwrite($sender, $payload);
+        $senderOpenAfterBackpressure = !feof($sender);
+
+        stream_socket_shutdown($sender, STREAM_SHUT_WR);
+        stream_set_blocking($receiver, true);
+
+        $received = stream_get_contents($receiver);
+
+        var_dump(is_int($firstWrite) && $firstWrite > 0 && $firstWrite < strlen($payload));
+        var_dump($secondWrite === 0);
+        var_dump($senderOpenAfterBackpressure);
+        var_dump(is_string($received) && strlen($received) === $firstWrite);
+        var_dump(is_string($received) && $received === substr($payload, 0, $firstWrite));
+    } finally {
+        foreach ([$sender, $receiver, $server] as $stream) {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
## Summary

Preserve partial byte counts returned by hooked stream writes instead of converting them into failures.

When a nonblocking socket accepts only part of a buffer, or `send_all()` makes progress before a terminal write error, the current stream adapter replaces that progress with `-1`. This can discard the caller's accounting boundary and emits a notice for ordinary socket backpressure.

## Implementation

The stream adapter now treats write results according to their actual meaning:

- positive values remain successful progress;
- retryable backpressure returns zero without a notice or false EOF;
- timeouts retain their existing timeout state and reporting;
- terminal errors retain their existing notice and EOF behavior.

This does not add buffering or another retry loop. PHP remains responsible for advancing by the returned byte count and retrying the unwritten remainder.

## Testing

The regression test uses a loopback TCP connection with constrained socket buffers to force a positive partial write followed by backpressure. It verifies stream liveness and exact byte preservation while treating any unexpected notice as a failure.
