### PR TITLE
Fix trailers after streamed HTTP/2 responses

### DIFF
--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -720,11 +720,15 @@ static bool http2_server_respond(HttpContext *ctx, const String *body) {
 #endif
 
     SW_LOOP {
-        if (ctx->send_chunked && body->length == 0 && !stream->send_end_stream_data_frame()) {
-            break;
+        if (body->length == 0) {
+            // Trailer HEADERS carry END_STREAM, so only trailerless streamed responses need an empty DATA frame.
+            if (ctx->send_chunked && !ztrailer && !stream->send_end_stream_data_frame()) {
+                break;
+            }
         } else if (!stream->send_body(body, end_stream, client)) {
             break;
-        } else if (ztrailer && !stream->send_trailer()) {
+        }
+        if (ztrailer && !stream->send_trailer()) {
             break;
         }
         error = false;

--- a/tests/swoole_http2_server/streaming_trailer.phpt
+++ b/tests/swoole_http2_server/streaming_trailer.phpt
@@ -1,0 +1,96 @@
+--TEST--
+swoole_http2_server: trailers after streamed writes
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+const BODY = 'Hello, World!';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Coroutine\run(function () use ($pm) {
+        $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+        Assert::true($client->connect());
+
+        // A streamed response without trailers still terminates with END_STREAM DATA.
+        $request = new Http2Request;
+        $request->path = '/stream-no-trailer';
+        Assert::greaterThan($client->send($request), 0);
+        $response = $client->recv();
+        Assert::same($response->data, BODY);
+        Assert::false(isset($response->headers['grpc-status']));
+
+        // Keep the streamed-write regression last so the controls run first.
+        foreach (['/final-chunk-trailer', '/body-trailer', '/stream-then-trailer'] as $path) {
+            $request = new Http2Request;
+            $request->path = $path;
+            Assert::greaterThan($client->send($request), 0);
+            $response = $client->recv();
+            Assert::same($response->data, BODY);
+            Assert::same($response->headers['grpc-status'] ?? null, '0');
+            Assert::same($response->headers['grpc-message'] ?? null, 'ok');
+        }
+
+        // The connection stays usable for an ordinary request afterwards.
+        $request = new Http2Request;
+        $request->path = '/plain';
+        Assert::greaterThan($client->send($request), 0);
+        $response = $client->recv();
+        Assert::same($response->data, 'OK');
+    });
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null',
+        'open_http2_protocol' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Request $request, Response $response) {
+        switch ($request->server['request_uri']) {
+            case '/stream-then-trailer':
+                $response->trailer('grpc-status', '0');
+                $response->trailer('grpc-message', 'ok');
+                $response->write('Hello, ');
+                $response->write('World!');
+                $response->end();
+                break;
+            case '/final-chunk-trailer':
+                $response->trailer('grpc-status', '0');
+                $response->trailer('grpc-message', 'ok');
+                $response->write('Hello, ');
+                $response->end('World!');
+                break;
+            case '/body-trailer':
+                $response->trailer('grpc-status', '0');
+                $response->trailer('grpc-message', 'ok');
+                $response->end('Hello, World!');
+                break;
+            case '/stream-no-trailer':
+                $response->write('Hello, ');
+                $response->write('World!');
+                $response->end();
+                break;
+            default:
+                $response->end('OK');
+        }
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
A streamed HTTP/2 response ending without a final body currently sends an empty DATA frame with END_STREAM before its trailer HEADERS. Clients receive the body but not the trailers, and the server emits HEADERS for a closed stream.

This keeps the empty DATA terminator for trailerless streams and lets trailer HEADERS terminate responses that have trailers.

The regression test covers streamed trailers alongside the existing trailer and trailerless completion paths on one connection.