### PR TITLE
Preserve explicit HTTP/2 Content-Length headers

### DIFF
--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -352,7 +352,7 @@ static ssize_t http2_server_build_header(HttpContext *ctx, uchar *buffer, const 
 
         zend_string *content_type = nullptr;
         auto add_header =
-            [ctx, &content_type](
+            [ctx, body, &content_type](
                 Http2::HeaderSet &headers, const char *key, size_t l_key, zval *value, uint32_t &header_flags) {
                 if (ZVAL_IS_NULL(value)) {
                     return;
@@ -365,7 +365,30 @@ static ssize_t http2_server_build_header(HttpContext *ctx, uchar *buffer, const 
                 if (SW_STRCASEEQ(key, l_key, "server")) {
                     header_flags |= HTTP_HEADER_SERVER;
                 } else if (SW_STRCASEEQ(key, l_key, "content-length")) {
-                    return;  // ignore
+#ifdef SW_HAVE_COMPRESSION
+                    // A complete body that the client accepts compressed is length-normalized below,
+                    // so the explicit value cannot be trusted; a streamed body (body == nullptr) is not.
+                    if (body && ctx->accept_compression) {
+                        swoole_error_log(SW_LOG_WARNING,
+                                         SW_ERROR_HTTP_CONFLICT_HEADER,
+                                         "The client has set 'Accept-Encoding', 'Content-Length' will be ignored");
+                        return;
+                    }
+#endif
+                    header_flags |= HTTP_HEADER_CONTENT_LENGTH;
+                    // An empty value keeps the field explicit, suppressing synthesis without emitting it.
+                    if (str_value.len() == 0) {
+                        return;
+                    }
+                } else if (SW_STRCASEEQ(key, l_key, "content-encoding")) {
+#ifdef SW_HAVE_COMPRESSION
+                    // The application owns the representation encoding; do not compress it again.
+                    ctx->accept_compression = 0;
+#endif
+                    // An empty value keeps the field explicit without emitting it, like other known headers.
+                    if (str_value.len() == 0) {
+                        return;
+                    }
                 } else if (SW_STRCASEEQ(key, l_key, "date")) {
                     header_flags |= HTTP_HEADER_DATE;
                 } else if (SW_STRCASEEQ(key, l_key, "content-type")) {
@@ -401,9 +424,11 @@ static ssize_t http2_server_build_header(HttpContext *ctx, uchar *buffer, const 
             std::string str_content_type = content_type ? std::string(ZSTR_VAL(content_type), ZSTR_LEN(content_type))
                                                         : std::string(ZEND_STRL(SW_HTTP_DEFAULT_CONTENT_TYPE));
             ctx->accept_compression = ctx->compression_types->find(str_content_type) != ctx->compression_types->end();
-            if (content_type) {
-                zend_string_release(content_type);
-            }
+        }
+        // Released unconditionally: an application content-encoding can clear accept_compression
+        // after content-type was captured, which would skip the refinement above.
+        if (content_type) {
+            zend_string_release(content_type);
         }
 #endif
     }
@@ -432,18 +457,26 @@ static ssize_t http2_server_build_header(HttpContext *ctx, uchar *buffer, const 
     }
 
     if (body) {
-        size_t content_length = body->length;
-        // content length
+        // HTTP/2 keeps the method in the request_method server var, not in llhttp's parser.
+        zval *zrequest_method = zend_hash_str_find(Z_ARR_P(ctx->request.zserver), ZEND_STRL("request_method"));
+        bool is_head = zrequest_method && Z_TYPE_P(zrequest_method) == IS_STRING &&
+                       SW_STRCASEEQ(Z_STRVAL_P(zrequest_method), Z_STRLEN_P(zrequest_method), "HEAD");
+
+        // Synthesize a length only when the caller did not supply one, and never rewrite a
+        // zero-length HEAD representation to an explicit zero.
+        if (!(header_flags & HTTP_HEADER_CONTENT_LENGTH) && (body->length > 0 || !is_head)) {
+            size_t content_length = body->length;
 #ifdef SW_HAVE_COMPRESSION
-        if (ctx->compress(body->str, body->length)) {
-            content_length = ctx->zlib_buffer->length;
-            // content encoding
-            const char *content_encoding = ctx->get_content_encoding();
-            headers.add(ZEND_STRL("content-encoding"), (char *) content_encoding, strlen(content_encoding));
-        }
+            if (ctx->compress(body->str, body->length)) {
+                content_length = ctx->zlib_buffer->length;
+                // content encoding
+                const char *content_encoding = ctx->get_content_encoding();
+                headers.add(ZEND_STRL("content-encoding"), (char *) content_encoding, strlen(content_encoding));
+            }
 #endif
-        ret = swoole_itoa(intbuf[1], content_length);
-        headers.add(ZEND_STRL("content-length"), intbuf[1], ret);
+            ret = swoole_itoa(intbuf[1], content_length);
+            headers.add(ZEND_STRL("content-length"), intbuf[1], ret);
+        }
     }
 
     auto client = http2_sessions[ctx->fd];

--- a/tests/swoole_http2_server/content_length.phpt
+++ b/tests/swoole_http2_server/content_length.phpt
@@ -1,0 +1,202 @@
+--TEST--
+swoole_http2_server: preserve explicit Content-Length
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+// A body that compresses far below its original size, so the compressed length is
+// distinct from both the raw length and the stale explicit value.
+$compressible_body = str_repeat('swoole compression payload ', 2048);
+// A response the application has already gzip-encoded itself, with its own exact
+// Content-Length. The server must not compress it a second time.
+$pre_encoded_plain = str_repeat('event-stream payload ', 64);
+$pre_encoded_gzip = gzencode($pre_encoded_plain);
+$explicit_body = str_repeat('x', 100);
+$chunk_one = str_repeat('a', 8192);
+$chunk_two = str_repeat('b', 4096);
+$stream_length = strlen($chunk_one) + strlen($chunk_two);
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use (
+    $pm,
+    $compressible_body,
+    $pre_encoded_plain,
+    $pre_encoded_gzip,
+    $explicit_body,
+    $chunk_one,
+    $chunk_two,
+    $stream_length
+) {
+    Coroutine\run(function () use (
+        $pm,
+        $compressible_body,
+        $pre_encoded_plain,
+        $pre_encoded_gzip,
+        $explicit_body,
+        $chunk_one,
+        $chunk_two,
+        $stream_length
+    ) {
+        $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+        $client->set(['timeout' => 10]);
+        Assert::true($client->connect());
+
+        $fetch = function (string $path, string $method = 'GET', array $headers = []) use ($client) {
+            $request = new Http2Request;
+            $request->path = $path;
+            $request->method = $method;
+            if ($headers) {
+                $request->headers = $headers;
+            }
+            Assert::greaterThan($client->send($request), 0);
+            $response = $client->recv();
+            Assert::notEmpty($response);
+            return $response;
+        };
+
+        // An explicit Content-Length survives streamed writes and a bare end().
+        $response = $fetch('/stream');
+        Assert::same($response->statusCode, 200);
+        Assert::same($response->data, $chunk_one . $chunk_two);
+        Assert::same($response->headers['content-length'], (string) $stream_length);
+
+        // The streamed length is kept even when the request advertises compression,
+        // because a streamed body is never compressed.
+        $response = $fetch('/stream', 'GET', ['accept-encoding' => 'gzip']);
+        Assert::same($response->data, $chunk_one . $chunk_two);
+        Assert::same($response->headers['content-length'], (string) $stream_length);
+        Assert::false(isset($response->headers['content-encoding']));
+
+        // HEAD preserves an explicit representation length with no body.
+        $response = $fetch('/head-explicit', 'HEAD');
+        Assert::same($response->statusCode, 200);
+        Assert::same((string) $response->data, '');
+        Assert::same($response->headers['content-length'], '12345');
+
+        // HEAD without an explicit length omits Content-Length instead of synthesizing zero.
+        $response = $fetch('/head-empty', 'HEAD');
+        Assert::same((string) $response->data, '');
+        Assert::false(isset($response->headers['content-length']));
+
+        // end($body) preserves the caller's exact wire value; the leading zeroes prove
+        // the value was not re-synthesized from the body length.
+        $response = $fetch('/end-explicit');
+        Assert::same($response->data, $explicit_body);
+        Assert::same($response->headers['content-length'], '0000100');
+
+        // end($body) without an explicit value still synthesizes the body length.
+        $response = $fetch('/end-plain');
+        Assert::same($response->data, 'hello');
+        Assert::same($response->headers['content-length'], '5');
+
+        // A negotiated-compression complete body ignores the stale explicit value and
+        // reports the compressed length with Content-Encoding.
+        $response = $fetch('/compress', 'GET', ['accept-encoding' => 'gzip']);
+        Assert::same($response->data, $compressible_body);
+        Assert::same($response->headers['content-encoding'], 'gzip');
+        Assert::notSame($response->headers['content-length'], '999999');
+        Assert::notSame($response->headers['content-length'], (string) strlen($compressible_body));
+
+        // A response the application already encoded keeps its encoding and exact length and is
+        // not compressed again, even though the request advertises gzip.
+        $response = $fetch('/pre-encoded', 'GET', ['accept-encoding' => 'gzip']);
+        Assert::same($response->data, $pre_encoded_plain);
+        Assert::same($response->headers['content-encoding'], 'gzip');
+        Assert::same($response->headers['content-length'], (string) strlen($pre_encoded_gzip));
+
+        // An empty explicit Content-Length suppresses the field rather than emitting an empty one.
+        $response = $fetch('/empty-length');
+        Assert::same($response->data, 'body');
+        Assert::false(isset($response->headers['content-length']));
+
+        // The connection remains usable for a final ordinary request.
+        $response = $fetch('/plain');
+        Assert::same($response->data, 'OK');
+
+        $client->close();
+    });
+    $pm->kill();
+};
+$pm->childFunc = function () use (
+    $pm,
+    $compressible_body,
+    $pre_encoded_gzip,
+    $explicit_body,
+    $chunk_one,
+    $chunk_two,
+    $stream_length
+) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null',
+        'open_http2_protocol' => true,
+        'http_compression' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Request $request, Response $response) use (
+        $compressible_body,
+        $pre_encoded_gzip,
+        $explicit_body,
+        $chunk_one,
+        $chunk_two,
+        $stream_length
+    ) {
+        switch ($request->server['request_uri']) {
+            case '/stream':
+                $response->header('content-length', (string) $stream_length);
+                $response->write($chunk_one);
+                $response->write($chunk_two);
+                $response->end();
+                break;
+            case '/head-explicit':
+                $response->header('content-length', '12345');
+                $response->end();
+                break;
+            case '/head-empty':
+                $response->end();
+                break;
+            case '/end-explicit':
+                $response->header('content-length', '0000100');
+                $response->end($explicit_body);
+                break;
+            case '/end-plain':
+                $response->end('hello');
+                break;
+            case '/compress':
+                $response->header('content-length', '999999');
+                $response->end($compressible_body);
+                break;
+            case '/pre-encoded':
+                $response->header('content-encoding', 'gzip');
+                $response->header('content-length', (string) strlen($pre_encoded_gzip));
+                $response->end($pre_encoded_gzip);
+                break;
+            case '/empty-length':
+                $response->header('content-length', '');
+                $response->end('body');
+                break;
+            case '/plain':
+                $response->end('OK');
+                break;
+        }
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
HTTP/2 responses currently discard every application-supplied `Content-Length` and generate a replacement only when the full body is available. This loses known lengths for streamed responses and rewrites HEAD metadata.

This preserves explicit values unless Swoole compresses a complete body. It also respects application-supplied `Content-Encoding` and omits empty length fields.

Tests cover streaming, HEAD, compression, and pre-encoded responses.