### PR TITLE
Fix proc_open stream descriptor ownership

### DIFF
--- a/tests/swoole_runtime/proc/file_descriptor_ownership.phpt
+++ b/tests/swoole_runtime/proc/file_descriptor_ownership.phpt
@@ -1,0 +1,33 @@
+--TEST--
+swoole_runtime/proc: preserve file descriptor ownership
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_win();
+skip_if_function_not_exist('proc_open');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+Swoole\Runtime::enableCoroutine();
+
+Co\run(static function (): void {
+    $descriptorSpec = [
+        0 => ['file', '/dev/null', 'r'],
+        1 => ['file', '/dev/null', 'w'],
+        2 => ['file', '/dev/null', 'w'],
+    ];
+
+    for ($i = 0; $i < 3; $i++) {
+        $process = proc_open([PHP_BINARY, '-n', '-r', 'exit(0);'], $descriptorSpec, $pipes);
+
+        Assert::true(is_resource($process));
+        Assert::same(proc_close($process), 0);
+    }
+});
+
+echo "Done\n";
+?>
+--EXPECT--
+Done

--- a/thirdparty/php/streams/plain_wrapper.c
+++ b/thirdparty/php/streams/plain_wrapper.c
@@ -257,7 +257,8 @@ static void _sw_detect_is_seekable(php_stdio_stream_data *self) {
         self->is_pipe = S_ISFIFO(self->sb.st_mode);
         self->can_poll = S_ISFIFO(self->sb.st_mode) || S_ISSOCK(self->sb.st_mode) || S_ISCHR(self->sb.st_mode);
         if (self->can_poll) {
-            swoole_coroutine_socket_create(self->fd);
+            /* Track successful registration so the close handler can unwrap it. */
+            self->can_poll = swoole_coroutine_socket_create(self->fd) == 0;
         }
     }
 #elif defined(PHP_WIN32)
@@ -450,6 +451,14 @@ static int sw_php_stdiop_close(php_stream *stream, int close_handle) {
         data->file_mapping = NULL;
     }
 #endif
+
+    /* fclose() and PHP_STREAM_CAST_RELEASE bypass swoole_coroutine_close(). */
+    if (data->can_poll && (!close_handle || data->file)) {
+        int fd;
+
+        PHP_STDIOP_GET_FD(fd, data);
+        swoole_coroutine_socket_unwrap(fd);
+    }
 
     if (close_handle) {
         if (data->file) {


### PR DESCRIPTION
This fixes a file descriptor ownership bug in the coroutine plain stream wrapper.

proc_open() takes ownership of file-backed descriptors. The wrapper kept a coroutine socket for the same descriptor, so deferred cleanup could close it after transfer or reuse. This caused EBADF errors and failed child processes.

The wrapper now records successful socket registration and unwraps the socket when the stream transfers the descriptor or closes it through FILE*.

A regression test repeatedly starts a child with /dev/null descriptors.

Tests:
- swoole_runtime/proc: 7 passed
- swoole_runtime/file_hook: 16 passed