### PR TITLE
Stream HTTP/2 sendfile responses in bounded chunks

### DIFF
--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -30,7 +30,6 @@ using swoole::RecvData;
 using swoole::Server;
 using swoole::SessionId;
 using swoole::String;
-using swoole::coroutine::System;
 using swoole::http2::get_default_setting;
 using swoole::http_server::StaticHandler;
 
@@ -863,24 +862,15 @@ static bool http2_server_send_range_file(HttpContext *ctx, StaticHandler *handle
 bool swoole_http2_server_send_file(HttpContext *ctx, zend_string *file, off_t offset, size_t length) {
     auto client = http2_sessions[ctx->fd];
     auto stream = client->get_stream(ctx->stream_id);
-    std::shared_ptr<String> body;
 
 #ifdef SW_HAVE_COMPRESSION
     ctx->accept_compression = 0;
 #endif
-    if (swoole_coroutine_is_in()) {
-        body = System::read_file(ZSTR_VAL(file), false);
-        if (!body) {
-            return false;
-        }
-    } else {
-        File fp(ZSTR_VAL(file), O_RDONLY);
-        if (!fp.ready()) {
-            return false;
-        }
-        body = fp.read_content();
+
+    File fp(ZSTR_VAL(file), O_RDONLY);
+    if (!fp.ready()) {
+        return false;
     }
-    body->length = SW_MIN(length, body->length);
 
     zval *ztrailer =
         sw_zend_read_property_ex(swoole_http_response_ce, ctx->response.zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_TRAILER), 0);
@@ -895,7 +885,11 @@ bool swoole_http2_server_send_file(HttpContext *ctx, zend_string *file, off_t of
     }
 
     bool end_stream = (ztrailer == nullptr);
-    if (!stream->send_header(body.get(), end_stream)) {
+
+    // Compression is disabled above, so send_header() reads only the transfer length.
+    String content_length{};
+    content_length.length = length;
+    if (!stream->send_header(&content_length, end_stream)) {
         return false;
     }
 
@@ -903,10 +897,39 @@ bool swoole_http2_server_send_file(HttpContext *ctx, zend_string *file, off_t of
     ctx->end_ = 1;
 
     bool error = false;
+    String chunk(SW_FILE_CHUNK_SIZE);
+    off_t file_offset = offset;
+    size_t remaining = length;
 
-    if (body->length > 0) {
-        if (!stream->send_body(body.get(), end_stream, client, offset, length)) {
+    while (remaining > 0) {
+        const size_t read_size = SW_MIN(remaining, chunk.size);
+        ssize_t n_read = -1;
+        auto read_chunk = [&]() { n_read = fp.pread(chunk.str, read_size, file_offset); };
+
+        if (swoole_coroutine_is_in()) {
+            if (!swoole::coroutine::async(read_chunk)) {
+                error = true;
+                break;
+            }
+        } else {
+            read_chunk();
+        }
+
+        // A positive short read is progress; a zero-length read before the requested
+        // range ends is a premature end of file.
+        if (n_read <= 0) {
             error = true;
+            break;
+        }
+
+        chunk.length = n_read;
+        file_offset += n_read;
+        remaining -= n_read;
+
+        const bool last_data = remaining == 0 && !ztrailer;
+        if (!stream->send_body(&chunk, last_data, client)) {
+            error = true;
+            break;
         }
     }
 

--- a/tests/swoole_http2_server/sendfile_disconnect.phpt
+++ b/tests/swoole_http2_server/sendfile_disconnect.phpt
@@ -1,0 +1,92 @@
+--TEST--
+swoole_http2_server: sendfile keeps the server alive when a client disconnects mid-transfer
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+// Larger than the default 64 KiB flow-control window, so the transfer is still in
+// progress when the client goes away.
+$big_file = tempnam(sys_get_temp_dir(), 'swoole_sendfile_big_');
+file_put_contents($big_file, str_repeat('swoole', 350000));
+
+foreach ([SWOOLE_BASE, SWOOLE_PROCESS] as $mode) {
+    $sendfile_finished = new Atomic(0);
+    $worker_error_fired = new Atomic(0);
+
+    $pm = new ProcessManager;
+    $pm->parentFunc = function () use ($pm, $sendfile_finished, $worker_error_fired) {
+        Coroutine\run(function () use ($pm, $sendfile_finished, $worker_error_fired) {
+            // Request the large file, then abandon the connection before draining it.
+            $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+            $client->set(['timeout' => 10]);
+            Assert::true($client->connect());
+            $request = new Http2Request;
+            $request->path = '/big';
+            Assert::greaterThan($client->send($request), 0);
+            $client->close();
+
+            // A fresh connection is still served.
+            $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+            $client->set(['timeout' => 10]);
+            Assert::true($client->connect());
+            $request = new Http2Request;
+            $request->path = '/health';
+            Assert::greaterThan($client->send($request), 0);
+            $response = $client->recv();
+            Assert::notEmpty($response);
+            Assert::same($response->statusCode, 200);
+            Assert::same($response->data, 'OK');
+
+            // The worker that ran the abandoned sendfile must have returned normally
+            // rather than crashed (which in process mode is masked by a worker restart).
+            $deadline = microtime(true) + 5;
+            while ($sendfile_finished->get() === 0 && $worker_error_fired->get() === 0 && microtime(true) < $deadline) {
+                Coroutine::sleep(0.05);
+            }
+            Assert::same($sendfile_finished->get(), 1);
+            Assert::same($worker_error_fired->get(), 0);
+        });
+        $pm->kill();
+    };
+    $pm->childFunc = function () use ($pm, $mode, $big_file, $sendfile_finished, $worker_error_fired) {
+        $server = new Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $server->set([
+            'worker_num' => 1,
+            'log_file' => '/dev/null',
+            'open_http2_protocol' => true,
+        ]);
+        $server->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $server->on('workerError', function () use ($worker_error_fired) {
+            $worker_error_fired->set(1);
+        });
+        $server->on('request', function (Request $request, Response $response) use ($big_file, $sendfile_finished) {
+            if ($request->server['request_uri'] === '/big') {
+                $response->sendfile($big_file);
+                $sendfile_finished->set(1);
+                return;
+            }
+            $response->end('OK');
+        });
+        $server->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+
+unlink($big_file);
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http2_server/sendfile_memory.phpt
+++ b/tests/swoole_http2_server/sendfile_memory.phpt
@@ -1,0 +1,114 @@
+--TEST--
+swoole_http2_server: sendfile streams a small range without buffering the whole file
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_function_not_exist('getrusage');
+if (PHP_OS !== 'Linux' && PHP_OS !== 'Darwin') {
+    skip('unknown ru_maxrss unit convention');
+}
+if (!isset(getrusage()['ru_maxrss'])) {
+    skip('ru_maxrss is not available');
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+// A 128 MiB sparse file: the baseline reads it whole before selecting the range,
+// the bounded implementation only touches a couple of 64 KiB windows.
+$sparse_file = tempnam(sys_get_temp_dir(), 'swoole_sendfile_rss_');
+register_shutdown_function(function () use ($sparse_file) {
+    if (is_file($sparse_file)) {
+        unlink($sparse_file);
+    }
+});
+$handle = fopen($sparse_file, 'w');
+ftruncate($handle, 128 * 1024 * 1024);
+fclose($handle);
+
+$offset = 64 * 1024 * 1024;
+$range = 128 * 1024;
+// Well above allocator noise for a couple of windows, well below the 128 MiB file.
+$ceiling = 32 * 1024 * 1024;
+
+$rss_delta = new Atomic\Long(0);
+$measured = new Atomic(0);
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm, $range, $ceiling, $rss_delta, $measured) {
+    Coroutine\run(function () use ($pm, $range, $ceiling, $rss_delta, $measured) {
+        $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+        $client->set(['timeout' => 10]);
+        Assert::true($client->connect());
+
+        // Warm the worker so its baseline allocations are already counted.
+        $request = new Http2Request;
+        $request->path = '/warmup';
+        Assert::greaterThan($client->send($request), 0);
+        Assert::same($client->recv()->data, 'OK');
+
+        // Request only a small range from deep inside the file.
+        $request = new Http2Request;
+        $request->path = '/measure';
+        Assert::greaterThan($client->send($request), 0);
+        $response = $client->recv();
+        Assert::notEmpty($response);
+        Assert::same(strlen($response->data), $range);
+        Assert::same($response->data, str_repeat("\0", $range));
+
+        // The worker records its peak-RSS growth after sendfile() returns.
+        $deadline = microtime(true) + 5;
+        while ($measured->get() === 0 && microtime(true) < $deadline) {
+            Coroutine::sleep(0.01);
+        }
+        Assert::same($measured->get(), 1);
+        Assert::lessThan($rss_delta->get(), $ceiling);
+    });
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm, $sparse_file, $offset, $range, $rss_delta, $measured) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null',
+        'open_http2_protocol' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Request $request, Response $response) use (
+        $sparse_file,
+        $offset,
+        $range,
+        $rss_delta,
+        $measured
+    ) {
+        if ($request->server['request_uri'] !== '/measure') {
+            $response->end('OK');
+            return;
+        }
+        $before = getrusage()['ru_maxrss'];
+        $response->sendfile($sparse_file, $offset, $range);
+        $after = getrusage()['ru_maxrss'];
+        // Linux reports ru_maxrss in KiB, macOS in bytes.
+        $delta = $after - $before;
+        $rss_delta->set(PHP_OS === 'Darwin' ? $delta : $delta * 1024);
+        $measured->set(1);
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http2_server/sendfile_range.phpt
+++ b/tests/swoole_http2_server/sendfile_range.phpt
@@ -1,0 +1,170 @@
+--TEST--
+swoole_http2_server: sendfile range, partial window, trailers and metadata
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+// Deterministic, position-dependent content spanning several 64 KiB windows so a
+// wrong offset or a dropped partial window is visible in the transferred bytes.
+$content = '';
+for ($i = 0; $i < 200000; $i++) {
+    $content .= chr(($i * 31 + 7) % 256);
+}
+// Rename the tempnam() file to a .bin path so the transferred file has a real
+// extension for the Content-Type assertion (and nothing is left behind).
+$data_file = tempnam(sys_get_temp_dir(), 'swoole_sendfile_');
+rename($data_file, "$data_file.bin");
+$data_file .= '.bin';
+$empty_file = tempnam(sys_get_temp_dir(), 'swoole_sendfile_empty_');
+file_put_contents($data_file, $content);
+file_put_contents($empty_file, '');
+
+$offset = 70000;
+$length = 90000;
+$partial_offset = 10000;
+$partial_length = 65536 + 1234;
+
+$configs = [
+    [SWOOLE_BASE, true],
+    [SWOOLE_PROCESS, true],
+    [SWOOLE_BASE, false],
+];
+
+foreach ($configs as [$mode, $enable_coroutine]) {
+    $pm = new ProcessManager;
+    $pm->parentFunc = function () use ($pm, $content, $offset, $length, $partial_offset, $partial_length) {
+        Coroutine\run(function () use ($pm, $content, $offset, $length, $partial_offset, $partial_length) {
+            $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+            $client->set(['timeout' => 10]);
+            Assert::true($client->connect());
+
+            $fetch = function (string $path) use ($client) {
+                $request = new Http2Request;
+                $request->path = $path;
+                Assert::greaterThan($client->send($request), 0);
+                $response = $client->recv();
+                Assert::notEmpty($response);
+                return $response;
+            };
+
+            // Complete file.
+            $response = $fetch('/complete');
+            Assert::same($response->statusCode, 200);
+            Assert::same($response->data, $content);
+            Assert::same($response->headers['content-length'], (string) strlen($content));
+            Assert::same($response->headers['content-type'], 'application/octet-stream');
+
+            // Nonzero offset with a multi-window length.
+            $response = $fetch('/offset');
+            Assert::same($response->statusCode, 200);
+            Assert::same($response->data, substr($content, $offset, $length));
+            Assert::same($response->headers['content-length'], (string) $length);
+            // Offset/length alone do not invent a Content-Range header.
+            Assert::false(isset($response->headers['content-range']));
+
+            // Length that ends inside a window exercises the final partial read.
+            $response = $fetch('/partial');
+            Assert::same($response->data, substr($content, $partial_offset, $partial_length));
+            Assert::same($response->headers['content-length'], (string) $partial_length);
+
+            // Empty file terminates with headers only and no DATA frame.
+            $response = $fetch('/empty');
+            Assert::same($response->statusCode, 200);
+            Assert::same((string) $response->data, '');
+            Assert::same($response->headers['content-length'], '0');
+
+            // Trailers close a file response instead of a terminal DATA frame.
+            $response = $fetch('/trailers');
+            Assert::same($response->data, substr($content, 0, 100000));
+            Assert::same($response->headers['content-length'], '100000');
+            Assert::same($response->headers['grpc-status'], '0');
+            Assert::same($response->headers['grpc-message'], 'done');
+
+            // An application-supplied status and Content-Range are preserved.
+            $response = $fetch('/custom-range');
+            Assert::same($response->statusCode, 206);
+            Assert::same($response->headers['content-range'], 'bytes 100-199/200000');
+            Assert::same($response->data, substr($content, 100, 100));
+
+            // The connection stays usable for a final ordinary request.
+            $response = $fetch('/complete');
+            Assert::same($response->data, $content);
+        });
+        $pm->kill();
+    };
+    $pm->childFunc = function () use (
+        $pm,
+        $mode,
+        $enable_coroutine,
+        $data_file,
+        $empty_file,
+        $offset,
+        $length,
+        $partial_offset,
+        $partial_length
+    ) {
+        $server = new Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $server->set([
+            'worker_num' => 1,
+            'enable_coroutine' => $enable_coroutine,
+            'log_file' => '/dev/null',
+            'open_http2_protocol' => true,
+        ]);
+        $server->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $server->on('request', function (Request $request, Response $response) use (
+            $data_file,
+            $empty_file,
+            $offset,
+            $length,
+            $partial_offset,
+            $partial_length
+        ) {
+            switch ($request->server['request_uri']) {
+                case '/complete':
+                    $response->sendfile($data_file);
+                    break;
+                case '/offset':
+                    $response->sendfile($data_file, $offset, $length);
+                    break;
+                case '/partial':
+                    $response->sendfile($data_file, $partial_offset, $partial_length);
+                    break;
+                case '/empty':
+                    $response->sendfile($empty_file);
+                    break;
+                case '/trailers':
+                    $response->header('trailer', 'grpc-status, grpc-message');
+                    $response->trailer('grpc-status', '0');
+                    $response->trailer('grpc-message', 'done');
+                    $response->sendfile($data_file, 0, 100000);
+                    break;
+                case '/custom-range':
+                    $response->status(206);
+                    $response->header('content-range', 'bytes 100-199/200000');
+                    $response->sendfile($data_file, 100, 100);
+                    break;
+            }
+        });
+        $server->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+
+unlink($data_file);
+unlink($empty_file);
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
This changes HTTP/2 `Response::sendfile()` to stream the requested file range through a reusable fixed-size buffer. Previously it read the entire file before applying the range.

Sending headers before asynchronous reads also prevents a worker crash when the client disconnects during the initial read.

Tests cover ranges, trailers, memory use, and disconnect handling.