### PR TITLE
Fix HTTP/2 session teardown after fatal requests

### DIFF
--- a/ext-src/php_swoole_http_server.h
+++ b/ext-src/php_swoole_http_server.h
@@ -40,6 +40,7 @@ int swoole_http2_server_onReceive(swoole::Server *serv, swoole::Connection *conn
 
 std::shared_ptr<swoole::http2::Session> swoole_http2_server_session_new(swoole::SessionId fd);
 void swoole_http2_server_session_free(swoole::SessionId fd);
+void swoole_http2_server_release_sessions();
 
 bool swoole_http2_server_end(swoole::http::Context *ctx, zend_string *sdata);
 bool swoole_http2_server_write(swoole::http::Context *ctx, zend_string *sdata);

--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -1297,7 +1297,6 @@ int swoole_http2_server_onReceive(Server *serv, Connection *conn, RecvData *req)
         client->default_ctx->onBeforeRequest = http2_server_onBeforeRequest;
         client->max_body_size = serv->get_package_max_length(conn);
         client->handle = http2_server_onRequest;
-        http2_sessions.emplace(session_id, client);
     } else {
         client = iter->second;
     }
@@ -1331,7 +1330,15 @@ void swoole_http2_server_session_free(SessionId session_id) {
     if (iter == http2_sessions.end()) {
         return;
     }
-    /* default_ctx does not blong to session object */
-    iter->second->default_ctx = nullptr;
+    if (iter->second->is_coro) {
+        // A coroutine session borrows default_ctx from its request/response objects; an async session owns it.
+        iter->second->default_ctx = nullptr;
+    }
     http2_sessions.erase(iter);
+}
+
+void swoole_http2_server_release_sessions() {
+    while (!http2_sessions.empty()) {
+        swoole_http2_server_session_free(http2_sessions.begin()->first);
+    }
 }

--- a/ext-src/swoole_http_server.cc
+++ b/ext-src/swoole_http_server.cc
@@ -192,6 +192,8 @@ void php_swoole_http_server_rshutdown() {
         SG(rfc1867_uploaded_files) = nullptr;
     }
 
+    // A fatal bailout can leave HTTP/2 sessions here; free them before Zend tears down the allocator nghttp2 uses.
+    swoole_http2_server_release_sessions();
     server_ips.clear();
     client_ips.clear();
     while (!queued_http_contexts.empty()) {

--- a/tests/swoole_http2_server/session_shutdown.phpt
+++ b/tests/swoole_http2_server/session_shutdown.phpt
@@ -1,0 +1,99 @@
+--TEST--
+swoole_http2_server: session teardown after a fatal request
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--INI--
+display_errors=0
+log_errors=0
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+$worker_error_signal = new Atomic(0);
+$worker_error_fired = new Atomic(0);
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm, $worker_error_signal, $worker_error_fired) {
+    Coroutine\run(function () use ($pm, $worker_error_signal, $worker_error_fired) {
+        // Leave an HTTP/2 session in the map by letting a suspended request coroutine be cancelled.
+        $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+        $client->set(['timeout' => 5]);
+        Assert::true($client->connect());
+        $request = new Http2Request;
+        $request->path = '/crash';
+        Assert::greaterThan($client->send($request), 0);
+
+        // The uncaught cancellation must not become a late nghttp2 SIGSEGV.
+        $deadline = microtime(true) + 5;
+        while ($worker_error_fired->get() === 0 && microtime(true) < $deadline) {
+            Coroutine::sleep(0.05);
+        }
+        Assert::same($worker_error_fired->get(), 1);
+        Assert::same($worker_error_signal->get(), 0);
+
+        // The replacement worker keeps the server usable on a fresh connection.
+        $healthy = false;
+        $deadline = microtime(true) + 5;
+        while (microtime(true) < $deadline) {
+            $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+            $client->set(['timeout' => 5]);
+            if ($client->connect()) {
+                $request = new Http2Request;
+                $request->path = '/health';
+                if ($client->send($request) > 0 && ($response = $client->recv()) && $response->data === 'OK') {
+                    $healthy = true;
+                    break;
+                }
+            }
+            Coroutine::sleep(0.05);
+        }
+        Assert::true($healthy);
+        echo "DONE\n";
+    });
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm, $worker_error_signal, $worker_error_fired) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $server->set([
+        'worker_num' => 1,
+        'enable_coroutine' => true,
+        'log_file' => '/dev/null',
+        'open_http2_protocol' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('workerError', function ($server, $worker_id, $worker_pid, $exit_code, $signal) use (
+        $worker_error_signal,
+        $worker_error_fired
+    ) {
+        $worker_error_signal->set($signal);
+        $worker_error_fired->set(1);
+    });
+    $server->on('request', function (Request $request, Response $response) {
+        if ($request->server['request_uri'] === '/crash') {
+            $cid = Coroutine::getCid();
+            Coroutine::create(function () use ($cid) {
+                Coroutine::sleep(0.05);
+                Coroutine::cancel($cid, true);
+            });
+            Coroutine::sleep(10);
+            return;
+        }
+        $response->end('OK');
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
This fixes a worker crash during shutdown when a fatal request leaves an HTTP/2 session alive.

Remaining sessions are now released during request shutdown, before Zend tears down the allocator used by nghttp2. Cleanup preserves the different context ownership rules for coroutine and async sessions.

The regression test covers the fatal request path and verifies that the replacement worker remains healthy.