### PR TITLE
Fix SSH2 resource ownership and stream error handling

### DIFF
--- a/ext-src/php_swoole_ssh2.h
+++ b/ext-src/php_swoole_ssh2.h
@@ -31,11 +31,6 @@ static inline SocketImpl *ssh2_get_socket(LIBSSH2_SESSION *session) {
     return (*session_data)->socket;
 }
 
-static inline void ssh2_set_socket_timeout(LIBSSH2_SESSION *session, int timeout_ms) {
-    auto sock = ssh2_get_socket(session);
-    sock->set_timeout(timeout_ms / 1000, SW_TIMEOUT_ALL);
-}
-
 class ResourceGuard {
     zval zres_;
 
@@ -49,9 +44,16 @@ class ResourceGuard {
     }
 };
 
-static inline int ssh2_async_call(LIBSSH2_SESSION *session, const std::function<int(void)> &fn) {
+static inline int ssh2_async_call(LIBSSH2_SESSION *session,
+                                  const std::function<int(void)> &fn,
+                                  double timeout = 0,
+                                  bool *timeout_event = nullptr) {
     auto event = ssh2_get_event_type(session);
     auto socket = ssh2_get_socket(session);
+
+    if (timeout_event) {
+        *timeout_event = false;
+    }
 
     socket->check_bound_co(SW_EVENT_READ);
     socket->check_bound_co(SW_EVENT_WRITE);
@@ -60,7 +62,10 @@ static inline int ssh2_async_call(LIBSSH2_SESSION *session, const std::function<
     while (1) {
         rc = fn();
         if (rc == LIBSSH2_ERROR_EAGAIN) {
-            if (!socket->poll(event)) {
+            if (!socket->poll(event, timeout)) {
+                if (timeout_event) {
+                    *timeout_event = timeout > 0 && socket->errCode == ETIMEDOUT;
+                }
                 return LIBSSH2_ERROR_SOCKET_NONE;
             }
             continue;

--- a/tests/swoole_ssh2/ssh2_channel_nonblocking.phpt
+++ b/tests/swoole_ssh2/ssh2_channel_nonblocking.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Nonblocking SSH2 channels distinguish backpressure from terminal errors
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $channel = ssh2_exec($session, 'cat >/dev/null; sleep 5');
+
+    if ($channel === false) {
+        throw new RuntimeException('Failed to open the SSH channel.');
+    }
+
+    var_dump(stream_get_meta_data($channel)['blocked']);
+    stream_set_blocking($channel, false);
+    var_dump(stream_get_meta_data($channel)['blocked']);
+
+    var_dump(fread($channel, 1) === '');
+    var_dump(stream_get_meta_data($channel)['eof']);
+    var_dump(ssh2_send_eof($channel));
+    var_dump(fwrite($channel, 'x'));
+    var_dump(stream_get_meta_data($channel)['eof']);
+
+    fclose($channel);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)

--- a/tests/swoole_ssh2/ssh2_channel_stream_errors.phpt
+++ b/tests/swoole_ssh2/ssh2_channel_stream_errors.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Blocking SSH2 channels preserve errors and derive EOF after reads
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $writeChannel = ssh2_exec($session, 'cat >/dev/null; sleep 5');
+
+    if ($writeChannel === false) {
+        throw new RuntimeException('Failed to open the SSH write channel.');
+    }
+
+    stream_set_blocking($writeChannel, true);
+
+    var_dump(ssh2_send_eof($writeChannel));
+    var_dump(fwrite($writeChannel, 'x'));
+    var_dump(stream_get_meta_data($writeChannel)['eof']);
+
+    fclose($writeChannel);
+
+    $readChannel = ssh2_exec($session, 'true');
+
+    if ($readChannel === false) {
+        throw new RuntimeException('Failed to open the SSH read channel.');
+    }
+
+    stream_set_blocking($readChannel, true);
+
+    var_dump(fread($readChannel, 1) === '');
+    var_dump(feof($readChannel));
+
+    fclose($readChannel);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_channel_timeout.phpt
+++ b/tests/swoole_ssh2/ssh2_channel_timeout.phpt
@@ -1,0 +1,57 @@
+--TEST--
+SSH2 channels preserve sub-second stream timeouts
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $timedChannel   = ssh2_exec($session, 'sleep 2; printf x');
+    $untimedChannel = ssh2_exec($session, 'sleep 1; printf y');
+
+    if ($timedChannel === false || $untimedChannel === false) {
+        throw new RuntimeException('Failed to open the SSH channels.');
+    }
+
+    stream_set_timeout($timedChannel, 0, 200000);
+
+    $startedAt = microtime(true);
+    var_dump(fread($timedChannel, 1));
+    $elapsed = microtime(true) - $startedAt;
+
+    var_dump($elapsed >= 0.1 && $elapsed < 1.0);
+    var_dump(stream_get_meta_data($timedChannel)['timed_out']);
+
+    stream_set_blocking($timedChannel, false);
+    var_dump(fread($timedChannel, 1) === '');
+    var_dump(stream_get_meta_data($timedChannel)['timed_out']);
+
+    $startedAt = microtime(true);
+    var_dump(fread($untimedChannel, 1));
+    var_dump(microtime(true) - $startedAt >= 0.5);
+    var_dump(stream_get_meta_data($untimedChannel)['timed_out']);
+
+    fclose($timedChannel);
+    fclose($untimedChannel);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+string(1) "y"
+bool(true)
+bool(false)

--- a/tests/swoole_ssh2/ssh2_resource_lifetime.phpt
+++ b/tests/swoole_ssh2/ssh2_resource_lifetime.phpt
@@ -1,0 +1,155 @@
+--TEST--
+SSH2 child resources fail safely after their parent session is closed
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $sessionBaseline = count(get_resources('SSH2 Session'));
+    $sftpBaseline    = count(get_resources('SSH2 SFTP'));
+    $connect         = static function () {
+        $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+        if ($session === false || !ssh2t_auth($session)) {
+            throw new RuntimeException('Failed to connect to the SSH fixture.');
+        }
+
+        return $session;
+    };
+
+    $terminalSession = $connect();
+    $terminal        = ssh2_shell($terminalSession);
+
+    if ($terminal === false) {
+        throw new RuntimeException('Failed to open an SSH terminal.');
+    }
+
+    $stderr = ssh2_fetch_stream($terminal, SSH2_STREAM_STDERR);
+
+    if ($stderr === false) {
+        throw new RuntimeException('Failed to open the terminal stderr stream.');
+    }
+
+    var_dump(ssh2_disconnect($terminalSession));
+    var_dump(fwrite($terminal, 'test') === false);
+    var_dump(fread($terminal, 1) === false);
+    var_dump(!fflush($terminal));
+    var_dump(!ssh2_shell_resize($terminal, 80, 24));
+    var_dump(!ssh2_send_eof($terminal));
+    var_dump(ssh2_fetch_stream($terminal, SSH2_STREAM_STDERR) === false);
+    var_dump(fclose($stderr));
+    var_dump(fclose($terminal));
+
+    unset($terminalSession);
+
+    $sftpSession = $connect();
+    $sftp        = ssh2_sftp($sftpSession);
+
+    if ($sftp === false) {
+        throw new RuntimeException('Failed to open the SFTP subsystem.');
+    }
+
+    $root      = ssh2t_tempnam();
+    $filePath  = $root . '/file.txt';
+    $otherPath = $root . '/other.txt';
+    $linkPath  = $root . '/link.txt';
+
+    if (!ssh2_sftp_mkdir($sftp, $root, 0700)) {
+        throw new RuntimeException('Failed to create the SFTP fixture directory.');
+    }
+
+    $file      = fopen('ssh2.sftp://' . (int) $sftp . $filePath, 'w+');
+    $directory = opendir('ssh2.sftp://' . (int) $sftp . $root);
+
+    if ($file === false || $directory === false) {
+        throw new RuntimeException('Failed to open the SFTP fixture streams.');
+    }
+
+    var_dump(ssh2_disconnect($sftpSession));
+    var_dump(fwrite($file, 'test') === false);
+    var_dump(fread($file, 1) === false);
+    var_dump(fseek($file, 0, SEEK_END) === -1);
+    var_dump(fstat($file) === false);
+    var_dump(readdir($directory) === false);
+    var_dump(!ssh2_sftp_rename($sftp, $filePath, $otherPath));
+    var_dump(!ssh2_sftp_unlink($sftp, $filePath));
+    var_dump(!ssh2_sftp_mkdir($sftp, $otherPath));
+    var_dump(!ssh2_sftp_rmdir($sftp, $root));
+    var_dump(!ssh2_sftp_chmod($sftp, $filePath, 0600));
+    var_dump(ssh2_sftp_stat($sftp, $filePath) === false);
+    var_dump(ssh2_sftp_lstat($sftp, $filePath) === false);
+    var_dump(!ssh2_sftp_symlink($sftp, $filePath, $linkPath));
+    var_dump(ssh2_sftp_readlink($sftp, $linkPath) === false);
+    var_dump(ssh2_sftp_realpath($sftp, $filePath) === false);
+    var_dump(fclose($file));
+    closedir($directory);
+
+    unset($directory, $sftp, $sftpSession);
+
+    $cleanupSession = $connect();
+    $cleanupSftp    = ssh2_sftp($cleanupSession);
+
+    if ($cleanupSftp === false
+        || !ssh2_sftp_unlink($cleanupSftp, $filePath)
+        || !ssh2_sftp_rmdir($cleanupSftp, $root)) {
+        throw new RuntimeException('Failed to clean up the SFTP fixture.');
+    }
+
+    unset($cleanupSftp);
+    ssh2_disconnect($cleanupSession);
+    unset($cleanupSession);
+
+    $listenerSession = $connect();
+    $listener        = ssh2_forward_listen($listenerSession, 0);
+
+    if ($listener === false) {
+        throw new RuntimeException('Failed to open an SSH remote-forward listener.');
+    }
+
+    var_dump(ssh2_disconnect($listenerSession));
+    var_dump(ssh2_forward_accept($listener) === false);
+
+    unset($listener, $listenerSession);
+    gc_collect_cycles();
+
+    var_dump(count(get_resources('SSH2 SFTP')) === $sftpBaseline);
+    var_dump(count(get_resources('SSH2 Session')) === $sessionBaseline);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_directory.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_directory.phpt
@@ -1,0 +1,63 @@
+--TEST--
+SFTP directory streams enumerate remote entries
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $sftp = ssh2_sftp($session);
+
+    if ($sftp === false) {
+        throw new RuntimeException('Failed to open the SFTP subsystem.');
+    }
+
+    $root    = ssh2t_tempnam();
+    $rootUrl = 'ssh2.sftp://' . (int) $sftp . $root;
+
+    if (!ssh2_sftp_mkdir($sftp, $root, 0700)
+        || file_put_contents($rootUrl . '/alpha.txt', 'alpha') !== 5
+        || file_put_contents($rootUrl . '/beta.txt', 'beta') !== 4) {
+        throw new RuntimeException('Failed to create the SFTP directory fixture.');
+    }
+
+    $directory = opendir($rootUrl);
+
+    if ($directory === false) {
+        throw new RuntimeException('Failed to open the SFTP directory fixture.');
+    }
+
+    $entries = [];
+
+    while (($entry = readdir($directory)) !== false) {
+        $entries[] = $entry;
+    }
+
+    closedir($directory);
+
+    $expected = ['.', '..', 'alpha.txt', 'beta.txt'];
+    sort($entries, SORT_STRING);
+    sort($expected, SORT_STRING);
+
+    var_dump($entries === $expected);
+
+    if (!ssh2_sftp_unlink($sftp, $root . '/alpha.txt')
+        || !ssh2_sftp_unlink($sftp, $root . '/beta.txt')
+        || !ssh2_sftp_rmdir($sftp, $root)) {
+        throw new RuntimeException('Failed to clean up the SFTP directory fixture.');
+    }
+});
+?>
+--EXPECT--
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_directory_stream_errors.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_directory_stream_errors.phpt
@@ -1,0 +1,96 @@
+--TEST--
+SFTP directory streams distinguish read errors from clean completion
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $connect = static function () {
+        $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+        if ($session === false || !ssh2t_auth($session)) {
+            throw new RuntimeException('Failed to connect to the SSH fixture.');
+        }
+
+        return $session;
+    };
+
+    $sessionBaseline = count(get_resources('SSH2 Session'));
+    $sftpBaseline    = count(get_resources('SSH2 SFTP'));
+    $root            = ssh2t_tempnam();
+    $session         = $connect();
+    $sftp            = ssh2_sftp($session);
+
+    if ($sftp === false
+        || !ssh2_sftp_mkdir($sftp, $root, 0700)
+        || file_put_contents('ssh2.sftp://' . (int) $sftp . $root . '/alpha.txt', 'alpha') !== 5
+        || file_put_contents('ssh2.sftp://' . (int) $sftp . $root . '/beta.txt', 'beta') !== 4) {
+        throw new RuntimeException('Failed to create the SFTP directory fixture.');
+    }
+
+    $directoryUrl = 'ssh2.sftp://' . (int) $sftp . $root;
+    $directory    = opendir($directoryUrl);
+
+    if ($directory === false) {
+        throw new RuntimeException('Failed to open the SFTP directory fixture.');
+    }
+
+    $entries = [];
+
+    while (($entry = readdir($directory)) !== false) {
+        $entries[] = $entry;
+    }
+
+    $expected = ['.', '..', 'alpha.txt', 'beta.txt'];
+    sort($entries, SORT_STRING);
+    sort($expected, SORT_STRING);
+
+    var_dump($entries === $expected);
+    var_dump(feof($directory));
+    closedir($directory);
+
+    $failedDirectory = opendir($directoryUrl);
+
+    if ($failedDirectory === false) {
+        throw new RuntimeException('Failed to open the SFTP failure directory.');
+    }
+
+    var_dump(ssh2_disconnect($session));
+    var_dump(readdir($failedDirectory) === false);
+    var_dump(feof($failedDirectory) === false);
+    closedir($failedDirectory);
+    unset($failedDirectory, $directory, $sftp, $session);
+
+    $session = $connect();
+    $sftp    = ssh2_sftp($session);
+
+    if ($sftp === false
+        || !ssh2_sftp_unlink($sftp, $root . '/alpha.txt')
+        || !ssh2_sftp_unlink($sftp, $root . '/beta.txt')
+        || !ssh2_sftp_rmdir($sftp, $root)) {
+        throw new RuntimeException('Failed to clean up the SFTP directory fixture.');
+    }
+
+    unset($sftp);
+    ssh2_disconnect($session);
+    unset($session);
+    gc_collect_cycles();
+
+    var_dump(count(get_resources('SSH2 SFTP')) === $sftpBaseline);
+    var_dump(count(get_resources('SSH2 Session')) === $sessionBaseline);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_resource_registration.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_resource_registration.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Direct SFTP wrapper connections register and release their subsystem resource
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+
+if (TEST_SSH2_AUTH !== 'password') {
+    echo 'skip direct wrapper test requires password authentication';
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $sessionBaseline = count(get_resources('SSH2 Session'));
+    $sftpBaseline    = count(get_resources('SSH2 SFTP'));
+    $context         = stream_context_create([
+        'ssh2' => [
+            'username' => TEST_SSH2_USER,
+            'password' => TEST_SSH2_PASS,
+        ],
+    ]);
+    $filename     = 'swoole-sftp-registration-' . getmypid() . '.txt';
+    $directoryUrl = sprintf(
+        'ssh2.sftp://%s:%d%s',
+        TEST_SSH2_HOSTNAME,
+        TEST_SSH2_PORT,
+        rtrim(TEST_SSH2_TEMPDIR, '/'),
+    );
+    $fileUrl  = $directoryUrl . '/' . $filename;
+    $contents = 'resource-registration';
+
+    var_dump(file_put_contents($fileUrl, $contents, 0, $context) === strlen($contents));
+    var_dump(file_get_contents($fileUrl, false, $context) === $contents);
+
+    $directory = opendir($directoryUrl, $context);
+
+    if ($directory === false) {
+        throw new RuntimeException('Failed to open the SSH fixture directory.');
+    }
+
+    $found = false;
+
+    while (($entry = readdir($directory)) !== false) {
+        $found = $found || $entry === $filename;
+    }
+
+    closedir($directory);
+
+    var_dump($found);
+    var_dump(unlink($fileUrl, $context));
+
+    gc_collect_cycles();
+
+    var_dump(count(get_resources('SSH2 SFTP')) === $sftpBaseline);
+    var_dump(count(get_resources('SSH2 Session')) === $sessionBaseline);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_stream_errors.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_stream_errors.phpt
@@ -1,0 +1,76 @@
+--TEST--
+SFTP streams distinguish read errors from clean EOF
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $connect = static function () {
+        $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+        if ($session === false || !ssh2t_auth($session)) {
+            throw new RuntimeException('Failed to connect to the SSH fixture.');
+        }
+
+        return $session;
+    };
+
+    $root     = ssh2t_tempnam();
+    $filePath = $root . '/file.txt';
+    $session  = $connect();
+    $sftp     = ssh2_sftp($session);
+
+    if ($sftp === false
+        || !ssh2_sftp_mkdir($sftp, $root, 0700)
+        || file_put_contents('ssh2.sftp://' . (int) $sftp . $filePath, 'test') !== 4) {
+        throw new RuntimeException('Failed to create the SFTP fixture.');
+    }
+
+    $failedRead = fopen('ssh2.sftp://' . (int) $sftp . $filePath, 'rb');
+
+    if ($failedRead === false) {
+        throw new RuntimeException('Failed to open the SFTP error stream.');
+    }
+
+    var_dump(ssh2_disconnect($session));
+    var_dump(fread($failedRead, 1) === false);
+    var_dump(feof($failedRead) === false);
+    fclose($failedRead);
+    unset($failedRead, $sftp, $session);
+
+    $session   = $connect();
+    $sftp      = ssh2_sftp($session);
+    $cleanRead = $sftp === false
+        ? false
+        : fopen('ssh2.sftp://' . (int) $sftp . $filePath, 'rb');
+
+    if ($cleanRead === false) {
+        throw new RuntimeException('Failed to open the SFTP EOF stream.');
+    }
+
+    var_dump(fread($cleanRead, 4) === 'test');
+    var_dump(fread($cleanRead, 1) === '');
+    var_dump(feof($cleanRead));
+    fclose($cleanRead);
+
+    if (!ssh2_sftp_unlink($sftp, $filePath) || !ssh2_sftp_rmdir($sftp, $root)) {
+        throw new RuntimeException('Failed to clean up the SFTP fixture.');
+    }
+
+    unset($cleanRead, $sftp);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_wrapper_release.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_wrapper_release.phpt
@@ -1,0 +1,63 @@
+--TEST--
+One-shot SFTP wrapper operations release their SFTP and session references
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+ssh2t_writes_remote();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $sessionBaseline = count(get_resources('SSH2 Session'));
+    $sftpBaseline    = count(get_resources('SSH2 SFTP'));
+    $session         = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $sftp = ssh2_sftp($session);
+
+    if ($sftp === false) {
+        throw new RuntimeException('Failed to open the SFTP subsystem.');
+    }
+
+    $root       = ssh2t_tempnam();
+    $rootUrl    = 'ssh2.sftp://' . (int) $sftp . $root;
+    $sourceUrl  = $rootUrl . '/source.txt';
+    $targetUrl  = $rootUrl . '/target.txt';
+    $missingUrl = $rootUrl . '/missing.txt';
+
+    var_dump(mkdir($rootUrl, 0700));
+    var_dump(file_put_contents($sourceUrl, 'test') === 4);
+
+    clearstatcache(true, $sourceUrl);
+    var_dump(file_exists($sourceUrl));
+
+    clearstatcache(true, $missingUrl);
+    var_dump(!file_exists($missingUrl));
+
+    var_dump(rename($sourceUrl, $targetUrl));
+    var_dump(unlink($targetUrl));
+    var_dump(rmdir($rootUrl));
+
+    unset($sftp, $session);
+    gc_collect_cycles();
+
+    var_dump(count(get_resources('SSH2 SFTP')) === $sftpBaseline);
+    var_dump(count(get_resources('SSH2 Session')) === $sessionBaseline);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_wrapper_session_ownership.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_wrapper_session_ownership.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Direct SFTP wrapper authentication failures release their native sessions
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+
+if (!is_dir('/proc/self/fd')) {
+    echo 'skip requires /proc/self/fd';
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $context = stream_context_create([
+        'ssh2' => [
+            'username' => TEST_SSH2_USER,
+            'password' => 'invalid-swoole-test-password',
+        ],
+    ]);
+    $url = sprintf(
+        'ssh2.sftp://%s:%d%s/missing.txt',
+        TEST_SSH2_HOSTNAME,
+        TEST_SSH2_PORT,
+        rtrim(TEST_SSH2_TEMPDIR, '/'),
+    );
+    $fileDescriptorCount = static fn (): int => count(scandir('/proc/self/fd')) - 2;
+
+    $warmupFailed   = @fopen($url, 'rb', false, $context) === false;
+    $baseline       = $fileDescriptorCount();
+    $attemptsFailed = true;
+
+    for ($attempt = 0; $attempt < 3; $attempt++) {
+        $attemptsFailed = @fopen($url, 'rb', false, $context) === false && $attemptsFailed;
+    }
+
+    gc_collect_cycles();
+
+    var_dump($warmupFailed);
+    var_dump($attemptsFailed);
+    var_dump($fileDescriptorCount() === $baseline);
+});
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/tests/swoole_ssh2/ssh2_sftp_wrapper_session_ownership.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_wrapper_session_ownership.phpt
@@ -28,18 +28,17 @@ Co\run(function (): void {
     );
     $fileDescriptorCount = static fn (): int => count(scandir('/proc/self/fd')) - 2;
 
-    $warmupFailed   = @fopen($url, 'rb', false, $context) === false;
-    $baseline       = $fileDescriptorCount();
-    $attemptsFailed = true;
+    $warmupFailed = @fopen($url, 'rb', false, $context) === false;
+    $baseline     = $fileDescriptorCount();
 
-    for ($attempt = 0; $attempt < 3; $attempt++) {
-        $attemptsFailed = @fopen($url, 'rb', false, $context) === false && $attemptsFailed;
-    }
+    // Keep the two failures below OpenSSH 9.8+'s default per-source penalty floor
+    // so this test cannot block later tests that share the SSH server.
+    $attemptFailed = @fopen($url, 'rb', false, $context) === false;
 
     gc_collect_cycles();
 
     var_dump($warmupFailed);
-    var_dump($attemptsFailed);
+    var_dump($attemptFailed);
     var_dump($fileDescriptorCount() === $baseline);
 });
 ?>

--- a/thirdparty/php/ssh2/php_ssh2.h
+++ b/thirdparty/php/ssh2/php_ssh2.h
@@ -100,6 +100,7 @@ typedef struct _php_ssh2_channel_data {
     unsigned int streamid;
     char is_blocking;
     long timeout;
+    bool timeout_event;
 
     /* Resource */
     zend_resource *session_rsrc;

--- a/thirdparty/php/ssh2/php_ssh2.h
+++ b/thirdparty/php/ssh2/php_ssh2.h
@@ -131,6 +131,10 @@ extern php_stream_wrapper php_ssh2_sftp_wrapper;
 extern int le_ssh2_session;
 extern int le_ssh2_sftp;
 
+static inline bool php_ssh2_session_is_open(zend_resource *session_rsrc) {
+    return session_rsrc && session_rsrc->ptr != NULL;
+}
+
 static inline LIBSSH2_SESSION *ssh2_get_session(php_ssh2_channel_data *abstract) {
     return (LIBSSH2_SESSION *) zend_fetch_resource(abstract->session_rsrc, PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
 }

--- a/thirdparty/php/ssh2/ssh2.cc
+++ b/thirdparty/php/ssh2/ssh2.cc
@@ -849,6 +849,10 @@ PHP_FUNCTION(ssh2_forward_accept) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = data->session;
     channel = libssh2_channel_forward_accept(data->listener);
 
@@ -935,6 +939,10 @@ PHP_FUNCTION(ssh2_publickey_add) {
 
     if ((data = (php_ssh2_pkey_subsys_data *) zend_fetch_resource(
              Z_RES_P(zpkey_data), PHP_SSH2_PKEY_SUBSYS_RES_NAME, le_ssh2_pkey_subsys)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -1040,6 +1048,10 @@ PHP_FUNCTION(ssh2_publickey_remove) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     if (libssh2_publickey_remove_ex(data->pkey, (unsigned char *) algo, algo_len, (unsigned char *) blob, blob_len)) {
         php_error_docref(NULL, E_WARNING, "Unable to remove %s key", algo);
         RETURN_FALSE;
@@ -1064,6 +1076,10 @@ PHP_FUNCTION(ssh2_publickey_list) {
 
     if ((data = (php_ssh2_pkey_subsys_data *) zend_fetch_resource(
              Z_RES_P(zpkey_data), PHP_SSH2_PKEY_SUBSYS_RES_NAME, le_ssh2_pkey_subsys)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -1218,9 +1234,12 @@ static void php_ssh2_session_dtor(zend_resource *rsrc) {
 static void php_ssh2_listener_dtor(zend_resource *rsrc) {
     php_ssh2_listener_data *data = (php_ssh2_listener_data *) rsrc->ptr;
     LIBSSH2_LISTENER *listener = data->listener;
-    auto session = data->session;
 
-    libssh2_channel_forward_cancel(listener);
+    if (php_ssh2_session_is_open(data->session_rsrc)) {
+        auto session = data->session;
+        libssh2_channel_forward_cancel(listener);
+    }
+
     zend_list_delete(data->session_rsrc);
     efree(data);
 }
@@ -1229,7 +1248,10 @@ static void php_ssh2_pkey_subsys_dtor(zend_resource *rsrc) {
     php_ssh2_pkey_subsys_data *data = (php_ssh2_pkey_subsys_data *) rsrc->ptr;
     LIBSSH2_PUBLICKEY *pkey = data->pkey;
 
-    libssh2_publickey_shutdown(pkey);
+    if (php_ssh2_session_is_open(data->session_rsrc)) {
+        libssh2_publickey_shutdown(pkey);
+    }
+
     zend_list_delete(data->session_rsrc);
     efree(data);
 }

--- a/thirdparty/php/ssh2/ssh2.cc
+++ b/thirdparty/php/ssh2/ssh2.cc
@@ -863,7 +863,9 @@ PHP_FUNCTION(ssh2_forward_accept) {
     channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     channel_data->channel = channel;
     channel_data->streamid = 0;
-    channel_data->is_blocking = 0;
+    channel_data->is_blocking = 1;
+    channel_data->timeout = 0;
+    channel_data->timeout_event = false;
     channel_data->session_rsrc = data->session_rsrc;
     channel_data->refcount = NULL;
 

--- a/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
+++ b/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
@@ -41,6 +41,10 @@ static ssize_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf
     ssize_t writestate;
     LIBSSH2_SESSION *session;
 
+    if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+        return -1;
+    }
+
     session =
         (LIBSSH2_SESSION *) zend_fetch_resource(abstract->session_rsrc, PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
 
@@ -73,6 +77,12 @@ static ssize_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf
 static ssize_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_t count) {
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
     ssize_t readstate;
+
+    if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+        stream->eof = 1;
+        return -1;
+    }
+
     auto session = ssh2_get_session(abstract);
 
     stream->eof = libssh2_channel_eof(abstract->channel);
@@ -111,9 +121,11 @@ static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle) {
         if (abstract->refcount) {
             efree(abstract->refcount);
         }
-        auto session = ssh2_get_session(abstract);
-        libssh2_channel_eof(abstract->channel);
-        libssh2_channel_free(abstract->channel);
+
+        if (php_ssh2_session_is_open(abstract->session_rsrc)) {
+            libssh2_channel_free(abstract->channel);
+        }
+
         zend_list_delete(abstract->session_rsrc);
     }
     efree(abstract);
@@ -123,6 +135,11 @@ static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle) {
 
 static int php_ssh2_channel_stream_flush(php_stream *stream) {
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
+
+    if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+        return -1;
+    }
+
     auto session = ssh2_get_session(abstract);
 
     return libssh2_channel_flush_ex(abstract->channel, abstract->streamid);
@@ -132,6 +149,10 @@ static int php_ssh2_channel_stream_cast(php_stream *stream, int castas, void **r
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
     LIBSSH2_SESSION *session;
     php_ssh2_session_data **session_data;
+
+    if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+        return FAILURE;
+    }
 
     session =
         (LIBSSH2_SESSION *) zend_fetch_resource(abstract->session_rsrc, PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
@@ -152,7 +173,6 @@ static int php_ssh2_channel_stream_cast(php_stream *stream, int castas, void **r
 
 static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, int value, void *ptrparam) {
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
-    auto session = ssh2_get_session(abstract);
     int ret;
 
     switch (option) {
@@ -162,6 +182,11 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
         return ret;
     }
     case PHP_STREAM_OPTION_META_DATA_API: {
+        if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+            return -1;
+        }
+
+        auto session = ssh2_get_session(abstract);
         add_assoc_long((zval *) ptrparam, "exit_status", libssh2_channel_get_exit_status(abstract->channel));
         break;
     }
@@ -176,6 +201,11 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
         return ret;
     }
     case PHP_STREAM_OPTION_CHECK_LIVENESS: {
+        if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
+            return stream->eof = 1;
+        }
+
+        auto session = ssh2_get_session(abstract);
         return stream->eof = libssh2_channel_eof(abstract->channel);
     }
     }
@@ -268,6 +298,11 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path,
             /* suppress potential warning by passing NULL as resource_type_name */
             sftp_data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(zresource), NULL, le_ssh2_sftp);
             if (sftp_data) {
+                if (!php_ssh2_session_is_open(sftp_data->session_rsrc)) {
+                    php_url_free(resource);
+                    return NULL;
+                }
+
                 /* Want the sftp layer */
                 Z_ADDREF_P(zresource);
                 *psftp_rsrc = Z_RES_P(zresource);
@@ -313,6 +348,11 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path,
         php_ssh2_sftp_data *sftp_data;
         sftp_data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(tmpzval), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp);
         if (sftp_data) {
+            if (!php_ssh2_session_is_open(sftp_data->session_rsrc)) {
+                php_url_free(resource);
+                return NULL;
+            }
+
             Z_ADDREF_P(tmpzval);
             *psftp_rsrc = Z_RES_P(tmpzval);
             *psftp = sftp_data->sftp;
@@ -737,6 +777,11 @@ PHP_FUNCTION(ssh2_shell_resize) {
     }
 
     data = (php_ssh2_channel_data *) parent->abstract;
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = ssh2_get_session(data);
 
     libssh2_channel_request_pty_size_ex(data->channel, width, height, width_px, height_px);
@@ -1404,6 +1449,10 @@ PHP_FUNCTION(ssh2_fetch_stream) {
 
     data = (php_ssh2_channel_data *) parent->abstract;
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     if (!data->refcount) {
         data->refcount = (uchar *) emalloc(sizeof(uchar));
         *(data->refcount) = 1;
@@ -1424,7 +1473,7 @@ PHP_FUNCTION(ssh2_fetch_stream) {
     if (!stream) {
         php_error_docref(NULL, E_WARNING, "Error opening substream");
         efree(stream_data);
-        (data->refcount)--;
+        (*(data->refcount))--;
         RETURN_FALSE;
     }
 
@@ -1454,6 +1503,10 @@ PHP_FUNCTION(ssh2_send_eof) {
     data = (php_ssh2_channel_data *) parent->abstract;
     if (!data) {
         php_error_docref(NULL, E_WARNING, "Abstract in stream is null");
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 

--- a/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
+++ b/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
@@ -414,6 +414,12 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path,
         return NULL;
     }
 
+    if (pubkey_file && privkey_file &&
+        (php_check_open_basedir(pubkey_file) || php_check_open_basedir(privkey_file))) {
+        php_url_free(resource);
+        return NULL;
+    }
+
     session = php_ssh2_session_connect(ZSTR_VAL(resource->host), resource->port, methods, callbacks);
     if (!session) {
         /* Unable to connect! */
@@ -421,13 +427,10 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path,
         return NULL;
     }
 
+    ZVAL_RES(&zsession, zend_register_resource(session, le_ssh2_session));
+
     /* Authenticate */
     if (pubkey_file && privkey_file) {
-        if (php_check_open_basedir(pubkey_file) || php_check_open_basedir(privkey_file)) {
-            php_url_free(resource);
-            return NULL;
-        }
-
         /* Attempt pubkey authentication */
         if (!libssh2_userauth_publickey_fromfile(session, username, pubkey_file, privkey_file, password)) {
             goto session_authed;
@@ -443,17 +446,12 @@ php_url *php_ssh2_fopen_wraper_parse_path(const char *path,
 
     /* Auth failure */
     php_url_free(resource);
-    if (Z_RES(zsession)) {
-        zend_list_delete(Z_RES(zsession));
-    }
+    zend_list_delete(Z_RES(zsession));
     return NULL;
 
 session_authed:
-    ZVAL_RES(&zsession, zend_register_resource(session, le_ssh2_session));
-
-    if (psftp) {
+    if (psftp && psftp_rsrc) {
         LIBSSH2_SFTP *sftp;
-        zval zsftp{};
 
         sftp = libssh2_sftp_init(session);
         if (!sftp) {
@@ -466,10 +464,7 @@ session_authed:
         sftp_data->session = session;
         sftp_data->sftp = sftp;
         sftp_data->session_rsrc = Z_RES(zsession);
-
-        // TODO Sean-Der
-        // ZEND_REGISTER_RESOURCE(sftp_data, le_ssh2_sftp);
-        *psftp_rsrc = Z_RES(zsftp);
+        *psftp_rsrc = zend_register_resource(sftp_data, le_ssh2_sftp);
         *psftp = sftp;
     }
 

--- a/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
+++ b/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
@@ -36,40 +36,59 @@ void *php_ssh2_zval_from_resource_handle(int handle) {
  * channel_stream_ops *
  ********************** */
 
+/* Raw single-attempt libssh2 calls. Parenthesizing the name bypasses the
+ * coroutine-hook function-like macros in php_swoole_ssh2_hook.h, so these surface
+ * LIBSSH2_ERROR_EAGAIN to the caller instead of polling/yielding until data. */
+static inline ssize_t php_ssh2_channel_read_raw(LIBSSH2_CHANNEL *channel, int streamid, char *buf, size_t count) {
+    return (libssh2_channel_read_ex)(channel, streamid, buf, count);
+}
+
+static inline ssize_t php_ssh2_channel_write_raw(LIBSSH2_CHANNEL *channel,
+                                                 int streamid,
+                                                 const char *buf,
+                                                 size_t count) {
+    return (libssh2_channel_write_ex)(channel, streamid, buf, count);
+}
+
+static inline int php_ssh2_channel_eof_raw(LIBSSH2_CHANNEL *channel) {
+    return (libssh2_channel_eof)(channel);
+}
+
 static ssize_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf, size_t count) {
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
     ssize_t writestate;
-    LIBSSH2_SESSION *session;
+
+    abstract->timeout_event = false;
 
     if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
         return -1;
     }
 
-    session =
+    if (!abstract->is_blocking) {
+        writestate = php_ssh2_channel_write_raw(abstract->channel, abstract->streamid, buf, count);
+        if (writestate == LIBSSH2_ERROR_EAGAIN) {
+            return 0;
+        }
+        return writestate;
+    }
+
+    auto session =
         (LIBSSH2_SESSION *) zend_fetch_resource(abstract->session_rsrc, PHP_SSH2_SESSION_RES_NAME, le_ssh2_session);
 
 #ifdef PHP_SSH2_SESSION_TIMEOUT
-    if (abstract->is_blocking) {
-        ssh2_set_socket_timeout(session, abstract->timeout);
-    }
+    const double timeout = abstract->timeout / 1000.0;
+#else
+    const double timeout = 0;
 #endif
 
-    writestate = libssh2_channel_write_ex(abstract->channel, abstract->streamid, buf, count);
-
-#ifdef PHP_SSH2_SESSION_TIMEOUT
-    if (abstract->is_blocking) {
-        ssh2_set_socket_timeout(session, -1);
-    }
-#endif
-
-    if (writestate < 0) {
-        char *error_msg = NULL;
-        if (libssh2_session_last_error(session, &error_msg, NULL, 0) == writestate) {
-            php_error_docref(NULL, E_WARNING, "Failure '%s' (%ld)", error_msg, writestate);
-        }
-
-        stream->eof = 1;
-    }
+    // Channel timeouts are stream-local; pass them to the poll instead of mutating the shared session socket.
+    writestate = ssh2_async_call(session,
+                                 [&]() {
+                                     return (libssh2_channel_write_ex)(
+                                         abstract->channel, abstract->streamid, buf, count);
+                                 },
+                                 timeout,
+                                 &abstract->timeout_event);
 
     return writestate;
 }
@@ -78,38 +97,47 @@ static ssize_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
     ssize_t readstate;
 
+    abstract->timeout_event = false;
+
     if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
         stream->eof = 1;
         return -1;
     }
 
+    if (!abstract->is_blocking) {
+        readstate = php_ssh2_channel_read_raw(abstract->channel, abstract->streamid, buf, count);
+        if (readstate == LIBSSH2_ERROR_EAGAIN) {
+            stream->eof = 0;
+            return 0;
+        }
+        if (readstate == 0) {
+            stream->eof = php_ssh2_channel_eof_raw(abstract->channel);
+            return 0;
+        }
+        return readstate;
+    }
+
     auto session = ssh2_get_session(abstract);
 
-    stream->eof = libssh2_channel_eof(abstract->channel);
-
 #ifdef PHP_SSH2_SESSION_TIMEOUT
-    if (abstract->is_blocking) {
-        ssh2_set_socket_timeout(session, abstract->timeout);
-    }
+    const double timeout = abstract->timeout / 1000.0;
+#else
+    const double timeout = 0;
 #endif
 
-    readstate = libssh2_channel_read_ex(abstract->channel, abstract->streamid, buf, count);
+    // Channel timeouts are stream-local; pass them to the poll instead of mutating the shared session socket.
+    readstate = ssh2_async_call(session,
+                                [&]() {
+                                    return (libssh2_channel_read_ex)(
+                                        abstract->channel, abstract->streamid, buf, count);
+                                },
+                                timeout,
+                                &abstract->timeout_event);
 
-#ifdef PHP_SSH2_SESSION_TIMEOUT
-    if (abstract->is_blocking) {
-        ssh2_set_socket_timeout(session, -1);
+    if (readstate == 0) {
+        stream->eof = libssh2_channel_eof(abstract->channel);
     }
-#endif
 
-    if (readstate < 0) {
-        char *error_msg = NULL;
-        if (libssh2_session_last_error(session, &error_msg, NULL, 0) == readstate) {
-            php_error_docref(NULL, E_WARNING, "Failure '%s' (%ld)", error_msg, readstate);
-        }
-
-        stream->eof = 1;
-        readstate = 0;
-    }
     return readstate;
 }
 
@@ -121,7 +149,6 @@ static int php_ssh2_channel_stream_close(php_stream *stream, int close_handle) {
         if (abstract->refcount) {
             efree(abstract->refcount);
         }
-
         if (php_ssh2_session_is_open(abstract->session_rsrc)) {
             libssh2_channel_free(abstract->channel);
         }
@@ -182,19 +209,23 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
         return ret;
     }
     case PHP_STREAM_OPTION_META_DATA_API: {
-        if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
-            return -1;
+        add_assoc_bool((zval *) ptrparam, "timed_out", abstract->timeout_event);
+        add_assoc_bool((zval *) ptrparam, "blocked", abstract->is_blocking);
+        add_assoc_bool((zval *) ptrparam, "eof", stream->eof);
+
+        if (php_ssh2_session_is_open(abstract->session_rsrc)) {
+            auto session = ssh2_get_session(abstract);
+            add_assoc_long((zval *) ptrparam, "exit_status", libssh2_channel_get_exit_status(abstract->channel));
         }
 
-        auto session = ssh2_get_session(abstract);
-        add_assoc_long((zval *) ptrparam, "exit_status", libssh2_channel_get_exit_status(abstract->channel));
-        break;
+        return PHP_STREAM_OPTION_RETURN_OK;
     }
     case PHP_STREAM_OPTION_READ_TIMEOUT: {
         ret = abstract->timeout;
 #ifdef PHP_SSH2_SESSION_TIMEOUT
         struct timeval tv = *(struct timeval *) ptrparam;
         abstract->timeout = tv.tv_sec * 1000 + (tv.tv_usec / 1000);
+        abstract->timeout_event = false;
 #else
         php_error_docref(NULL, E_WARNING, "No support for ssh2 stream timeout. Please recompile with libssh2 >= 1.2.9");
 #endif
@@ -205,8 +236,7 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
             return stream->eof = 1;
         }
 
-        auto session = ssh2_get_session(abstract);
-        return stream->eof = libssh2_channel_eof(abstract->channel);
+        return stream->eof = php_ssh2_channel_eof_raw(abstract->channel);
     }
     }
 
@@ -593,8 +623,9 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session,
     channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     channel_data->channel = channel;
     channel_data->streamid = 0;
-    channel_data->is_blocking = 0;
+    channel_data->is_blocking = 1;
     channel_data->timeout = 0;
+    channel_data->timeout_event = false;
     channel_data->session_rsrc = resource;
     channel_data->refcount = NULL;
 
@@ -871,8 +902,9 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session,
     channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     channel_data->channel = channel;
     channel_data->streamid = 0;
-    channel_data->is_blocking = 0;
+    channel_data->is_blocking = 1;
     channel_data->timeout = 0;
+    channel_data->timeout_event = false;
     channel_data->session_rsrc = rsrc;
     channel_data->refcount = NULL;
 
@@ -1059,8 +1091,9 @@ static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, zend_resource *rs
     channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     channel_data->channel = channel;
     channel_data->streamid = 0;
-    channel_data->is_blocking = 0;
+    channel_data->is_blocking = 1;
     channel_data->timeout = 0;
+    channel_data->timeout_event = false;
     channel_data->session_rsrc = rsrc;
     channel_data->refcount = NULL;
 
@@ -1308,8 +1341,9 @@ static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, zend_resource
     channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     channel_data->channel = channel;
     channel_data->streamid = 0;
-    channel_data->is_blocking = 0;
+    channel_data->is_blocking = 1;
     channel_data->timeout = 0;
+    channel_data->timeout_event = false;
     channel_data->session_rsrc = rsrc;
     channel_data->refcount = NULL;
 
@@ -1468,6 +1502,7 @@ PHP_FUNCTION(ssh2_fetch_stream) {
     stream_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
     memcpy(stream_data, data, sizeof(php_ssh2_channel_data));
     stream_data->streamid = streamid;
+    stream_data->timeout_event = false;
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, stream_data, 0, "r+");
     if (!stream) {

--- a/thirdparty/php/ssh2/ssh2_sftp.cc
+++ b/thirdparty/php/ssh2/ssh2_sftp.cc
@@ -141,7 +141,7 @@ static ssize_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t c
     auto session = data->session;
     bytes_read = libssh2_sftp_read(data->handle, buf, count);
 
-    stream->eof = (bytes_read <= 0 && bytes_read != LIBSSH2_ERROR_EAGAIN);
+    stream->eof = (bytes_read == 0);
 
     return bytes_read;
 }
@@ -305,20 +305,29 @@ static ssize_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
     php_stream_dirent *ent = (php_stream_dirent *) buf;
 
+    // readdir() uses false for both errors and completion, so every branch must own EOF.
     if (!php_ssh2_sftp_handle_session_is_open(data)) {
-        return 0;
+        stream->eof = 0;
+        return -1;
     }
 
     auto session = data->session;
     int bytesread = libssh2_sftp_readdir(data->handle, ent->d_name, sizeof(ent->d_name) - 1, NULL);
-    zend_string *basename;
 
-    if (bytesread <= 0) {
+    if (bytesread < 0) {
+        stream->eof = 0;
+        return bytesread;
+    }
+
+    if (bytesread == 0) {
+        stream->eof = 1;
         return 0;
     }
+
+    stream->eof = 0;
     ent->d_name[bytesread] = 0;
 
-    basename = php_basename(ent->d_name, bytesread, NULL, 0);
+    zend_string *basename = php_basename(ent->d_name, bytesread, NULL, 0);
     if (!basename) {
         return 0;
     }

--- a/thirdparty/php/ssh2/ssh2_sftp.cc
+++ b/thirdparty/php/ssh2/ssh2_sftp.cc
@@ -357,6 +357,8 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper,
 
     data = (php_ssh2_sftp_handle_data *) emalloc(sizeof(php_ssh2_sftp_handle_data));
     data->handle = handle;
+    data->session = session;
+    data->sftp = sftp;
     data->sftp_rsrc = sftp_rsrc;
 
     stream = php_stream_alloc(&php_ssh2_sftp_dirstream_ops, data, 0, mode);

--- a/thirdparty/php/ssh2/ssh2_sftp.cc
+++ b/thirdparty/php/ssh2/ssh2_sftp.cc
@@ -343,7 +343,7 @@ static php_stream *php_ssh2_sftp_dirstream_opener(php_stream_wrapper *wrapper,
     php_url *resource;
 
     resource = php_ssh2_fopen_wraper_parse_path(filename, "sftp", context, &session, &rsrc, &sftp, &sftp_rsrc);
-    if (!resource || !session || !sftp) {
+    if (!resource || !session || !sftp || !sftp_rsrc) {
         return NULL;
     }
 
@@ -392,20 +392,18 @@ static int php_ssh2_sftp_urlstat(
         return -1;
     }
 
-    if (libssh2_sftp_stat_ex(sftp,
-                             ZSTR_VAL(resource->path),
-                             ZSTR_LEN(resource->path),
-                             (flags & PHP_STREAM_URL_STAT_LINK) ? LIBSSH2_SFTP_LSTAT : LIBSSH2_SFTP_STAT,
-                             &attrs)) {
-        php_url_free(resource);
-        // zend_list_delete(sftp_rsrcid);
-        return -1;
-    }
+    int result = libssh2_sftp_stat_ex(sftp,
+                                      ZSTR_VAL(resource->path),
+                                      ZSTR_LEN(resource->path),
+                                      (flags & PHP_STREAM_URL_STAT_LINK) ? LIBSSH2_SFTP_LSTAT : LIBSSH2_SFTP_STAT,
+                                      &attrs);
 
     php_url_free(resource);
+    zend_list_delete(sftp_rsrc);
 
-    /* parse_path addrefs the resource, but we're not holding on to it so we have to delref it before we leave */
-    // zend_list_delete(sftp_rsrcid);
+    if (result) {
+        return -1;
+    }
 
     return php_ssh2_sftp_attr2ssb(ssb, &attrs);
 }
@@ -433,8 +431,7 @@ static int php_ssh2_sftp_unlink(php_stream_wrapper *wrapper,
 
     result = libssh2_sftp_unlink(sftp, ZSTR_VAL(resource->path));
     php_url_free(resource);
-
-    // zend_list_delete(sftp_rsrcid);
+    zend_list_delete(sftp_rsrc);
 
     /* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
     return (result == 0) ? -1 : 0;
@@ -476,8 +473,7 @@ static int php_ssh2_sftp_rename(
     result = libssh2_sftp_rename(sftp, ZSTR_VAL(resource->path), ZSTR_VAL(resource_to->path));
     php_url_free(resource);
     php_url_free(resource_to);
-
-    // zend_list_delete(sftp_rsrcid);
+    zend_list_delete(sftp_rsrc);
 
     /* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
     return (result == 0) ? -1 : 0;
@@ -512,8 +508,7 @@ static int php_ssh2_sftp_mkdir(
 
     result = libssh2_sftp_mkdir(sftp, ZSTR_VAL(resource->path), mode);
     php_url_free(resource);
-
-    // zend_list_delete(sftp_rsrcid);
+    zend_list_delete(sftp_rsrc);
 
     /* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
     return (result == 0) ? -1 : 0;
@@ -539,8 +534,7 @@ static int php_ssh2_sftp_rmdir(php_stream_wrapper *wrapper, const char *url, int
 
     result = libssh2_sftp_rmdir(sftp, ZSTR_VAL(resource->path));
     php_url_free(resource);
-
-    // zend_list_delete(sftp_rsrcid);
+    zend_list_delete(sftp_rsrc);
 
     /* libssh2 uses 0 for success and the streams API uses 0 for failure, so invert */
     return (result == 0) ? -1 : 0;

--- a/thirdparty/php/ssh2/ssh2_sftp.cc
+++ b/thirdparty/php/ssh2/ssh2_sftp.cc
@@ -35,7 +35,7 @@ void php_ssh2_sftp_dtor(zend_resource *rsrc) {
         return;
     }
 
-    if (data->session_rsrc->ptr != NULL) {
+    if (php_ssh2_session_is_open(data->session_rsrc)) {
         libssh2_sftp_shutdown(data->sftp);
     }
 
@@ -105,11 +105,21 @@ typedef struct _php_ssh2_sftp_handle_data {
     zend_resource *sftp_rsrc;
 } php_ssh2_sftp_handle_data;
 
+static inline bool php_ssh2_sftp_handle_session_is_open(php_ssh2_sftp_handle_data *data) {
+    php_ssh2_sftp_data *sftp_data = (php_ssh2_sftp_data *) data->sftp_rsrc->ptr;
+
+    return sftp_data && php_ssh2_session_is_open(sftp_data->session_rsrc);
+}
+
 /* {{{ php_ssh2_sftp_stream_write
  */
 static ssize_t php_ssh2_sftp_stream_write(php_stream *stream, const char *buf, size_t count) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
     ssize_t bytes_written;
+
+    if (!php_ssh2_sftp_handle_session_is_open(data)) {
+        return -1;
+    }
 
     auto session = data->session;
     bytes_written = libssh2_sftp_write(data->handle, buf, count);
@@ -124,6 +134,10 @@ static ssize_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t c
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
     ssize_t bytes_read;
 
+    if (!php_ssh2_sftp_handle_session_is_open(data)) {
+        return -1;
+    }
+
     auto session = data->session;
     bytes_read = libssh2_sftp_read(data->handle, buf, count);
 
@@ -137,9 +151,12 @@ static ssize_t php_ssh2_sftp_stream_read(php_stream *stream, char *buf, size_t c
  */
 static int php_ssh2_sftp_stream_close(php_stream *stream, int close_handle) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
-    auto session = data->session;
 
-    libssh2_sftp_close(data->handle);
+    if (php_ssh2_sftp_handle_session_is_open(data)) {
+        auto session = data->session;
+        libssh2_sftp_close(data->handle);
+    }
+
     zend_list_delete(data->sftp_rsrc);
     efree(data);
 
@@ -151,6 +168,11 @@ static int php_ssh2_sftp_stream_close(php_stream *stream, int close_handle) {
  */
 static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffset) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
+
+    if (!php_ssh2_sftp_handle_session_is_open(data)) {
+        return -1;
+    }
+
     auto session = data->session;
 
     switch (whence) {
@@ -194,6 +216,11 @@ static int php_ssh2_sftp_stream_seek(php_stream *stream, zend_off_t offset, int 
 static int php_ssh2_sftp_stream_fstat(php_stream *stream, php_stream_statbuf *ssb) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
     LIBSSH2_SFTP_ATTRIBUTES attrs;
+
+    if (!php_ssh2_sftp_handle_session_is_open(data)) {
+        return -1;
+    }
+
     auto session = data->session;
 
     if (libssh2_sftp_fstat(data->handle, &attrs)) {
@@ -277,6 +304,11 @@ static php_stream *php_ssh2_sftp_stream_opener(php_stream_wrapper *wrapper,
 static ssize_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_t count) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
     php_stream_dirent *ent = (php_stream_dirent *) buf;
+
+    if (!php_ssh2_sftp_handle_session_is_open(data)) {
+        return 0;
+    }
+
     auto session = data->session;
     int bytesread = libssh2_sftp_readdir(data->handle, ent->d_name, sizeof(ent->d_name) - 1, NULL);
     zend_string *basename;
@@ -304,9 +336,12 @@ static ssize_t php_ssh2_sftp_dirstream_read(php_stream *stream, char *buf, size_
  */
 static int php_ssh2_sftp_dirstream_close(php_stream *stream, int close_handle) {
     php_ssh2_sftp_handle_data *data = (php_ssh2_sftp_handle_data *) stream->abstract;
-    auto session = data->session;
 
-    libssh2_sftp_close(data->handle);
+    if (php_ssh2_sftp_handle_session_is_open(data)) {
+        auto session = data->session;
+        libssh2_sftp_close(data->handle);
+    }
+
     zend_list_delete(data->sftp_rsrc);
     efree(data);
 
@@ -618,6 +653,10 @@ PHP_FUNCTION(ssh2_sftp_rename) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = data->session;
 
     RETURN_BOOL(!libssh2_sftp_rename_ex(
@@ -646,6 +685,10 @@ PHP_FUNCTION(ssh2_sftp_unlink) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = data->session;
     RETURN_BOOL(!libssh2_sftp_unlink_ex(data->sftp, filename->val, filename->len));
 }
@@ -671,6 +714,10 @@ PHP_FUNCTION(ssh2_sftp_mkdir) {
 
     if ((data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) ==
         NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -707,6 +754,10 @@ PHP_FUNCTION(ssh2_sftp_rmdir) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = data->session;
     RETURN_BOOL(!libssh2_sftp_rmdir_ex(data->sftp, dirname->val, dirname->len));
 }
@@ -731,6 +782,10 @@ PHP_FUNCTION(ssh2_sftp_chmod) {
 
     if ((data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) ==
         NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -760,6 +815,10 @@ static void php_ssh2_sftp_stat_func(INTERNAL_FUNCTION_PARAMETERS, int stat_type)
 
     if ((data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) ==
         NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -827,6 +886,10 @@ PHP_FUNCTION(ssh2_sftp_symlink) {
         RETURN_FALSE;
     }
 
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
+        RETURN_FALSE;
+    }
+
     auto session = data->session;
     RETURN_BOOL(!libssh2_sftp_symlink_ex(data->sftp, targ->val, targ->len, link->val, link->len, LIBSSH2_SFTP_SYMLINK));
 }
@@ -847,6 +910,10 @@ PHP_FUNCTION(ssh2_sftp_readlink) {
 
     if ((data = (php_ssh2_sftp_data *) zend_fetch_resource(Z_RES_P(zsftp), PHP_SSH2_SFTP_RES_NAME, le_ssh2_sftp)) ==
         NULL) {
+        RETURN_FALSE;
+    }
+
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 
@@ -879,7 +946,7 @@ PHP_FUNCTION(ssh2_sftp_realpath) {
         RETURN_FALSE;
     }
 
-    if (data->session_rsrc->ptr == NULL) {
+    if (!php_ssh2_session_is_open(data->session_rsrc)) {
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
## Problem

The bundled SSH2 extension has one connected set of resource-lifetime and stream-contract bugs:

- direct SFTP wrapper connections do not consistently register and release their session and SFTP resources;
- one-shot wrapper operations leak temporary references;
- child resources can call libssh2 after their parent session has been destroyed;
- channel reads, writes, EOF, blocking mode, and timeouts do not follow PHP stream semantics; and
- SFTP file and directory errors can be reported as clean EOF.

These paths share the same ownership graph and stream implementations. Splitting them across pull requests would leave unsafe intermediate states.

## Change

The series contains five implementation commits plus one test-isolation follow-up:

1. Initialize every field on SFTP directory handles before exposing the stream.
2. Make direct wrapper session/SFTP ownership transactional and release temporary wrapper resources.
3. Guard child operations and destructors with their parent resource lifetime.
4. Correct channel blocking, nonblocking backpressure, operation-local timeouts, error returns, and EOF metadata.
5. Keep SFTP file and directory failures distinct from clean completion.
6. Keep the authentication-failure regression below OpenSSH 9.8+'s default per-source penalty floor without weakening its descriptor-leak assertion.

Channel timeouts are passed directly to the owning socket poll. They no longer mutate shared session socket state, so a timeout on one channel cannot affect another channel or a later SFTP operation on the same SSH session.

## Tests

New PHPT coverage exercises:

- SFTP directory enumeration;
- direct wrapper authentication, resource registration, and reference release;
- child-resource behavior after parent-session closure;
- channel blocking mode, nonblocking backpressure, transport errors, EOF, and sub-second timeout isolation; and
- SFTP file and directory error handling.

Each implementation commit was built and tested at its own boundary. The complete added SSH2 test set also passes against the final extension build.

## Review notes

The affected ownership paths were compared with PECL ssh2 1.5.0. This keeps the established Zend resource model where it applies, while retaining Swoole's coroutine-aware I/O and adding the Swoole-specific channel timeout and nonblocking behavior.

The parent-guard commit also changes `(data->refcount)--` to `(*(data->refcount))--` in the allocation-failure cleanup for `ssh2_fetch_stream()`. That branch cannot be forced through a normal PHPT without a production test hook, but the current expression advances the pointer instead of decrementing the referenced count.
