### PR TITLE
Fix concurrent SSH2 authentication state and redact secrets

### DIFF
--- a/ext-src/php_swoole_ssh2.h
+++ b/ext-src/php_swoole_ssh2.h
@@ -15,6 +15,11 @@ typedef struct _php_ssh2_session_data {
     zval *disconnect_cb;
 
     SocketImpl *socket;
+
+    /* Keyboard-interactive password for the in-flight auth attempt. This lives
+     * on the session so concurrent coroutines cannot overwrite callback state. */
+    const char *kbd_password;
+    size_t kbd_password_len;
 } php_ssh2_session_data;
 
 static inline swoole::EventType ssh2_get_event_type(LIBSSH2_SESSION *session) {

--- a/ext-src/stubs/php_swoole_ssh2.stub.php
+++ b/ext-src/stubs/php_swoole_ssh2.stub.php
@@ -54,7 +54,7 @@ function ssh2_auth_none($session, string $username): bool {}
  * @param string $password The password to use for authentication
  * @return bool Returns true on success or false on failure
  */
-function ssh2_auth_password($session, string $username, string $password): bool {}
+function ssh2_auth_password($session, string $username, #[\SensitiveParameter] string $password): bool {}
 
 /**
  * Authenticate using a public key
@@ -65,7 +65,7 @@ function ssh2_auth_password($session, string $username, string $password): bool 
  * @param string $passphrase [optional] The passphrase for the private key
  * @return bool Returns true on success or false on failure
  */
-function ssh2_auth_pubkey_file($session, string $username, string $pubkeyfile, string $privkeyfile, ?string $passphrase = null): bool {}
+function ssh2_auth_pubkey_file($session, string $username, string $pubkeyfile, string $privkeyfile, #[\SensitiveParameter] ?string $passphrase = null): bool {}
 
 /**
  * Authenticate using a public key
@@ -76,7 +76,7 @@ function ssh2_auth_pubkey_file($session, string $username, string $pubkeyfile, s
  * @param string $passphrase [optional] The passphrase for the private key
  * @return bool Returns true on success or false on failure
  */
-function ssh2_auth_pubkey($session, string $username, string $pubkey, string $privkey, ?string $passphrase = null): bool {}
+function ssh2_auth_pubkey($session, string $username, string $pubkey, #[\SensitiveParameter] string $privkey, #[\SensitiveParameter] ?string $passphrase = null): bool {}
 
 /**
  * Authenticate using a public hostkey
@@ -89,7 +89,7 @@ function ssh2_auth_pubkey($session, string $username, string $pubkey, string $pr
  * @param string $local_username [optional] The local username
  * @return bool Returns true on success or false on failure
  */
-function ssh2_auth_hostbased_file($session, string $username, string $hostname, string $pubkeyfile, string $privkeyfile, ?string $passphrase = null, ?string $local_username = null): bool {}
+function ssh2_auth_hostbased_file($session, string $username, string $hostname, string $pubkeyfile, string $privkeyfile, #[\SensitiveParameter] ?string $passphrase = null, ?string $local_username = null): bool {}
 
 /**
  * Request SSH port forwarding

--- a/ext-src/stubs/php_swoole_ssh2_arginfo.h
+++ b/ext-src/stubs/php_swoole_ssh2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dfaf05276c29a8606b576793221837fe7170806d */
+ * Stub hash: 2d72aa4bdf64bb574090f464861cbc80ff9d8e83 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ssh2_connect, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, host, IS_STRING, 0)

--- a/tests/swoole_ssh2/ssh2_sensitive_auth_parameters.phpt
+++ b/tests/swoole_ssh2/ssh2_sensitive_auth_parameters.phpt
@@ -1,0 +1,71 @@
+--TEST--
+SSH2 authentication parameters publish sensitive metadata and redact traces
+--SKIPIF--
+<?php
+if (!function_exists('ssh2_auth_password')) {
+    echo 'skip SSH2 support is not enabled';
+}
+?>
+--INI--
+zend.exception_ignore_args=0
+--FILE--
+<?php
+$sensitiveParameters = [
+    ['ssh2_auth_password', 'password'],
+    ['ssh2_auth_pubkey_file', 'passphrase'],
+    ['ssh2_auth_pubkey', 'privkey'],
+    ['ssh2_auth_pubkey', 'passphrase'],
+    ['ssh2_auth_hostbased_file', 'passphrase'],
+];
+
+foreach ($sensitiveParameters as [$function, $parameter]) {
+    $reflectionParameter = new ReflectionParameter($function, $parameter);
+
+    printf(
+        "%s:%s sensitive: %s\n",
+        $function,
+        $parameter,
+        count($reflectionParameter->getAttributes(SensitiveParameter::class)) === 1 ? 'true' : 'false',
+    );
+}
+
+$ordinaryParameters = [
+    ['ssh2_auth_password', 'username'],
+    ['ssh2_auth_pubkey', 'pubkey'],
+    ['ssh2_auth_hostbased_file', 'privkeyfile'],
+];
+
+foreach ($ordinaryParameters as [$function, $parameter]) {
+    $reflectionParameter = new ReflectionParameter($function, $parameter);
+
+    printf(
+        "%s:%s sensitive: %s\n",
+        $function,
+        $parameter,
+        $reflectionParameter->getAttributes(SensitiveParameter::class) === [] ? 'false' : 'true',
+    );
+}
+
+try {
+    ssh2_auth_password(null, 'trace-user', 'trace-secret');
+} catch (Throwable $exception) {
+    $arguments    = $exception->getTrace()[0]['args'];
+    $printedTrace = print_r($exception->getTrace(), true);
+
+    printf("trace username: %s\n", $arguments[1]);
+    printf("trace password wrapped: %s\n", $arguments[2] instanceof SensitiveParameterValue ? 'true' : 'false');
+    printf("trace contains secret: %s\n", str_contains($printedTrace, 'trace-secret') ? 'true' : 'false');
+}
+?>
+--EXPECT--
+ssh2_auth_password:password sensitive: true
+ssh2_auth_pubkey_file:passphrase sensitive: true
+ssh2_auth_pubkey:privkey sensitive: true
+ssh2_auth_pubkey:passphrase sensitive: true
+ssh2_auth_hostbased_file:passphrase sensitive: true
+ssh2_auth_password:username sensitive: false
+ssh2_auth_pubkey:pubkey sensitive: false
+ssh2_auth_hostbased_file:privkeyfile sensitive: false
+trace username: trace-user
+trace password wrapped: true
+trace contains secret: false

--- a/thirdparty/php/ssh2/ssh2.cc
+++ b/thirdparty/php/ssh2/ssh2.cc
@@ -584,8 +584,6 @@ PHP_FUNCTION(ssh2_auth_none) {
 }
 /* }}} */
 
-char *password_for_kbd_callback;
-
 static void kbd_callback(const char *name,
                          int name_len,
                          const char *instruction,
@@ -598,12 +596,19 @@ static void kbd_callback(const char *name,
     (void) name_len;
     (void) instruction;
     (void) instruction_len;
-    if (num_prompts == 1) {
-        responses[0].text = estrdup(password_for_kbd_callback);
-        responses[0].length = strlen(password_for_kbd_callback);
-    }
     (void) prompts;
-    (void) abstract;
+
+    auto session_data = (php_ssh2_session_data **) abstract;
+
+    for (int i = 0; i < num_prompts; i++) {
+        responses[i].text = NULL;
+        responses[i].length = 0;
+    }
+
+    if (num_prompts >= 1 && session_data && *session_data && (*session_data)->kbd_password) {
+        responses[0].text = estrndup((*session_data)->kbd_password, (*session_data)->kbd_password_len);
+        responses[0].length = (unsigned int) (*session_data)->kbd_password_len;
+    }
 }
 
 /* {{{ proto bool ssh2_auth_password(resource session, string username, string password)
@@ -624,11 +629,20 @@ PHP_FUNCTION(ssh2_auth_password) {
     userauthlist = libssh2_userauth_list(session, username->val, username->len);
 
     if (userauthlist != NULL) {
-        password_for_kbd_callback = password->val;
+        auto session_data = (php_ssh2_session_data **) libssh2_session_abstract(session);
+        (*session_data)->kbd_password = password->val;
+        (*session_data)->kbd_password_len = password->len;
+
+        int kbd_ok = 0;
         if (strstr(userauthlist, "keyboard-interactive") != NULL) {
-            if (libssh2_userauth_keyboard_interactive(session, username->val, &kbd_callback) == 0) {
-                RETURN_TRUE;
-            }
+            kbd_ok = (libssh2_userauth_keyboard_interactive(session, username->val, &kbd_callback) == 0);
+        }
+
+        (*session_data)->kbd_password = NULL;
+        (*session_data)->kbd_password_len = 0;
+
+        if (kbd_ok) {
+            RETURN_TRUE;
         }
 
         /* TODO: Support password change callback */

--- a/thirdparty/php/ssh2/ssh2.cc
+++ b/thirdparty/php/ssh2/ssh2.cc
@@ -1259,6 +1259,41 @@ int php_swoole_ssh2_minit(int module_number) {
     le_ssh2_pkey_subsys = zend_register_list_destructors_ex(
         php_ssh2_pkey_subsys_dtor, NULL, PHP_SSH2_PKEY_SUBSYS_RES_NAME, module_number);
 
+#if PHP_VERSION_ID >= 80200
+    // Mirror ext/ftp's generated sensitive-parameter registration. SSH2 keeps its
+    // function table hand-written, and C++ requires the lookup's void pointer to be cast.
+    zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(CG(function_table),
+                                                                          "ssh2_auth_password",
+                                                                          sizeof("ssh2_auth_password") - 1),
+                                 2,
+                                 ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER),
+                                 0);
+    zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(CG(function_table),
+                                                                          "ssh2_auth_pubkey_file",
+                                                                          sizeof("ssh2_auth_pubkey_file") - 1),
+                                 4,
+                                 ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER),
+                                 0);
+    zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(CG(function_table),
+                                                                          "ssh2_auth_pubkey",
+                                                                          sizeof("ssh2_auth_pubkey") - 1),
+                                 3,
+                                 ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER),
+                                 0);
+    zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(CG(function_table),
+                                                                          "ssh2_auth_pubkey",
+                                                                          sizeof("ssh2_auth_pubkey") - 1),
+                                 4,
+                                 ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER),
+                                 0);
+    zend_add_parameter_attribute((zend_function *) zend_hash_str_find_ptr(CG(function_table),
+                                                                          "ssh2_auth_hostbased_file",
+                                                                          sizeof("ssh2_auth_hostbased_file") - 1),
+                                 5,
+                                 ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER),
+                                 0);
+#endif
+
     REGISTER_LONG_CONSTANT("SSH2_FINGERPRINT_MD5", PHP_SSH2_FINGERPRINT_MD5, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("SSH2_FINGERPRINT_SHA1", PHP_SSH2_FINGERPRINT_SHA1, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("SSH2_FINGERPRINT_HEX", PHP_SSH2_FINGERPRINT_HEX, CONST_CS | CONST_PERSISTENT);


### PR DESCRIPTION
## Summary

- move keyboard-interactive passwords from process-global state to the owning SSH2 session
- clear borrowed authentication state before success or password fallback
- redact passwords, in-memory private keys, and passphrases from exception traces

## Why

The keyboard-interactive callback previously read a process-global password pointer. Two coroutines authenticating separate sessions could overwrite that pointer and submit one session's password to the other server.

SSH2's secret-bearing authentication parameters also lacked `SensitiveParameter` metadata, so PHP exception traces could retain their plaintext values when argument capture was enabled.

## Implementation

The in-flight keyboard-interactive password now lives in libssh2's per-session abstract data. The callback initializes every response slot, copies the first response with the allocator registered for that session, and the caller clears both borrowed fields before returning or falling back.

The SSH2 stub marks the exact secret inputs. Since this integration uses a hand-written function table, MINIT registers the corresponding parameter attributes explicitly. A fixture-independent PHPT verifies the reflection metadata and end-to-end trace redaction.

The existing OpenSSH fixture disables keyboard-interactive authentication, so this does not add a probabilistic concurrency test or PAM-specific fixture machinery. Existing password and public-key authentication coverage verifies compatibility around the changed path.
