### PR TITLE
Fix Redis server request cleanup on rejected commands, Fix GH-6092

### DIFF
--- a/ext-src/swoole_redis_server.cc
+++ b/ext-src/swoole_redis_server.cc
@@ -102,6 +102,10 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
 
     zval zparams{};
     array_init(&zparams);
+    ON_SCOPE_EXIT {
+        zval_ptr_dtor(&zdata);
+        zval_ptr_dtor(&zparams);
+    };
 
     int state = Redis::STATE_RECEIVE_TOTAL_LINE;
     int add_param = 0;
@@ -175,6 +179,7 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
     auto fci_cache = i->second;
     zval args[2];
     zval retval;
+    ZVAL_UNDEF(&retval);
 
     ZVAL_LONG(&args[0], fd);
     args[1] = zparams;
@@ -190,9 +195,9 @@ int php_swoole_redis_server_onReceive(Server *serv, RecvData *req) {
     if (Z_TYPE_P(&retval) == IS_STRING) {
         serv->send(fd, Z_STRVAL_P(&retval), Z_STRLEN_P(&retval));
     }
-    zval_ptr_dtor(&retval);
-    zval_ptr_dtor(&zdata);
-    zval_ptr_dtor(&zparams);
+    if (!Z_ISUNDEF(retval)) {
+        zval_ptr_dtor(&retval);
+    }
 
     return SW_OK;
 }

--- a/tests/swoole_redis_server/unknown_command_memory.phpt
+++ b/tests/swoole_redis_server/unknown_command_memory.phpt
@@ -1,0 +1,95 @@
+--TEST--
+swoole_redis_server: rejected commands do not leak request memory
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Redis\Server;
+
+const REQUEST_COUNT = 256;
+const PAYLOAD_SIZE = 8192;
+const MAX_MEMORY_GROWTH = 1024 * 1024;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm): void {
+    $socket = stream_socket_client(
+        'tcp://127.0.0.1:' . $pm->getFreePort(),
+        $errorCode,
+        $errorMessage,
+        1
+    );
+    Assert::assert(is_resource($socket));
+    stream_set_timeout($socket, 1);
+
+    $memoryRequest = "*1\r\n$6\r\nMEMORY\r\n";
+    $payload = str_repeat('A', PAYLOAD_SIZE);
+    $unknownRequest = "*2\r\n$7\r\nUNKNOWN\r\n$" . strlen($payload) . "\r\n{$payload}\r\n";
+    $longCommand = str_repeat('X', 64);
+    $longCommandRequest =
+        "*2\r\n$" . strlen($longCommand) . "\r\n{$longCommand}\r\n" .
+        "$" . strlen($payload) . "\r\n{$payload}\r\n";
+
+    fwrite($socket, $memoryRequest);
+    $before = (int) substr(fgets($socket), 1);
+
+    for ($i = 0; $i < REQUEST_COUNT; $i++) {
+        Assert::same(fwrite($socket, $unknownRequest), strlen($unknownRequest));
+        Assert::string(fgets($socket));
+    }
+
+    fwrite($socket, $memoryRequest);
+    $after = (int) substr(fgets($socket), 1);
+
+    Assert::lessThan($after - $before, MAX_MEMORY_GROWTH);
+
+    for ($i = 0; $i < REQUEST_COUNT; $i++) {
+        $commandSocket = stream_socket_client(
+            'tcp://127.0.0.1:' . $pm->getFreePort(),
+            $errorCode,
+            $errorMessage,
+            1
+        );
+        Assert::assert(is_resource($commandSocket));
+        stream_set_timeout($commandSocket, 1);
+        Assert::same(fwrite($commandSocket, $longCommandRequest), strlen($longCommandRequest));
+        Assert::same(stream_get_contents($commandSocket), '');
+        fclose($commandSocket);
+    }
+
+    fwrite($socket, $memoryRequest);
+    $afterLongCommands = (int) substr(fgets($socket), 1);
+    Assert::lessThan($afterLongCommands - $after, MAX_MEMORY_GROWTH);
+
+    fclose($socket);
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm): void {
+    set_error_handler(
+        static fn(int $severity, string $message): bool =>
+            str_contains($message, 'command [XXXXXXXX...](length=64) is too long'),
+        E_WARNING
+    );
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'enable_coroutine' => false,
+        'log_file' => '/dev/null',
+        'worker_num' => 1,
+    ]);
+    $server->setHandler('MEMORY', static function (): string {
+        gc_collect_cycles();
+        gc_mem_caches();
+        return Server::format(Server::INT, memory_get_usage());
+    });
+    $server->on('WorkerStart', function () use ($pm): void {
+        $pm->wakeup();
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

- release Redis request data and parameters with `ON_SCOPE_EXIT`
- cover both unknown-command and oversized-command early returns
- safely handle an undefined callback return value
- add a PHPT that verifies rejected requests do not retain memory when coroutines are disabled

## Review of #6092

The fixed `SW_SESSION_LIST_SIZE` mapping remains unchanged. Its pages are populated lazily as cumulative session IDs advance, so the shared-memory RSS/PSS can grow to a bounded high-water mark of roughly 16 MiB even after connections close. This is not an unbounded connection leak.

During the source review, two real Redis-only leaks were found in rejected-command paths: `zdata` and `zparams` were not destroyed before returning for unknown or oversized commands. The PHPT reproduces both paths.

## Tests

- PHP 8.4 debug/ZTS build
- `tests/run-tests tests/swoole_redis_server`: 7/7 passed

Refs #6092