### PR TITLE
Fix hooked stream socket shutdown return values

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -1057,7 +1057,7 @@ static inline int socket_xport_api(php_stream *stream, SocketImpl *sock, php_str
         }
         break;
     case STREAM_XPORT_OP_SHUTDOWN:
-        xparam->outputs.returncode = sock->shutdown(shutdown_how[xparam->how]);
+        xparam->outputs.returncode = sock->shutdown(shutdown_how[xparam->how]) ? 0 : -1;
         break;
     default:
 #ifdef SW_DEBUG

--- a/tests/swoole_runtime/stream_socket_shutdown.phpt
+++ b/tests/swoole_runtime/stream_socket_shutdown.phpt
@@ -1,0 +1,58 @@
+--TEST--
+swoole_runtime: stream_socket_shutdown return values
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--INI--
+error_reporting=E_ALL
+display_errors=1
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$server   = null;
+$sender   = null;
+$receiver = null;
+
+Co\run(function () use (&$server, &$sender, &$receiver): void {
+    try {
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+
+        if ($server === false) {
+            throw new RuntimeException('Failed to create the loopback server.');
+        }
+
+        $address = stream_socket_get_name($server, false);
+
+        if (!is_string($address)) {
+            throw new RuntimeException('Failed to resolve the loopback server address.');
+        }
+
+        $sender   = stream_socket_client("tcp://{$address}");
+        $receiver = stream_socket_accept($server, 1);
+
+        if ($sender === false || $receiver === false) {
+            throw new RuntimeException('Failed to create the loopback connection.');
+        }
+
+        fwrite($sender, 'payload');
+
+        var_dump(stream_socket_shutdown($sender, STREAM_SHUT_WR));
+        var_dump(stream_get_contents($receiver));
+        var_dump(feof($receiver));
+        var_dump(stream_socket_shutdown($sender, STREAM_SHUT_WR));
+    } finally {
+        foreach ([$sender, $receiver, $server] as $stream) {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+});
+?>
+--EXPECT--
+bool(true)
+string(7) "payload"
+bool(true)
+bool(false)


### PR DESCRIPTION
## Summary

Fix the return value reported by `stream_socket_shutdown()` when runtime hooks are enabled.

Swoole's coroutine socket returns a boolean from `shutdown()`, while PHP's stream transport API expects `0` for success and `-1` for failure. Passing the boolean through directly reverses the result observed by PHP even though the underlying shutdown occurs correctly.

## Implementation

Normalize the boolean at the transport adapter boundary, matching the convention already used by the adjacent listen operation. Socket state, ownership, and shutdown behavior remain unchanged.

## Testing

The loopback regression verifies the successful write-half return value, payload delivery, peer EOF, and the failure reported by a repeated shutdown. Strict diagnostic output ensures unexpected warnings or notices fail the test.
