### PR TITLE
Add optional file deletion after sendfile

### DIFF
--- a/ext-src/php_swoole_http.h
+++ b/ext-src/php_swoole_http.h
@@ -202,7 +202,7 @@ struct Context {
     // The `private_data_2` pointer is used to save callback function
     void *private_data_2;
     bool (*send)(Context *ctx, const char *data, size_t length);
-    bool (*sendfile)(Context *ctx, zend_string *file, off_t offset, size_t length);
+    bool (*sendfile)(Context *ctx, zend_string *file, off_t offset, size_t length, bool &delete_file);
     bool (*close)(Context *ctx);
     bool (*onBeforeRequest)(Context *ctx);
     void (*onAfterResponse)(Context *ctx);
@@ -225,7 +225,7 @@ struct Context {
     HTTP_API bool set_header(const char *, size_t, const std::string &, bool);
     HTTP_API void end(zend_string *sdata, zval *return_value);
     HTTP_API void write(zend_string *sdata, zval *return_value);
-    HTTP_API bool send_file(zend_string *file, off_t offset, size_t length);
+    HTTP_API bool send_file(zend_string *file, off_t offset, size_t length, bool delete_file);
 
     String *get_write_buffer();
 

--- a/ext-src/stubs/php_swoole_http_response.stub.php
+++ b/ext-src/stubs/php_swoole_http_response.stub.php
@@ -3,7 +3,7 @@ namespace Swoole\Http {
 	class Response {
 		public function write(string $content): bool {}
 		public function end(?string $content = null): bool {}
-		public function sendfile(string $filename, int $offset = 0, int $length = 0): bool {}
+		public function sendfile(string $filename, int $offset = 0, int $length = 0, bool $delete_file = false): bool {}
 		public function redirect(string $location, int $http_code = 302): bool {}
 		public function cookie(\Swoole\Http\Cookie|string $name_or_object , string $value = '', int $expires = 0 , string $path = '/', string $domain  = '', bool $secure = false , bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool {}
 		public function rawcookie(string $name, string $value = '', int $expires = 0 , string $path = '/', string $domain  = '', bool $secure = false , bool $httponly = false, string $samesite = '', string $priority = '', bool $partitioned = false): bool {}

--- a/ext-src/stubs/php_swoole_http_response_arginfo.h
+++ b/ext-src/stubs/php_swoole_http_response_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1a9de3282e3f5ad468a56ef68064dd824b21ad58 */
+ * Stub hash: bc1a8ffe9f7e99f3da7681df73d3334dbcf4fe7a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Http_Response_write, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
@@ -13,6 +13,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Http_Response_sendf
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, delete_file, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Http_Response_redirect, 0, 1, _IS_BOOL, 0)

--- a/ext-src/stubs/php_swoole_server.stub.php
+++ b/ext-src/stubs/php_swoole_server.stub.php
@@ -13,7 +13,7 @@ namespace Swoole {
         public function start(): bool {}
         public function stop(int $workerId = -1): bool {}
         public function send(int|string $fd, string $send_data, int $serverSocket = -1): bool {}
-        public function sendfile(int $conn_fd, string $filename, int $offset = 0, int $length = 0): bool {}
+        public function sendfile(int $conn_fd, string $filename, int $offset = 0, int $length = 0, bool $delete_file = false): bool {}
         public function stats(): array {}
         public function bind(int $fd, int $uid): bool {}
         public function sendto(string $ip, int $port, string $send_data, int $server_socket = -1): bool {}

--- a/ext-src/stubs/php_swoole_server_arginfo.h
+++ b/ext-src/stubs/php_swoole_server_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b6b6e8431c0b97603630fb1428d7a3c86a527db2 */
+ * Stub hash: 68fbb7ba235dff4652b7d59bf274ca9165ff3953 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Server___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 0, "\'0.0.0.0\'")
@@ -63,6 +63,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Server_sendfile, 0,
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, delete_file, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Server_stats, 0, 0, IS_ARRAY, 0)

--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -17,6 +17,7 @@
 #include "php_swoole_http_server.h"
 #include "php_swoole_websocket.h"
 #include "swoole_util.h"
+#include "swoole_coroutine_api.h"
 
 BEGIN_EXTERN_C()
 #include "stubs/php_swoole_http_response_arginfo.h"
@@ -700,9 +701,14 @@ void HttpContext::send_trailer(zval *return_value) {
     }
 }
 
-bool HttpContext::send_file(zend_string *file, off_t offset, size_t length) {
+bool HttpContext::send_file(zend_string *file, off_t offset, size_t length, bool delete_file) {
     if (http2) {
-        return swoole_http2_server_send_file(this, file, offset, length);
+        bool retval = swoole_http2_server_send_file(this, file, offset, length);
+        // The HTTP/2 source is consumed synchronously, so deletion is safe on any result.
+        if (delete_file) {
+            swoole_coroutine_unlink(file->val);
+        }
+        return retval;
     }
 
     zval *zheader =
@@ -723,13 +729,27 @@ bool HttpContext::send_file(zend_string *file, off_t offset, size_t length) {
 
         if (!send(this, http_buffer->str, http_buffer->length)) {
             send_header_ = 0;
+            // Header dispatch failed before any transport took ownership of the file.
+            if (delete_file) {
+                swoole_coroutine_unlink(file->val);
+            }
             return false;
         }
     }
 
-    if (length > 0 && !sendfile(this, file, offset, length)) {
-        close(this);
-        return false;
+    if (length > 0) {
+        // The transport callback consumes the token when it takes ownership; if it declines
+        // without consuming it, the file is still ours to remove.
+        if (!sendfile(this, file, offset, length, delete_file)) {
+            close(this);
+            if (delete_file) {
+                swoole_coroutine_unlink(file->val);
+            }
+            return false;
+        }
+    } else if (delete_file) {
+        // An empty file never reaches the transport callback; delete at the success boundary.
+        swoole_coroutine_unlink(file->val);
     }
 
     end_ = 1;
@@ -950,12 +970,14 @@ static PHP_METHOD(swoole_http_response, sendfile) {
     zend_string *file;
     zend_long offset = 0;
     zend_long length = 0;
+    zend_bool delete_file = 0;
 
-    ZEND_PARSE_PARAMETERS_START(1, 3)
+    ZEND_PARSE_PARAMETERS_START(1, 4)
     Z_PARAM_STR(file)
     Z_PARAM_OPTIONAL
     Z_PARAM_LONG(offset)
     Z_PARAM_LONG(length)
+    Z_PARAM_BOOL(delete_file)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     if (ZSTR_LEN(file) == 0) {
@@ -999,7 +1021,7 @@ static PHP_METHOD(swoole_http_response, sendfile) {
     if (swoole_isset_hook((enum swGlobalHookType) PHP_SWOOLE_HOOK_AFTER_RESPONSE)) {
         swoole_call_hook((enum swGlobalHookType) PHP_SWOOLE_HOOK_AFTER_RESPONSE, ctx);
     }
-    RETURN_BOOL(ctx->send_file(file, offset, length));
+    RETURN_BOOL(ctx->send_file(file, offset, length, delete_file));
 }
 
 static bool inline http_response_create_cookie(HttpCookie *cookie, zval *zobject) {

--- a/ext-src/swoole_http_server.cc
+++ b/ext-src/swoole_http_server.cc
@@ -45,7 +45,7 @@ static SW_THREAD_LOCAL std::unordered_map<SessionId, zend::Variable> server_ips;
 static SW_THREAD_LOCAL std::unordered_map<SessionId, zend::Variable> client_ips;
 
 static bool http_context_send_data(HttpContext *ctx, const char *data, size_t length);
-static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length);
+static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length, bool &delete_file);
 static bool http_context_disconnect(HttpContext *ctx);
 
 static void http_server_process_request(const Server *serv, zend::Callable *cb, HttpContext *ctx) {
@@ -358,9 +358,9 @@ bool http_context_send_data(HttpContext *ctx, const char *data, size_t length) {
     return retval;
 }
 
-static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length) {
+static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length, bool &delete_file) {
     auto *serv = ctx->get_async_server();
-    return serv->sendfile(ctx->fd, file->val, file->len, offset, length);
+    return serv->sendfile(ctx->fd, file->val, file->len, offset, length, delete_file);
 }
 
 static bool http_context_disconnect(HttpContext *ctx) {

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -16,6 +16,7 @@
 
 #include "php_swoole_http_server.h"
 #include "php_swoole_websocket.h"
+#include "swoole_coroutine_api.h"
 
 #include <string>
 
@@ -42,7 +43,7 @@ static zend_class_entry *swoole_http_server_coro_ce;
 static zend_object_handlers swoole_http_server_coro_handlers;
 
 static bool http_context_send_data(HttpContext *ctx, const char *data, size_t length);
-static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length);
+static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length, bool &delete_file);
 static bool http_context_disconnect(HttpContext *ctx);
 
 static void http2_server_onRequest(const std::shared_ptr<Http2Session> &session,
@@ -256,8 +257,14 @@ static bool http_context_send_data(HttpContext *ctx, const char *data, size_t le
     return ctx->get_co_socket()->send_all(data, length) == (ssize_t) length;
 }
 
-static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length) {
-    return ctx->get_co_socket()->sendfile(file->val, offset, length);
+static bool http_context_sendfile(HttpContext *ctx, zend_string *file, off_t offset, size_t length, bool &delete_file) {
+    bool retval = ctx->get_co_socket()->sendfile(file->val, offset, length);
+    // The coroutine socket send is synchronous, so the file can be removed on any result.
+    if (delete_file) {
+        swoole_coroutine_unlink(file->val);
+        delete_file = false;
+    }
+    return retval;
 }
 
 static bool http_context_disconnect(HttpContext *ctx) {

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2961,13 +2961,15 @@ static PHP_METHOD(swoole_server, sendfile) {
     size_t len;
     zend_long offset = 0;
     zend_long length = 0;
+    zend_bool delete_file = false;
 
-    ZEND_PARSE_PARAMETERS_START(2, 4)
+    ZEND_PARSE_PARAMETERS_START(2, 5)
     Z_PARAM_LONG(fd)
     Z_PARAM_STRING(filename, len)
     Z_PARAM_OPTIONAL
     Z_PARAM_LONG(offset)
     Z_PARAM_LONG(length)
+    Z_PARAM_BOOL(delete_file)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     if (serv->is_master()) {
@@ -2983,7 +2985,7 @@ static PHP_METHOD(swoole_server, sendfile) {
         RETURN_FALSE;
     }
 
-    RETURN_BOOL(serv->sendfile(fd, filename, len, offset, length));
+    RETURN_BOOL(serv->sendfile(fd, filename, len, offset, length, delete_file));
 }
 
 static PHP_METHOD(swoole_server, close) {

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -689,6 +689,12 @@ enum ServerEventType {
     SW_SERVER_EVENT_SHUTDOWN_SIGNAL,
 };
 
+// Carried in DataHead::ext_flags of a SW_SERVER_EVENT_SEND_FILE event: the event owns the file
+// and must delete it once the native transfer terminates.
+enum ServerSendfileFlag {
+    SW_SERVER_SENDFILE_DELETE = 1u << 0,
+};
+
 class Server {
   public:
     typedef int (*DispatchFunction)(Server *, Connection *, SendData *);
@@ -1606,7 +1612,7 @@ class Server {
     static int close_connection(Reactor *reactor, network::Socket *_socket);
     static int dispatch_task(const Protocol *proto, network::Socket *_socket, const RecvData *rdata);
 
-    int send_to_connection(const SendData *) const;
+    int send_to_connection(SendData *) const;
     ssize_t send_to_worker_from_worker(const Worker *dst_worker, const void *buf, size_t len, int flags);
     bool has_kernel_nobufs_error(SessionId session_id) const;
 
@@ -1628,6 +1634,8 @@ class Server {
      * It will read the file from disk and send it to the client.
      */
     bool sendfile(SessionId session_id, const char *file, uint32_t l_file, off_t offset, size_t length) const;
+    bool sendfile(
+        SessionId session_id, const char *file, uint32_t l_file, off_t offset, size_t length, bool &delete_file) const;
     bool sendwait(SessionId session_id, const void *data, uint32_t length) const;
     bool close(SessionId session_id, bool reset = false) const;
 

--- a/include/swoole_socket.h
+++ b/include/swoole_socket.h
@@ -72,9 +72,10 @@ struct SendfileRequest {
     int8_t corked;
     off_t begin;
     off_t end;
+    bool delete_file;
 
   public:
-    SendfileRequest(const char *filename, off_t _offset)
+    SendfileRequest(const char *filename, off_t _offset, bool _delete_file)
 #ifdef _WIN32
         : file(filename, _O_RDONLY | _O_BINARY) {
 #else
@@ -83,7 +84,10 @@ struct SendfileRequest {
         begin = _offset;
         end = 0;
         corked = 0;
+        delete_file = _delete_file;
     }
+
+    ~SendfileRequest();
 
     const char *get_filename() const {
         return file.get_path().c_str();
@@ -369,7 +373,7 @@ struct Socket {
     bool set_tcp_nodelay(int nodelay = 1);
     bool check_liveness();
 
-    int sendfile_async(const char *filename, off_t offset, size_t length);
+    int sendfile_async(const char *filename, off_t offset, size_t length, bool delete_file = false);
     int sendfile_sync(const char *filename, off_t offset, size_t length);
     ssize_t sendfile(const File &fp, off_t *offset, size_t length);
 

--- a/src/network/socket.cc
+++ b/src/network/socket.cc
@@ -872,6 +872,14 @@ int Socket::handle_send() {
     return SW_OK;
 }
 
+SendfileRequest::~SendfileRequest() {
+    if (delete_file) {
+        // Close before unlink so the handle is released first, which Windows requires.
+        file.close();
+        ::unlink(file.get_path().c_str());
+    }
+}
+
 static void Socket_sendfile_destructor(BufferChunk *chunk) {
     auto *task = static_cast<SendfileRequest *>(chunk->value.ptr);
     delete task;
@@ -885,8 +893,8 @@ ssize_t Socket::sendfile(const File &fp, off_t *offset, size_t length) {
     }
 }
 
-int Socket::sendfile_async(const char *filename, off_t offset, size_t length) {
-    std::unique_ptr<SendfileRequest> task(new SendfileRequest(filename, offset));
+int Socket::sendfile_async(const char *filename, off_t offset, size_t length, bool delete_file) {
+    std::unique_ptr<SendfileRequest> task(new SendfileRequest(filename, offset, delete_file));
 
     if (!check_sendfile_parameters(&task->file, offset, length, &task->end)) {
         return SW_ERR;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -22,6 +22,7 @@
 #include "swoole_hash.h"
 
 #include "swoole_api.h"
+#include "swoole_coroutine_api.h"
 
 #include <cassert>
 #include <net/if.h>
@@ -1433,10 +1434,20 @@ int Server::schedule_worker(int fd, SendData *data) {
  * [Master] send to client or append to out_buffer
  * @return SW_OK or SW_ERR
  */
-int Server::send_to_connection(const SendData *_send) const {
+int Server::send_to_connection(SendData *_send) const {
     const SessionId session_id = _send->info.fd;
     const char *_send_data = _send->data;
     uint32_t _send_length = _send->info.len;
+
+    // A SEND_FILE event that owns its file is dropped here before reaching sendfile_async(),
+    // so delete the file and clear the token before returning an error.
+    auto drop_owned_sendfile = [](SendData *_send) {
+        if (_send->info.type == SW_SERVER_EVENT_SEND_FILE && (_send->info.ext_flags & SW_SERVER_SENDFILE_DELETE)) {
+            const auto *task = reinterpret_cast<const SendfileTask *>(_send->data);
+            swoole_coroutine_unlink(task->filename);
+            _send->info.ext_flags &= ~SW_SERVER_SENDFILE_DELETE;
+        }
+    };
 
     Connection *conn;
     if (_send->info.type != SW_SERVER_EVENT_CLOSE) {
@@ -1458,6 +1469,7 @@ int Server::send_to_connection(const SendData *_send) const {
                              _send->info.type,
                              session_id);
         }
+        drop_owned_sendfile(_send);
         return SW_ERR;
     }
 
@@ -1476,6 +1488,7 @@ int Server::send_to_connection(const SendData *_send) const {
         } else {
             swoole_error_log(SW_LOG_WARNING, SW_ERROR_OUTPUT_BUFFER_OVERFLOW, "socket#%d output buffer overflow", fd);
         }
+        drop_owned_sendfile(_send);
         return SW_ERR;
     }
 
@@ -1559,7 +1572,11 @@ int Server::send_to_connection(const SendData *_send) const {
         conn->close_queued = 1;
     } else if (_send->info.type == SW_SERVER_EVENT_SEND_FILE) {
         auto *task = (SendfileTask *) _send_data;
-        if (conn->socket->sendfile_async(task->filename, task->offset, task->length) < 0) {
+        // Hand the delete token to the request that now owns the transfer, and clear it from
+        // the event so a synchronous base/thread caller does not delete the file again.
+        const bool delete_file = _send->info.ext_flags & SW_SERVER_SENDFILE_DELETE;
+        _send->info.ext_flags &= ~SW_SERVER_SENDFILE_DELETE;
+        if (conn->socket->sendfile_async(task->filename, task->offset, task->length, delete_file) < 0) {
             return false;
         }
     } else {
@@ -1625,6 +1642,12 @@ bool Server::notify(Connection *conn, ServerEventType event) const {
  * @process Worker
  */
 bool Server::sendfile(SessionId session_id, const char *file, uint32_t l_file, off_t offset, size_t length) const {
+    bool delete_file = false;
+    return sendfile(session_id, file, l_file, offset, length, delete_file);
+}
+
+bool Server::sendfile(
+    SessionId session_id, const char *file, uint32_t l_file, off_t offset, size_t length, bool &delete_file) const {
     if (sw_unlikely(session_id <= 0)) {
         swoole_error_log(SW_LOG_WARNING, SW_ERROR_SESSION_INVALID_ID, "invalid fd[%ld]", session_id);
         return false;
@@ -1677,9 +1700,20 @@ bool Server::sendfile(SessionId session_id, const char *file, uint32_t l_file, o
     send_data.info.fd = session_id;
     send_data.info.type = SW_SERVER_EVENT_SEND_FILE;
     send_data.info.len = sizeof(SendfileTask) + l_file + 1;
+    // Validation has passed, so ownership of the file moves into the SEND_FILE event.
+    send_data.info.ext_flags = delete_file ? SW_SERVER_SENDFILE_DELETE : 0;
     send_data.data = _buffer;
+    delete_file = false;
 
-    return factory_->finish(&send_data);
+    const bool accepted = factory_->finish(&send_data);
+
+    // The handoff failed before any layer consumed the event token, so clean up here. A
+    // synchronous base/thread path that already handled cleanup has cleared the flag.
+    if (!accepted && (send_data.info.ext_flags & SW_SERVER_SENDFILE_DELETE)) {
+        swoole_coroutine_unlink(req->filename);
+    }
+
+    return accepted;
 }
 
 /**

--- a/src/server/static_handler.cc
+++ b/src/server/static_handler.cc
@@ -547,7 +547,8 @@ bool Server::select_static_handler(const http_server::Request *request, const Co
     }
 
     char header_buffer[1024];
-    SendData response;
+    // Value-initialize so ext_flags is zero: static SEND_FILE events never opt into deletion.
+    SendData response{};
     response.info.fd = conn->session_id;
     response.info.type = SW_SERVER_EVENT_SEND_DATA;
 

--- a/tests/swoole_http2_server/sendfile_delete.phpt
+++ b/tests/swoole_http2_server/sendfile_delete.phpt
@@ -1,0 +1,75 @@
+--TEST--
+swoole_http2_server: sendfile delete_file removes the file after the synchronous send
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http2\Client;
+use Swoole\Coroutine\System;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Http2\Request as Http2Request;
+
+$content = get_safe_random(256 * 1024);
+
+foreach ([SWOOLE_BASE, SWOOLE_PROCESS] as $mode) {
+    $path = tempnam('/tmp', 'swoole_http2_sendfile_delete_');
+    file_put_contents($path, $content);
+
+    $pm             = new ProcessManager();
+    $pm->parentFunc = function () use ($pm, $path, $content) {
+        Coroutine\run(function () use ($pm, $path, $content) {
+            $client = new Client('127.0.0.1', $pm->getFreePort(), false);
+            $client->set(['timeout' => 10]);
+            Assert::true($client->connect());
+
+            $request       = new Http2Request();
+            $request->path = '/download';
+            Assert::greaterThan($client->send($request), 0);
+            $response = $client->recv();
+            Assert::same($response->statusCode, 200);
+            Assert::same(md5($response->data), md5($content));
+
+            // The HTTP/2 source is consumed synchronously before the response returns, so
+            // the file is deleted; poll within a deadline to absorb scheduling.
+            for ($i = 0; $i < 200; $i++) {
+                clearstatcache(true, $path);
+                if (!is_file($path)) {
+                    break;
+                }
+                System::sleep(0.025);
+            }
+            clearstatcache(true, $path);
+            Assert::false(is_file($path));
+
+            $client->close();
+        });
+        $pm->kill();
+        @unlink($path);
+    };
+    $pm->childFunc = function () use ($pm, $mode, $path) {
+        $http = new Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $http->set([
+            'worker_num'          => 1,
+            'log_file'            => '/dev/null',
+            'open_http2_protocol' => true,
+        ]);
+        $http->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $http->on('request', function (Request $request, Response $response) use ($path) {
+            $response->sendfile($path, 0, 0, true);
+        });
+        $http->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server/send_empty_file.phpt
+++ b/tests/swoole_http_server/send_empty_file.phpt
@@ -6,27 +6,55 @@ swoole_http_server: send empty file
 <?php
 require __DIR__ . '/../include/bootstrap.php';
 
-const TMP_FILE = '/tmp/sendfile.txt';
+use Swoole\Coroutine\System;
 
-$pm = new ProcessManager;
-$pm->parentFunc = function ($pid) use ($pm) {
-    Co\run(function () use ($pm) {
-        file_put_contents(TMP_FILE, '');
-        $recv_file = httpGetBody("http://127.0.0.1:{$pm->getFreePort()}");
-        unlink(TMP_FILE);
-        Assert::same($recv_file, '');
+$keep_path   = tempnam('/tmp', 'swoole_empty_keep_');
+$delete_path = tempnam('/tmp', 'swoole_empty_delete_');
+file_put_contents($keep_path, '');
+file_put_contents($delete_path, '');
+
+$pm             = new ProcessManager();
+$pm->parentFunc = function () use ($pm, $keep_path, $delete_path) {
+    Co\run(function () use ($pm, $keep_path, $delete_path) {
+        // An empty file sends an empty body; the default keeps the file.
+        Assert::same(httpGetBody("http://127.0.0.1:{$pm->getFreePort()}/keep"), '');
+        clearstatcache(true, $keep_path);
+        Assert::true(is_file($keep_path));
+
+        // delete_file removes the empty file at the terminal response boundary, where the
+        // transport callback is never invoked.
+        Assert::same(httpGetBody("http://127.0.0.1:{$pm->getFreePort()}/delete"), '');
+        $gone = false;
+        for ($i = 0; $i < 200; $i++) {
+            clearstatcache(true, $delete_path);
+            if (!is_file($delete_path)) {
+                $gone = true;
+                break;
+            }
+            System::sleep(0.025);
+        }
+        Assert::true($gone);
     });
     echo "DONE\n";
     $pm->kill();
+    @unlink($keep_path);
+    @unlink($delete_path);
 };
-$pm->childFunc = function () use ($pm) {
+$pm->childFunc = function () use ($pm, $keep_path, $delete_path) {
     $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
-    $http->set(['worker_num' => 1]);
+    $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
     $http->on('workerStart', function () use ($pm) {
         $pm->wakeup();
     });
-    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
-        $response->sendfile(TMP_FILE);
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use (
+        $keep_path,
+        $delete_path
+    ) {
+        if ($request->server['request_uri'] === '/delete') {
+            $response->sendfile($delete_path, 0, 0, true);
+        } else {
+            $response->sendfile($keep_path);
+        }
     });
     $http->start();
 };

--- a/tests/swoole_http_server/sendfile_delete.phpt
+++ b/tests/swoole_http_server/sendfile_delete.phpt
@@ -1,0 +1,109 @@
+--TEST--
+swoole_http_server: sendfile delete_file removes the file at native transfer completion
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine\Client;
+use Swoole\Coroutine\System;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Runtime;
+
+// Large enough that an 8 MiB transfer cannot complete within one 128 KiB client
+// buffer, so the opted-in file is still present while the reactor owns the transfer.
+const CONTENT_SIZE = 8 * 1024 * 1024;
+
+$wait_gone = function (string $path): bool {
+    for ($i = 0; $i < 200; $i++) {
+        clearstatcache(true, $path);
+        if (!is_file($path)) {
+            return true;
+        }
+        System::sleep(0.025);
+    }
+    return false;
+};
+
+foreach ([SWOOLE_BASE, SWOOLE_PROCESS] as $mode) {
+    $delete_path = tempnam('/tmp', 'swoole_sendfile_delete_');
+    $keep_path   = tempnam('/tmp', 'swoole_sendfile_keep_');
+    $content     = get_safe_random(CONTENT_SIZE);
+    file_put_contents($delete_path, $content);
+    file_put_contents($keep_path, $content);
+    $submitted = new Atomic(0);
+
+    $pm             = new ProcessManager();
+    $pm->parentFunc = function () use ($pm, $delete_path, $keep_path, $content, $submitted, $wait_gone) {
+        Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+        Co\run(function () use ($pm, $delete_path, $keep_path, $content, $submitted, $wait_gone) {
+            $client = new Client(SWOOLE_SOCK_TCP);
+            $client->set(['socket_buffer_size' => 128 * 1024]);
+            Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 5));
+            $client->send("GET /delete HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+
+            // Wait until the worker has returned from Response::sendfile().
+            $deadline = microtime(true) + 5;
+            while ($submitted->get() === 0 && microtime(true) < $deadline) {
+                System::sleep(0.01);
+            }
+            Assert::same($submitted->get(), 1);
+
+            // The first chunk has arrived but the transfer is far from complete, so the
+            // opted-in file must still exist: deletion is tied to native completion, not
+            // to the worker call returning.
+            $response = $client->recv();
+            Assert::notEmpty($response);
+            clearstatcache(true, $delete_path);
+            Assert::true(is_file($delete_path));
+
+            while (true) {
+                $chunk = $client->recv();
+                if ($chunk === '' || $chunk === false) {
+                    break;
+                }
+                $response .= $chunk;
+            }
+            $client->close();
+
+            $body = substr($response, strpos($response, "\r\n\r\n") + 4);
+            Assert::same($body, $content);
+            Assert::true($wait_gone($delete_path));
+
+            // The default keeps the file after a successful transfer.
+            $keep_body = file_get_contents("http://127.0.0.1:{$pm->getFreePort()}/keep");
+            Assert::same($keep_body, $content);
+            clearstatcache(true, $keep_path);
+            Assert::true(is_file($keep_path));
+        });
+        $pm->kill();
+        @unlink($delete_path);
+        @unlink($keep_path);
+    };
+    $pm->childFunc = function () use ($pm, $mode, $delete_path, $keep_path, $submitted) {
+        $http = new Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+        $http->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $http->on('request', function (Request $request, Response $response) use ($delete_path, $keep_path, $submitted) {
+            if ($request->server['request_uri'] === '/delete') {
+                $response->sendfile($delete_path, 0, 0, true);
+                $submitted->set(1);
+            } else {
+                $response->sendfile($keep_path);
+            }
+        });
+        $http->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server/sendfile_delete_disconnect.phpt
+++ b/tests/swoole_http_server/sendfile_delete_disconnect.phpt
@@ -1,0 +1,86 @@
+--TEST--
+swoole_http_server: sendfile delete_file removes the file when the client disconnects mid-transfer
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Coroutine\Client;
+use Swoole\Coroutine\System;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+use Swoole\Runtime;
+
+const CONTENT_SIZE = 8 * 1024 * 1024;
+
+$wait_gone = function (string $path): bool {
+    for ($i = 0; $i < 200; $i++) {
+        clearstatcache(true, $path);
+        if (!is_file($path)) {
+            return true;
+        }
+        System::sleep(0.025);
+    }
+    return false;
+};
+
+foreach ([SWOOLE_BASE, SWOOLE_PROCESS] as $mode) {
+    $delete_path = tempnam('/tmp', 'swoole_sendfile_disconnect_');
+    file_put_contents($delete_path, get_safe_random(CONTENT_SIZE));
+    $submitted = new Atomic(0);
+
+    $pm             = new ProcessManager();
+    $pm->parentFunc = function () use ($pm, $delete_path, $submitted, $wait_gone) {
+        Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+        Co\run(function () use ($pm, $delete_path, $submitted, $wait_gone) {
+            $client = new Client(SWOOLE_SOCK_TCP);
+            $client->set(['socket_buffer_size' => 128 * 1024]);
+            Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 5));
+            $client->send("GET /delete HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+
+            $deadline = microtime(true) + 5;
+            while ($submitted->get() === 0 && microtime(true) < $deadline) {
+                System::sleep(0.01);
+            }
+            Assert::same($submitted->get(), 1);
+
+            // Take only the first chunk, then abandon the connection mid-transfer.
+            Assert::notEmpty($client->recv());
+            $client->close();
+
+            // The connection/output buffer is destroyed with an incomplete transfer, and
+            // the opted-in file is still removed.
+            Assert::true($wait_gone($delete_path));
+
+            // The server stays available for a fresh request.
+            Assert::same(file_get_contents("http://127.0.0.1:{$pm->getFreePort()}/health"), 'OK');
+        });
+        $pm->kill();
+        @unlink($delete_path);
+    };
+    $pm->childFunc = function () use ($pm, $mode, $delete_path, $submitted) {
+        $http = new Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+        $http->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $http->on('request', function (Request $request, Response $response) use ($delete_path, $submitted) {
+            if ($request->server['request_uri'] === '/health') {
+                $response->end('OK');
+                return;
+            }
+            $response->sendfile($delete_path, 0, 0, true);
+            $submitted->set(1);
+        });
+        $http->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server/sendfile_delete_validation.phpt
+++ b/tests/swoole_http_server/sendfile_delete_validation.phpt
@@ -1,0 +1,45 @@
+--TEST--
+swoole_http_server: sendfile delete_file keeps the file when validation fails before ownership
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+
+$file = tempnam('/tmp', 'swoole_sendfile_validation_');
+file_put_contents($file, 'hello swoole');
+$dir = sys_get_temp_dir();
+
+$pm             = new ProcessManager();
+$pm->parentFunc = function () use ($pm, $file) {
+    Assert::same(file_get_contents("http://127.0.0.1:{$pm->getFreePort()}"), 'DONE');
+    // Validation rejected the calls before ownership moved to Swoole, so the file is intact.
+    clearstatcache(true, $file);
+    Assert::true(is_file($file));
+    echo "DONE\n";
+    $pm->kill();
+    @unlink($file);
+};
+$pm->childFunc = function () use ($pm, $file, $dir) {
+    $http = new Server('127.0.0.1', $pm->getFreePort(), SERVER_MODE_RANDOM);
+    $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Request $request, Response $response) use ($file, $dir) {
+        Assert::false(@$response->sendfile($file, -1, 0, true));
+        Assert::false(@$response->sendfile($file, 0, -1, true));
+        Assert::false(@$response->sendfile($dir, 0, 0, true));
+        $response->end('DONE');
+    });
+    $http->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server_coro/sendfile_delete.phpt
+++ b/tests/swoole_http_server_coro/sendfile_delete.phpt
@@ -1,0 +1,54 @@
+--TEST--
+swoole_http_server_coro: sendfile delete_file removes the file after the synchronous send
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$path    = tempnam('/tmp', 'swoole_coro_sendfile_delete_');
+$content = get_safe_random(256 * 1024);
+file_put_contents($path, $content);
+
+$pm             = new ProcessManager();
+$pm->parentFunc = function () use ($pm, $path, $content) {
+    $body = file_get_contents("http://127.0.0.1:{$pm->getFreePort()}/download");
+    Assert::same(md5($body), md5($content));
+
+    // The coroutine socket send is synchronous, so the file is deleted by the time the
+    // body has been received; poll within a deadline to absorb scheduling.
+    for ($i = 0; $i < 200; $i++) {
+        clearstatcache(true, $path);
+        if (!is_file($path)) {
+            break;
+        }
+        usleep(25 * 1000);
+    }
+    clearstatcache(true, $path);
+    Assert::false(is_file($path));
+
+    file_get_contents("http://127.0.0.1:{$pm->getFreePort()}/shutdown");
+    echo "DONE\n";
+    @unlink($path);
+};
+$pm->childFunc = function () use ($pm, $path) {
+    go(function () use ($pm, $path) {
+        $server = new Co\Http\Server('127.0.0.1', $pm->getFreePort(), false);
+        $server->handle('/download', function ($request, $response) use ($path) {
+            $response->header('Content-Type', 'application/octet-stream');
+            $response->sendfile($path, 0, 0, true);
+        });
+        $server->handle('/shutdown', function ($request, $response) use ($server) {
+            $response->end();
+            $server->shutdown();
+        });
+        $pm->wakeup();
+        $server->start();
+    });
+    Swoole\Event::wait();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_server/sendfile_delete.phpt
+++ b/tests/swoole_server/sendfile_delete.phpt
@@ -1,0 +1,110 @@
+--TEST--
+swoole_server: Server::sendfile delete_file ownership boundaries
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_in_valgrind();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Client;
+use Swoole\Coroutine\System;
+use Swoole\Runtime;
+use Swoole\Server;
+
+const CONTENT_SIZE = 256 * 1024;
+
+$wait_gone = function (string $path): bool {
+    for ($i = 0; $i < 200; $i++) {
+        clearstatcache(true, $path);
+        if (!is_file($path)) {
+            return true;
+        }
+        System::sleep(0.025);
+    }
+    return false;
+};
+
+$transfer_path = tempnam('/tmp', 'swoole_srv_sendfile_transfer_');
+$negative_path = tempnam('/tmp', 'swoole_srv_sendfile_negative_');
+$stale_path    = tempnam('/tmp', 'swoole_srv_sendfile_stale_');
+$content       = get_safe_random(CONTENT_SIZE);
+file_put_contents($transfer_path, $content);
+file_put_contents($negative_path, 'keep me');
+file_put_contents($stale_path, 'delete me');
+
+$pm             = new ProcessManager();
+$pm->parentFunc = function () use ($pm, $transfer_path, $negative_path, $stale_path, $content, $wait_gone) {
+    Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+    Co\run(function () use ($pm, $transfer_path, $negative_path, $stale_path, $content, $wait_gone) {
+        $client = new Client(SWOOLE_SOCK_TCP);
+        Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 5));
+
+        // A successful opted-in transfer sends the exact body and deletes at completion.
+        $client->send("transfer\n");
+        $received = '';
+        while (strlen($received) < CONTENT_SIZE) {
+            $chunk = $client->recv();
+            if ($chunk === '' || $chunk === false) {
+                break;
+            }
+            $received .= $chunk;
+        }
+        Assert::same($received, $content);
+        Assert::true($wait_gone($transfer_path));
+
+        // A negative session id is rejected before ownership, so the file is preserved.
+        $client->send("negative\n");
+        Assert::same(rtrim($client->recv()), 'negative-done');
+        clearstatcache(true, $negative_path);
+        Assert::true(is_file($negative_path));
+
+        // A positive session id with no live connection passes pre-factory validation, so
+        // ownership has moved and the later live-session rejection still deletes the file.
+        $client->send("stale\n");
+        Assert::same(rtrim($client->recv()), 'stale-done');
+        Assert::true($wait_gone($stale_path));
+
+        $client->close();
+    });
+    $pm->kill();
+    @unlink($transfer_path);
+    @unlink($negative_path);
+    @unlink($stale_path);
+};
+$pm->childFunc = function () use ($pm, $transfer_path, $negative_path, $stale_path) {
+    $serv = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $serv->set([
+        'worker_num'     => 1,
+        'log_file'       => '/dev/null',
+        'open_eof_check' => true,
+        'package_eof'    => "\n",
+    ]);
+    $serv->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $serv->on('receive', function (Server $serv, $fd, $rid, $data) use ($transfer_path, $negative_path, $stale_path) {
+        switch (rtrim($data)) {
+            case 'transfer':
+                $serv->sendfile($fd, $transfer_path, 0, 0, true);
+                break;
+            case 'negative':
+                Assert::false(@$serv->sendfile(-1, $negative_path, 0, 0, true));
+                $serv->send($fd, "negative-done\n");
+                break;
+            case 'stale':
+                Assert::false($serv->sendfile($fd + 100000, $stale_path, 0, 0, true));
+                $serv->send($fd, "stale-done\n");
+                break;
+        }
+    });
+    $serv->start();
+};
+$pm->childFirst();
+$pm->run();
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_thread/server/sendfile_delete.phpt
+++ b/tests/swoole_thread/server/sendfile_delete.phpt
@@ -1,0 +1,65 @@
+--TEST--
+swoole_thread/server: sendfile delete_file removes the file after transfer
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Thread;
+
+$port = get_constant_port(__FILE__);
+// A deterministic path and body: SWOOLE_THREAD re-runs this script in every thread, so
+// each thread writes the same content to the same path before the server starts serving.
+$path    = sys_get_temp_dir() . '/swoole_thread_sendfile_delete_' . $port . '.bin';
+$content = str_repeat('swoole thread sendfile delete payload ', 4096);
+file_put_contents($path, $content);
+
+$serv = new Swoole\Http\Server('127.0.0.1', $port, SWOOLE_THREAD);
+$serv->set([
+    'worker_num'     => 1,
+    'log_level'      => SWOOLE_LOG_ERROR,
+    'init_arguments' => function () {
+        global $atomic;
+        $atomic = new Thread\Atomic(0);
+        return [$atomic];
+    },
+]);
+$serv->on('WorkerStart', function (Swoole\Server $serv, $workerId) {
+    [$atomic] = Thread::getArguments();
+    $atomic->add();
+});
+$serv->on('Request', function ($request, $response) use ($path) {
+    $response->sendfile($path, 0, 0, true);
+});
+$serv->on('shutdown', function () {
+    echo "shutdown\n";
+});
+$serv->addProcess(new Swoole\Process(function ($process) use ($serv, $path, $content, $port) {
+    [$atomic] = Thread::getArguments();
+    while ($atomic->get() < 1) {
+        usleep(10 * 1000);
+    }
+    $body = file_get_contents('http://127.0.0.1:' . $port . '/download');
+    Assert::same(md5($body), md5($content));
+    for ($i = 0; $i < 200; $i++) {
+        clearstatcache(true, $path);
+        if (!is_file($path)) {
+            break;
+        }
+        usleep(25 * 1000);
+    }
+    clearstatcache(true, $path);
+    Assert::false(is_file($path));
+    echo "done\n";
+    $serv->shutdown();
+}));
+$serv->start();
+@unlink($path);
+?>
+--EXPECT--
+done
+shutdown


### PR DESCRIPTION
Frameworks often serve generated or temporary files that should be deleted after the response finishes using them. In `SWOOLE_PROCESS` mode, `sendfile()` queues a pathname and returns before the reactor opens it. Swoole provides no completion signal, so a framework cannot know when it can safely remove the file. It must stream the file through PHP or delay cleanup. In `SWOOLE_BASE` mode the file is opened before `sendfile()` returns for the connection handled by that worker; the same gap exists when a send is forwarded to another worker or thread.

This adds an optional `delete_file` argument to `Response::sendfile()` and `Server::sendfile()`. When enabled, Swoole takes responsibility for deletion and removes the source file after the native transfer finishes or terminates, including send errors and client disconnects. `sendfile()` can still return `false` after that responsibility has moved to Swoole, so a `false` return does not mean the file still exists. Existing behavior remains unchanged by default.

This does not prevent application code from independently deleting or replacing the path. It gives callers that request cleanup a safe way to retain native `sendfile()`.