### PR TITLE
Add atomic row operations to Swoole Table

### DIFF
--- a/core-tests/src/memory/table.cpp
+++ b/core-tests/src/memory/table.cpp
@@ -131,6 +131,40 @@ class table_t {
     }
 };
 
+static TableValue table_int(Table *table, const char *column, long value) {
+    return TableValue(table->get_column(column), &value, sizeof(value));
+}
+
+static TableValue table_float(Table *table, const char *column, double value) {
+    return TableValue(table->get_column(column), &value, sizeof(value));
+}
+
+static TableValue table_string(Table *table, const char *column, const std::string &value) {
+    return TableValue(table->get_column(column), value.data(), value.size());
+}
+
+static TableValues table_row(Table *table, const row_t &value) {
+    return {
+        table_int(table, "id", value.id),
+        table_string(table, "name", value.name),
+        table_float(table, "score", value.score),
+    };
+}
+
+static row_t table_snapshot(Table *table, const std::string &data) {
+    row_t value;
+    const auto column_id = table->get_column("id");
+    const auto column_name = table->get_column("name");
+    const auto column_score = table->get_column("score");
+
+    memcpy(&value.id, data.data() + column_id->index, sizeof(value.id));
+    memcpy(&value.score, data.data() + column_score->index, sizeof(value.score));
+    TableStringLength length;
+    memcpy(&length, data.data() + column_name->index, sizeof(length));
+    value.name.assign(data.data() + column_name->index + sizeof(length), length);
+    return value;
+}
+
 TEST(table, create) {
     table_t table(1024);
     auto ptr = table.ptr();
@@ -160,6 +194,178 @@ TEST(table, create) {
 
     // Test with a string that is longer than the column size
     ASSERT_TRUE(table.set("golang", {"golang " TEST_JPG_MD5SUM TEST_JPG_MD5SUM, 3, 4.888}));
+}
+
+TEST(table, conditional_writes) {
+    table_t table(128);
+    auto ptr = table.ptr();
+
+    ASSERT_TRUE(ptr->add("empty", 5, {}));
+    row_t empty = table.get("empty");
+    ASSERT_EQ(empty.id, 0);
+    ASSERT_EQ(empty.name, "");
+    ASSERT_EQ(empty.score, 0);
+    ASSERT_EQ(ptr->insert_count, 1);
+
+    auto php = table_row(ptr, {"php", 1, 1.25});
+    ASSERT_TRUE(ptr->add("php", 3, php));
+    ASSERT_FALSE(ptr->add("php", 3, table_row(ptr, {"changed", 2, 2.5})));
+    ASSERT_EQ(ptr->insert_count, 2);
+    ASSERT_EQ(ptr->update_count, 0);
+    ASSERT_EQ(table.get("php").name, "php");
+
+    ASSERT_FALSE(ptr->update("missing", 7, php));
+    ASSERT_TRUE(ptr->update("php", 3, {}));
+    ASSERT_TRUE(ptr->update("php", 3, {table_string(ptr, "name", "updated")}));
+    ASSERT_EQ(ptr->update_count, 2);
+    ASSERT_EQ(table.get("php").name, "updated");
+
+    TableValues expected = {
+        table_int(ptr, "id", 1),
+        table_string(ptr, "name", "updated"),
+        table_float(ptr, "score", 1.25),
+    };
+    ASSERT_FALSE(ptr->cmpset("missing", 7, expected, {}));
+    ASSERT_FALSE(ptr->cmpset("php", 3, {table_int(ptr, "id", 2)}, {}));
+    ASSERT_FALSE(
+        ptr->cmpset("php",
+                    3,
+                    {table_int(ptr, "id", 2), table_string(ptr, "name", "updated"), table_float(ptr, "score", 1.25)},
+                    {}));
+    ASSERT_FALSE(ptr->cmpset(
+        "php", 3, {table_int(ptr, "id", 1), table_string(ptr, "name", "wrong"), table_float(ptr, "score", 1.25)}, {}));
+    ASSERT_FALSE(ptr->cmpset(
+        "php", 3, {table_int(ptr, "id", 1), table_string(ptr, "name", "updated"), table_float(ptr, "score", 2.5)}, {}));
+    ASSERT_TRUE(ptr->cmpset("php", 3, expected, {table_int(ptr, "id", 2)}));
+    ASSERT_EQ(ptr->update_count, 3);
+    ASSERT_EQ(table.get("php").id, 2);
+}
+
+TEST(table, exact_comparisons) {
+    table_t table(128);
+    auto ptr = table.ptr();
+
+    const std::string binary("a\0b", 3);
+    ASSERT_TRUE(ptr->add("binary", 6, {table_string(ptr, "name", binary)}));
+    ASSERT_TRUE(ptr->cmpset("binary", 6, {table_string(ptr, "name", binary)}, {}));
+    ASSERT_FALSE(ptr->cmpset("binary", 6, {table_string(ptr, "name", std::string("a\0c", 3))}, {}));
+
+    ASSERT_TRUE(ptr->add("capacity", 8, {table_string(ptr, "name", std::string(32, 'a'))}));
+    ASSERT_FALSE(ptr->cmpset("capacity", 8, {table_string(ptr, "name", std::string(33, 'a'))}, {}));
+
+    double positive_zero = 0.0;
+    uint64_t negative_zero_bits = 1ULL << 63;
+    double negative_zero;
+    memcpy(&negative_zero, &negative_zero_bits, sizeof(negative_zero));
+    ASSERT_TRUE(ptr->add("zero", 4, {table_float(ptr, "score", positive_zero)}));
+    ASSERT_FALSE(ptr->cmpset("zero", 4, {table_float(ptr, "score", negative_zero)}, {}));
+    ASSERT_TRUE(ptr->cmpset("zero", 4, {table_float(ptr, "score", positive_zero)}, {}));
+
+    uint64_t nan_bits = 0x7ff8000000000001ULL;
+    uint64_t other_nan_bits = 0x7ff8000000000002ULL;
+    double nan;
+    double other_nan;
+    memcpy(&nan, &nan_bits, sizeof(nan));
+    memcpy(&other_nan, &other_nan_bits, sizeof(other_nan));
+    ASSERT_TRUE(ptr->add("nan", 3, {table_float(ptr, "score", nan)}));
+    ASSERT_TRUE(ptr->cmpset("nan", 3, {table_float(ptr, "score", nan)}, {}));
+    ASSERT_FALSE(ptr->cmpset("nan", 3, {table_float(ptr, "score", other_nan)}, {}));
+}
+
+TEST(table, conditional_deletes_and_snapshots) {
+    table_t table(128);
+    auto ptr = table.ptr();
+
+    ASSERT_TRUE(ptr->add("php", 3, table_row(ptr, {std::string("p\0hp", 4), 42, 3.5})));
+    ASSERT_FALSE(ptr->cmpdel("php", 3, {table_int(ptr, "id", 41)}));
+    ASSERT_TRUE(table.exists("php"));
+
+    std::string data;
+    ASSERT_TRUE(ptr->getdel("php", 3, nullptr, &data));
+    row_t snapshot = table_snapshot(ptr, data);
+    ASSERT_EQ(snapshot.id, 42);
+    ASSERT_EQ(snapshot.name, std::string("p\0hp", 4));
+    ASSERT_EQ(snapshot.score, 3.5);
+    ASSERT_FALSE(table.exists("php"));
+
+    ASSERT_TRUE(ptr->add("field", 5, table_row(ptr, {"field", 99, 9.5})));
+    ASSERT_TRUE(ptr->getdel("field", 5, ptr->get_column("name"), &data));
+    TableStringLength length;
+    memcpy(&length, data.data(), sizeof(length));
+    ASSERT_EQ(std::string(data.data() + sizeof(length), length), "field");
+    ASSERT_FALSE(table.exists("field"));
+
+    ASSERT_TRUE(ptr->add("delete", 6, table_row(ptr, {"delete", 7, 1.0})));
+    ASSERT_TRUE(ptr->cmpdel("delete", 6, {table_int(ptr, "id", 7)}));
+    ASSERT_FALSE(table.exists("delete"));
+    ASSERT_EQ(ptr->delete_count, 3);
+}
+
+TEST(table, conditional_collision_chain) {
+    table_t table(128);
+    auto ptr = table.ptr();
+    ptr->set_hash_func([](const char *key, size_t len) -> uint64_t { return 1; });
+
+    const uint32_t available = ptr->get_available_slice_num();
+    for (long i = 1; i <= 7; i++) {
+        std::string key = "k" + std::to_string(i);
+        ASSERT_TRUE(ptr->add(key.data(), key.size(), table_row(ptr, {key, i, (double) i})));
+    }
+
+    ASSERT_TRUE(ptr->update("k1", 2, {table_int(ptr, "id", 11)}));
+    ASSERT_TRUE(ptr->update("k4", 2, {table_int(ptr, "id", 14)}));
+    ASSERT_TRUE(ptr->update("k7", 2, {table_int(ptr, "id", 17)}));
+    ASSERT_EQ(table.get("k1").id, 11);
+    ASSERT_EQ(table.get("k4").id, 14);
+    ASSERT_EQ(table.get("k7").id, 17);
+
+    ASSERT_TRUE(ptr->cmpdel("k1", 2, {table_int(ptr, "id", 11)}));
+    ASSERT_TRUE(ptr->cmpdel("k4", 2, {table_int(ptr, "id", 14)}));
+    ASSERT_TRUE(ptr->cmpdel("k7", 2, {table_int(ptr, "id", 17)}));
+
+    std::string data;
+    ASSERT_TRUE(ptr->getdel("k2", 2, nullptr, &data));
+    ASSERT_EQ(table_snapshot(ptr, data).id, 2);
+    ASSERT_TRUE(ptr->getdel("k5", 2, ptr->get_column("id"), &data));
+    long id;
+    memcpy(&id, data.data(), sizeof(id));
+    ASSERT_EQ(id, 5);
+    ASSERT_TRUE(ptr->getdel("k6", 2, nullptr, &data));
+    ASSERT_EQ(table_snapshot(ptr, data).id, 6);
+
+    ASSERT_EQ(table.count(), 1);
+    ASSERT_TRUE(table.exists("k3"));
+    ASSERT_EQ(table.get("k3").id, 3);
+    ASSERT_EQ(ptr->get_available_slice_num(), available);
+}
+
+TEST(table, conditional_add_exhaustion) {
+    table_t table(4, 1.0);
+    auto ptr = table.ptr();
+    ptr->set_hash_func([](const char *key, size_t len) -> uint64_t { return 1; });
+
+    const size_t capacity = 1 + ptr->get_total_slice_num();
+    for (size_t i = 0; i < capacity; i++) {
+        std::string key = "k" + std::to_string(i);
+        ASSERT_TRUE(ptr->add(key.data(), key.size(), table_row(ptr, {key, (long) i, (double) i})));
+    }
+
+    const auto insert_count = ptr->insert_count;
+    const auto conflict_count = ptr->conflict_count;
+    const auto conflict_max_level = ptr->conflict_max_level;
+    bool out_of_space = false;
+    ASSERT_FALSE(ptr->add("overflow", 8, table_row(ptr, {"overflow", 99, 99}), &out_of_space));
+    ASSERT_TRUE(out_of_space);
+    ASSERT_EQ(ptr->insert_count, insert_count);
+    ASSERT_EQ(ptr->conflict_count, conflict_count);
+    ASSERT_EQ(ptr->conflict_max_level, conflict_max_level);
+    ASSERT_EQ(table.count(), capacity);
+    ASSERT_TRUE(ptr->update("k0", 2, {table_int(ptr, "id", 100)}));
+
+    ASSERT_TRUE(ptr->cmpdel("k1", 2, {table_int(ptr, "id", 1)}));
+    ASSERT_TRUE(ptr->add("replacement", 11, table_row(ptr, {"replacement", 101, 101}), &out_of_space));
+    ASSERT_FALSE(out_of_space);
+    ASSERT_EQ(table.count(), capacity);
 }
 
 void start_iterator(Table *_ptr) {

--- a/ext-src/stubs/php_swoole_table.stub.php
+++ b/ext-src/stubs/php_swoole_table.stub.php
@@ -5,8 +5,13 @@ namespace Swoole {
         public function column(string $name, int $type, int $size = 0): bool {}
         public function create(): bool {}
         public function set(string $key, array $value): bool {}
+        public function add(string $key, array $values): bool {}
+        public function update(string $key, array $values): bool {}
+        public function cmpset(string $key, array $expected, array $values): bool {}
         public function get(string $key, ?string $field = null): array|false|string|float|int {}
+        public function getdel(string $key, ?string $field = null): array|false|string|float|int {}
         public function del(string $key): bool {}
+        public function cmpdel(string $key, array $expected): bool {}
         public function exists(string $key): bool {}
         public function incr(string $key, string $column, int|float $incrby = 1): false|float|int {}
         public function decr(string $key, string $column, int|float $incrby = 1): false|float|int {}

--- a/ext-src/stubs/php_swoole_table_arginfo.h
+++ b/ext-src/stubs/php_swoole_table_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6f27e661a71cca25f9d93788ad1dc938f50f8a41 */
+ * Stub hash: 62c49ea2bccd88e927bd3434d65569b6a62215a3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Table___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, table_size, IS_LONG, 0)
@@ -20,13 +20,33 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Table_set, 0, 2, _I
 	ZEND_ARG_TYPE_INFO(0, value, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Table_add, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Table_update arginfo_class_Swoole_Table_add
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Table_cmpset, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, expected, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Table_get, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE|MAY_BE_STRING|MAY_BE_DOUBLE|MAY_BE_LONG)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, field, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_Swoole_Table_getdel arginfo_class_Swoole_Table_get
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Table_del, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Table_cmpdel, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, expected, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Table_exists arginfo_class_Swoole_Table_del

--- a/ext-src/swoole_table.cc
+++ b/ext-src/swoole_table.cc
@@ -26,52 +26,34 @@ using swoole::Table;
 using swoole::TableColumn;
 using swoole::TableRow;
 using swoole::TableStringLength;
+using swoole::TableValues;
 
-static inline void table_row2array(const Table *table, TableRow *row, zval *return_value) {
-    array_init(return_value);
-
-    for (const auto col : *table->column_list) {
-        if (col->type == TableColumn::TYPE_STRING) {
-            TableStringLength len = 0;
-            char *str = nullptr;
-            row->get_value(col, &str, &len);
-            add_assoc_stringl_ex(return_value, col->name.c_str(), col->name.length(), str, len);
-        } else if (col->type == TableColumn::TYPE_FLOAT) {
-            double dval = 0;
-            row->get_value(col, &dval);
-            add_assoc_double_ex(return_value, col->name.c_str(), col->name.length(), dval);
-        } else if (col->type == TableColumn::TYPE_INT) {
-            long lval = 0;
-            row->get_value(col, &lval);
-            add_assoc_long_ex(return_value, col->name.c_str(), col->name.length(), lval);
-        } else {
-            php_swoole_fatal_error(E_WARNING, "unknown table column type[%d]", col->type);
-        }
-    }
-}
-
-static inline void table_get_field_value(Table *table, TableRow *row, zval *return_value, const zend_string *field) {
-    TableColumn *col = table->get_column(std::string(ZSTR_VAL(field), ZSTR_LEN(field)));
-    if (!col) {
-        ZVAL_FALSE(return_value);
-        return;
-    }
+static inline void table_data2value(const TableColumn *col, const char *data, zval *return_value) {
     if (col->type == TableColumn::TYPE_STRING) {
         TableStringLength len = 0;
-        char *str = nullptr;
-        row->get_value(col, &str, &len);
-        ZVAL_STRINGL(return_value, str, len);
+        memcpy(&len, data, sizeof(len));
+        ZVAL_STRINGL(return_value, data + sizeof(len), len);
     } else if (col->type == TableColumn::TYPE_FLOAT) {
         double dval = 0;
-        row->get_value(col, &dval);
+        memcpy(&dval, data, sizeof(dval));
         ZVAL_DOUBLE(return_value, dval);
     } else if (col->type == TableColumn::TYPE_INT) {
         long lval = 0;
-        row->get_value(col, &lval);
+        memcpy(&lval, data, sizeof(lval));
         ZVAL_LONG(return_value, lval);
     } else {
         php_swoole_fatal_error(E_WARNING, "unknown table column type[%d]", col->type);
         ZVAL_FALSE(return_value);
+    }
+}
+
+static inline void table_data2array(const Table *table, const char *data, zval *return_value) {
+    array_init(return_value);
+
+    for (const auto col : *table->column_list) {
+        zval value;
+        table_data2value(col, data + col->index, &value);
+        add_assoc_zval_ex(return_value, col->name.c_str(), col->name.length(), &value);
     }
 }
 
@@ -80,6 +62,7 @@ static zend_object_handlers swoole_table_handlers;
 
 struct TableObject {
     Table *ptr;
+    uint32_t value_conversion_depth;
     zend_object std;
 };
 
@@ -119,6 +102,100 @@ static inline bool table_check_key_length(size_t keylen) {
     return true;
 }
 
+enum TableValueMode {
+    TABLE_VALUE_EXPECTED,
+    TABLE_VALUE_WRITE,
+};
+
+static bool table_marshal_values(const zval *zobject,
+                                 Table *table,
+                                 HashTable *ht,
+                                 const char *key,
+                                 size_t keylen,
+                                 TableValueMode mode,
+                                 TableValues *values) {
+    values->clear();
+    values->reserve(zend_hash_num_elements(ht));
+
+    const char *name;
+    uint32_t name_length;
+    int key_type;
+    zval *value;
+    if (mode == TABLE_VALUE_EXPECTED) {
+        if (zend_hash_num_elements(ht) == 0) {
+            php_swoole_fatal_error(E_WARNING, "expected values must not be empty");
+            return false;
+        }
+
+        // Reject the complete condition before conversions can execute user code.
+        SW_HASHTABLE_FOREACH_START2(ht, name, name_length, key_type, value) {
+            if (name == nullptr) {
+                php_swoole_fatal_error(E_WARNING, "expected values must use column names");
+                return false;
+            }
+            if (table->get_column(std::string(name, name_length)) == nullptr) {
+                php_swoole_fatal_error(E_WARNING, "column[%.*s] does not exist", (int) name_length, name);
+                return false;
+            }
+        }
+        (void) key_type;
+        SW_HASHTABLE_FOREACH_END();
+    }
+
+    // Keep the table schema alive while conversions may execute user code.
+    TableObject *object = table_fetch_object(Z_OBJ_P(zobject));
+    object->value_conversion_depth++;
+    ON_SCOPE_EXIT {
+        object->value_conversion_depth--;
+    };
+
+    SW_HASHTABLE_FOREACH_START2(ht, name, name_length, key_type, value) {
+        if (name == nullptr) {
+            continue;
+        }
+
+        TableColumn *column = table->get_column(std::string(name, name_length));
+        if (column == nullptr) {
+            continue;
+        }
+
+        if (column->type == TableColumn::TYPE_STRING) {
+            zend_string *string = zval_get_string(value);
+            if (UNEXPECTED(EG(exception))) {
+                if (string) {
+                    zend_string_release(string);
+                }
+                return false;
+            }
+
+            size_t length = ZSTR_LEN(string);
+            const size_t capacity = column->size - sizeof(TableStringLength);
+            if (mode == TABLE_VALUE_WRITE && length > capacity) {
+                swoole_warning("[key=%.*s,field=%s]string value is too long", (int) keylen, key, column->name.c_str());
+                length = capacity;
+            }
+            values->emplace_back(column, ZSTR_VAL(string), length);
+            zend_string_release(string);
+        } else if (column->type == TableColumn::TYPE_FLOAT) {
+            double number = zval_get_double(value);
+            if (UNEXPECTED(EG(exception))) {
+                return false;
+            }
+            values->emplace_back(column, &number, sizeof(number));
+        } else {
+            long number = zval_get_long(value);
+            if (UNEXPECTED(EG(exception))) {
+                return false;
+            }
+            values->emplace_back(column, &number, sizeof(number));
+        }
+    }
+    (void) key_type;
+    SW_HASHTABLE_FOREACH_END();
+
+    return true;
+}
+
 static void table_set_ptr(const zval *zobject, Table *ptr) {
     table_fetch_object(Z_OBJ_P(zobject))->ptr = ptr;
 }
@@ -140,8 +217,13 @@ static PHP_METHOD(swoole_table, __construct);
 static PHP_METHOD(swoole_table, column);
 static PHP_METHOD(swoole_table, create);
 static PHP_METHOD(swoole_table, set);
+static PHP_METHOD(swoole_table, add);
+static PHP_METHOD(swoole_table, update);
+static PHP_METHOD(swoole_table, cmpset);
 static PHP_METHOD(swoole_table, get);
+static PHP_METHOD(swoole_table, getdel);
 static PHP_METHOD(swoole_table, del);
+static PHP_METHOD(swoole_table, cmpdel);
 static PHP_METHOD(swoole_table, exists);
 static PHP_METHOD(swoole_table, incr);
 static PHP_METHOD(swoole_table, decr);
@@ -167,10 +249,15 @@ static const zend_function_entry swoole_table_methods[] =
     PHP_ME(swoole_table, create,            arginfo_class_Swoole_Table_create,        ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, destroy,           arginfo_class_Swoole_Table_destroy,       ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, set,               arginfo_class_Swoole_Table_set,           ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_table, add,               arginfo_class_Swoole_Table_add,           ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_table, update,            arginfo_class_Swoole_Table_update,        ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_table, cmpset,            arginfo_class_Swoole_Table_cmpset,        ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, get,               arginfo_class_Swoole_Table_get,           ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_table, getdel,            arginfo_class_Swoole_Table_getdel,        ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, count,             arginfo_class_Swoole_Table_count,         ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, del,               arginfo_class_Swoole_Table_del,           ZEND_ACC_PUBLIC)
     PHP_MALIAS(swoole_table, delete, del,   arginfo_class_Swoole_Table_del,           ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_table, cmpdel,            arginfo_class_Swoole_Table_cmpdel,        ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, exists,            arginfo_class_Swoole_Table_exists,        ZEND_ACC_PUBLIC)
     PHP_MALIAS(swoole_table, exist, exists, arginfo_class_Swoole_Table_exists,        ZEND_ACC_PUBLIC)
     PHP_ME(swoole_table, incr,              arginfo_class_Swoole_Table_incr,          ZEND_ACC_PUBLIC)
@@ -271,6 +358,12 @@ static PHP_METHOD(swoole_table, create) {
 }
 
 static PHP_METHOD(swoole_table, destroy) {
+    TableObject *object = table_fetch_object(Z_OBJ_P(ZEND_THIS));
+    if (UNEXPECTED(object->value_conversion_depth != 0)) {
+        zend_throw_error(nullptr, "Cannot destroy %s during value conversion", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     Table *table = table_get_and_check_ptr2(ZEND_THIS);
 
     table->destroy();
@@ -359,6 +452,100 @@ static PHP_METHOD(swoole_table, set) {
     }
     _rowlock->unlock();
     RETURN_TRUE;
+}
+
+static PHP_METHOD(swoole_table, add) {
+    zval *array;
+    char *key;
+    size_t keylen;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+    Z_PARAM_STRING(key, keylen)
+    Z_PARAM_ARRAY(array)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
+    if (!table_check_key_length(keylen)) {
+        RETURN_FALSE;
+    }
+
+    TableValues values;
+    if (!table_marshal_values(ZEND_THIS, table, Z_ARRVAL_P(array), key, keylen, TABLE_VALUE_WRITE, &values)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+        RETURN_FALSE;
+    }
+
+    bool out_of_space = false;
+    bool result = table->add(key, keylen, values, &out_of_space);
+    if (!result && out_of_space) {
+        php_swoole_error(E_WARNING, "failed to add('%*s'), unable to allocate memory", (int) keylen, key);
+    }
+    RETURN_BOOL(result);
+}
+
+static PHP_METHOD(swoole_table, update) {
+    zval *array;
+    char *key;
+    size_t keylen;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+    Z_PARAM_STRING(key, keylen)
+    Z_PARAM_ARRAY(array)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
+    if (!table_check_key_length(keylen)) {
+        RETURN_FALSE;
+    }
+
+    TableValues values;
+    if (!table_marshal_values(ZEND_THIS, table, Z_ARRVAL_P(array), key, keylen, TABLE_VALUE_WRITE, &values)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+        RETURN_FALSE;
+    }
+
+    RETURN_BOOL(table->update(key, keylen, values));
+}
+
+static PHP_METHOD(swoole_table, cmpset) {
+    zval *expected_array;
+    zval *values_array;
+    char *key;
+    size_t keylen;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 3, 3)
+    Z_PARAM_STRING(key, keylen)
+    Z_PARAM_ARRAY(expected_array)
+    Z_PARAM_ARRAY(values_array)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
+    if (!table_check_key_length(keylen)) {
+        RETURN_FALSE;
+    }
+
+    TableValues expected;
+    if (!table_marshal_values(
+            ZEND_THIS, table, Z_ARRVAL_P(expected_array), key, keylen, TABLE_VALUE_EXPECTED, &expected)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+        RETURN_FALSE;
+    }
+
+    TableValues values;
+    if (!table_marshal_values(ZEND_THIS, table, Z_ARRVAL_P(values_array), key, keylen, TABLE_VALUE_WRITE, &values)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+        RETURN_FALSE;
+    }
+
+    RETURN_BOOL(table->cmpset(key, keylen, expected, values));
 }
 
 static PHP_METHOD(swoole_table, incr) {
@@ -512,12 +699,53 @@ static PHP_METHOD(swoole_table, get) {
     if (!row) {
         RETVAL_FALSE;
     } else if (field) {
-        table_get_field_value(table, row, return_value, field);
+        TableColumn *column = table->get_column(std::string(ZSTR_VAL(field), ZSTR_LEN(field)));
+        if (column) {
+            table_data2value(column, row->data + column->index, return_value);
+        } else {
+            RETVAL_FALSE;
+        }
     } else {
-        table_row2array(table, row, return_value);
+        table_data2array(table, row->data, return_value);
     }
     if (_rowlock) {
         _rowlock->unlock();
+    }
+}
+
+static PHP_METHOD(swoole_table, getdel) {
+    char *key;
+    size_t keylen;
+    zend_string *field = nullptr;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 2)
+    Z_PARAM_STRING(key, keylen)
+    Z_PARAM_OPTIONAL
+    Z_PARAM_STR_OR_NULL(field)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
+    if (!table_check_key_length(keylen)) {
+        RETURN_FALSE;
+    }
+
+    TableColumn *column = nullptr;
+    if (field) {
+        column = table->get_column(std::string(ZSTR_VAL(field), ZSTR_LEN(field)));
+        if (column == nullptr) {
+            RETURN_FALSE;
+        }
+    }
+
+    std::string data;
+    if (!table->getdel(key, keylen, column, &data)) {
+        RETURN_FALSE;
+    }
+
+    if (column) {
+        table_data2value(column, data.data(), return_value);
+    } else {
+        table_data2array(table, data.data(), return_value);
     }
 }
 
@@ -548,6 +776,33 @@ static PHP_METHOD(swoole_table, del) {
         RETURN_FALSE;
     }
     RETURN_BOOL(table->del(key, keylen));
+}
+
+static PHP_METHOD(swoole_table, cmpdel) {
+    zval *expected_array;
+    char *key;
+    size_t keylen;
+
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+    Z_PARAM_STRING(key, keylen)
+    Z_PARAM_ARRAY(expected_array)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
+    if (!table_check_key_length(keylen)) {
+        RETURN_FALSE;
+    }
+
+    TableValues expected;
+    if (!table_marshal_values(
+            ZEND_THIS, table, Z_ARRVAL_P(expected_array), key, keylen, TABLE_VALUE_EXPECTED, &expected)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+        RETURN_FALSE;
+    }
+
+    RETURN_BOOL(table->cmpdel(key, keylen, expected));
 }
 
 static PHP_METHOD(swoole_table, count) {
@@ -622,7 +877,7 @@ static PHP_METHOD(swoole_table, current) {
     if (row->key_len == 0) {
         RETURN_NULL();
     }
-    table_row2array(table, row, return_value);
+    table_data2array(table, row->data, return_value);
 }
 
 static PHP_METHOD(swoole_table, key) {

--- a/include/swoole_table.h
+++ b/include/swoole_table.h
@@ -40,6 +40,15 @@ typedef uint64_t (*HashFunc)(const char *key, size_t len);
 
 struct TableColumn;
 
+struct TableValue {
+    const TableColumn *column;
+    std::string data;
+
+    TableValue(const TableColumn *_column, const void *value, size_t length);
+};
+
+using TableValues = std::vector<TableValue>;
+
 struct TableRow {
     sw_atomic_t lock_;
     pid_t lock_pid;
@@ -157,6 +166,11 @@ class Table {
     TableColumn *get_column(const std::string &key) const;
     TableRow *set(const char *key, size_t keylen, TableRow **rowlock, int *out_flags);
     TableRow *get(const char *key, size_t keylen, TableRow **rowlock) const;
+    bool add(const char *key, size_t keylen, const TableValues &values, bool *out_of_space = nullptr);
+    bool update(const char *key, size_t keylen, const TableValues &values);
+    bool cmpset(const char *key, size_t keylen, const TableValues &expected, const TableValues &values);
+    bool cmpdel(const char *key, size_t keylen, const TableValues &expected);
+    bool getdel(const char *key, size_t keylen, const TableColumn *column, std::string *data);
     bool exists(const char *key, size_t keylen) const;
     bool del(const char *key, size_t keylen);
     void forward() const;
@@ -237,6 +251,12 @@ class Table {
         pool->free(tmp);
         unlock();
     }
+
+    TableRow *find_row(
+        TableRow *root, const char *key, size_t keylen, TableRow **previous, uint32_t *conflict_level = nullptr) const;
+    void delete_row(TableRow *root, TableRow *row, TableRow *previous);
+    static void apply_values(TableRow *row, const TableValues &values);
+    static bool match_values(const TableRow *row, const TableValues &expected);
 
     static bool is_valid_key_length(size_t keylen) {
         return keylen > 0 && keylen < SW_TABLE_KEY_SIZE;

--- a/src/memory/table.cc
+++ b/src/memory/table.cc
@@ -23,6 +23,12 @@
 
 namespace swoole {
 
+TableValue::TableValue(const TableColumn *_column, const void *value, size_t length) : column(_column) {
+    if (length != 0) {
+        data.assign(static_cast<const char *>(value), length);
+    }
+}
+
 static bool size_mul_overflow(size_t a, size_t b, size_t *result) {
     if (a != 0 && b > std::numeric_limits<size_t>::max() / a) {
         return true;
@@ -376,6 +382,85 @@ void Table::forward() const {
     iterator->unlock();
 }
 
+TableRow *Table::find_row(
+    TableRow *root, const char *key, size_t keylen, TableRow **previous, uint32_t *conflict_level) const {
+    *previous = nullptr;
+    if (conflict_level) {
+        *conflict_level = 0;
+    }
+    if (!root->active) {
+        return nullptr;
+    }
+
+    TableRow *row = root;
+    uint32_t level = 1;
+    for (;;) {
+        if (sw_mem_equal(row->key, row->key_len, key, keylen)) {
+            if (conflict_level) {
+                *conflict_level = level;
+            }
+            return row;
+        }
+        if (row->next == nullptr) {
+            *previous = row;
+            if (conflict_level) {
+                *conflict_level = level;
+            }
+            return nullptr;
+        }
+        *previous = row;
+        row = row->next;
+        level++;
+    }
+}
+
+void Table::apply_values(TableRow *row, const TableValues &values) {
+    for (const auto &value : values) {
+        if (value.column->type == TableColumn::TYPE_STRING) {
+            row->set_value(value.column, value.data.data(), value.data.size());
+        } else {
+            memcpy(row->data + value.column->index, value.data.data(), value.column->size);
+        }
+    }
+}
+
+bool Table::match_values(const TableRow *row, const TableValues &expected) {
+    for (const auto &value : expected) {
+        if (value.column->type == TableColumn::TYPE_STRING) {
+            TableStringLength length;
+            memcpy(&length, row->data + value.column->index, sizeof(length));
+            if (length != value.data.size() ||
+                (length != 0 &&
+                 memcmp(row->data + value.column->index + sizeof(length), value.data.data(), length) != 0)) {
+                return false;
+            }
+        } else if (memcmp(row->data + value.column->index, value.data.data(), value.column->size) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void Table::delete_row(TableRow *root, TableRow *row, TableRow *previous) {
+    if (row->next == nullptr && row == root) {
+        row->clear();
+    } else if (row == root) {
+        // When deleting the root, move the first conflict row into it before releasing that conflict slice.
+        TableRow *next = row->next;
+        row->next = next->next;
+        memcpy(row->key, next->key, next->key_len + 1);
+        row->key_len = next->key_len;
+        memcpy(row->data, next->data, item_size);
+        free_row(next);
+    } else {
+        previous->next = row->next;
+        free_row(row);
+    }
+
+    sw_atomic_fetch_add(&(delete_count), 1);
+    sw_atomic_fetch_sub(&(row_num), 1);
+}
+
 TableRow *Table::get(const char *key, size_t keylen, TableRow **rowlock) const {
     // The caller owns the returned bucket lock and must pass a non-null rowlock to release it.
     if (sw_unlikely(rowlock == nullptr)) {
@@ -386,26 +471,12 @@ TableRow *Table::get(const char *key, size_t keylen, TableRow **rowlock) const {
         return nullptr;
     }
 
-    TableRow *row = hash(key, keylen);
+    TableRow *root = hash(key, keylen);
+    *rowlock = root;
+    root->lock();
 
-    *rowlock = row;
-    row->lock();
-
-    for (;;) {
-        if (sw_mem_equal(row->key, row->key_len, key, keylen)) {
-            if (!row->active) {
-                row = nullptr;
-            }
-            break;
-        } else if (row->next == nullptr) {
-            row = nullptr;
-            break;
-        } else {
-            row = row->next;
-        }
-    }
-
-    return row;
+    TableRow *previous = nullptr;
+    return find_row(root, key, keylen, &previous);
 }
 
 TableRow *Table::set(const char *key, size_t keylen, TableRow **rowlock, int *out_flags) {
@@ -421,44 +492,44 @@ TableRow *Table::set(const char *key, size_t keylen, TableRow **rowlock, int *ou
         return nullptr;
     }
 
-    TableRow *row = hash(key, keylen);
-    *rowlock = row;
-    row->lock();
-    int _out_flags = 0;
+    TableRow *root = hash(key, keylen);
+    *rowlock = root;
+    root->lock();
 
-    if (row->active) {
-        uint32_t _conflict_level = 1;
-        while (!sw_mem_equal(row->key, row->key_len, key, keylen)) {
-            if (row->next == nullptr) {
-                conflict_count++;
-                if (_conflict_level > conflict_max_level) {
-                    conflict_max_level = _conflict_level;
-                }
-                TableRow *new_row = alloc_row();
-                if (!new_row) {
-                    return nullptr;
-                }
-                init_row(new_row, key, keylen);
-                _out_flags |= SW_TABLE_FLAG_NEW_ROW;
-                row->next = new_row;
-                row = new_row;
-                break;
-            } else {
-                row = row->next;
-                _out_flags |= SW_TABLE_FLAG_CONFLICT;
-                _conflict_level++;
+    TableRow *previous = nullptr;
+    uint32_t conflict_level = 0;
+    TableRow *row = find_row(root, key, keylen, &previous, &conflict_level);
+    int flags = 0;
+
+    if (row == nullptr) {
+        if (root->active) {
+            conflict_count++;
+            if (conflict_level > conflict_max_level) {
+                conflict_max_level = conflict_level;
             }
+            row = alloc_row();
+            if (row == nullptr) {
+                return nullptr;
+            }
+            init_row(row, key, keylen);
+            previous->next = row;
+            if (conflict_level > 1) {
+                flags |= SW_TABLE_FLAG_CONFLICT;
+            }
+        } else {
+            row = root;
+            init_row(row, key, keylen);
         }
-    } else {
-        init_row(row, key, keylen);
-        _out_flags |= SW_TABLE_FLAG_NEW_ROW;
+        flags |= SW_TABLE_FLAG_NEW_ROW;
+    } else if (previous != nullptr) {
+        flags |= SW_TABLE_FLAG_CONFLICT;
     }
 
     if (out_flags) {
-        *out_flags = _out_flags;
+        *out_flags = flags;
     }
 
-    if (_out_flags & SW_TABLE_FLAG_NEW_ROW) {
+    if (flags & SW_TABLE_FLAG_NEW_ROW) {
         sw_atomic_fetch_add(&(insert_count), 1);
     } else {
         sw_atomic_fetch_add(&(update_count), 1);
@@ -467,60 +538,153 @@ TableRow *Table::set(const char *key, size_t keylen, TableRow **rowlock, int *ou
     return row;
 }
 
+bool Table::add(const char *key, size_t keylen, const TableValues &values, bool *out_of_space) {
+    if (out_of_space) {
+        *out_of_space = false;
+    }
+    if (!is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    TableRow *root = hash(key, keylen);
+    root->lock();
+
+    TableRow *previous = nullptr;
+    uint32_t conflict_level = 0;
+    if (find_row(root, key, keylen, &previous, &conflict_level) != nullptr) {
+        root->unlock();
+        return false;
+    }
+
+    TableRow *row = root;
+    if (root->active) {
+        row = alloc_row();
+        if (row == nullptr) {
+            if (out_of_space) {
+                *out_of_space = true;
+            }
+            root->unlock();
+            return false;
+        }
+        init_row(row, key, keylen);
+        previous->next = row;
+        conflict_count++;
+        if (conflict_level > conflict_max_level) {
+            conflict_max_level = conflict_level;
+        }
+    } else {
+        init_row(row, key, keylen);
+    }
+
+    clear_row(row);
+    apply_values(row, values);
+    sw_atomic_fetch_add(&(insert_count), 1);
+    root->unlock();
+    return true;
+}
+
+bool Table::update(const char *key, size_t keylen, const TableValues &values) {
+    if (!is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    TableRow *root = hash(key, keylen);
+    root->lock();
+    TableRow *previous = nullptr;
+    TableRow *row = find_row(root, key, keylen, &previous);
+    if (row == nullptr) {
+        root->unlock();
+        return false;
+    }
+
+    apply_values(row, values);
+    sw_atomic_fetch_add(&(update_count), 1);
+    root->unlock();
+    return true;
+}
+
+bool Table::cmpset(const char *key, size_t keylen, const TableValues &expected, const TableValues &values) {
+    if (!is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    TableRow *root = hash(key, keylen);
+    root->lock();
+    TableRow *previous = nullptr;
+    TableRow *row = find_row(root, key, keylen, &previous);
+    if (row == nullptr || !match_values(row, expected)) {
+        root->unlock();
+        return false;
+    }
+
+    apply_values(row, values);
+    sw_atomic_fetch_add(&(update_count), 1);
+    root->unlock();
+    return true;
+}
+
+bool Table::cmpdel(const char *key, size_t keylen, const TableValues &expected) {
+    if (!is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    TableRow *root = hash(key, keylen);
+    root->lock();
+    TableRow *previous = nullptr;
+    TableRow *row = find_row(root, key, keylen, &previous);
+    if (row == nullptr || !match_values(row, expected)) {
+        root->unlock();
+        return false;
+    }
+
+    delete_row(root, row, previous);
+    root->unlock();
+    return true;
+}
+
+bool Table::getdel(const char *key, size_t keylen, const TableColumn *column, std::string *data) {
+    if (data == nullptr || !is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    const size_t snapshot_size = column == nullptr ? item_size : column->size;
+    data->resize(snapshot_size);
+
+    TableRow *root = hash(key, keylen);
+    root->lock();
+    TableRow *previous = nullptr;
+    TableRow *row = find_row(root, key, keylen, &previous);
+    if (row == nullptr) {
+        root->unlock();
+        data->clear();
+        return false;
+    }
+
+    if (snapshot_size != 0) {
+        const char *source = row->data + (column == nullptr ? 0 : column->index);
+        memcpy(&(*data)[0], source, snapshot_size);
+    }
+    delete_row(root, row, previous);
+    root->unlock();
+    return true;
+}
+
 bool Table::del(const char *key, size_t keylen) {
     if (!is_valid_key_length(keylen)) {
         return false;
     }
 
-    TableRow *row = hash(key, keylen);
-    TableRow *tmp, *prev = nullptr;
-
-    row->lock();
-    if (!row->active) {
-        row->unlock();
+    TableRow *root = hash(key, keylen);
+    root->lock();
+    TableRow *previous = nullptr;
+    TableRow *row = find_row(root, key, keylen, &previous);
+    if (row == nullptr) {
+        root->unlock();
         return false;
     }
-    if (row->next == nullptr) {
-        if (sw_mem_equal(row->key, row->key_len, key, keylen)) {
-            row->clear();
-        } else {
-            goto _not_exists;
-        }
-    } else {
-        tmp = row;
-        while (tmp) {
-            if (sw_mem_equal(tmp->key, tmp->key_len, key, keylen)) {
-                break;
-            }
-            prev = tmp;
-            tmp = tmp->next;
-        }
 
-        if (tmp == nullptr) {
-        _not_exists:
-            row->unlock();
-
-            return false;
-        }
-
-        // when the deleting element is root, should move the first element's data to root,
-        // and remove the element from the collision list.
-        if (tmp == row) {
-            tmp = tmp->next;
-            row->next = tmp->next;
-            memcpy(row->key, tmp->key, tmp->key_len + 1);
-            row->key_len = tmp->key_len;
-            memcpy(row->data, tmp->data, item_size);
-        } else {
-            prev->next = tmp->next;
-        }
-        free_row(tmp);
-    }
-
-    sw_atomic_fetch_add(&(delete_count), 1);
-    sw_atomic_fetch_sub(&(row_num), 1);
-    row->unlock();
-
+    delete_row(root, row, previous);
+    root->unlock();
     return true;
 }
 

--- a/tests/swoole_table/conditional_conversion.phpt
+++ b/tests/swoole_table/conditional_conversion.phpt
@@ -1,0 +1,100 @@
+--TEST--
+swoole_table: conditional conversion happens before locking
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+class NestedUpdate
+{
+    public function __construct(private Table $table)
+    {
+    }
+
+    public function __toString(): string
+    {
+        Assert::true($this->table->update('row', ['id' => 2]));
+
+        return 'original';
+    }
+}
+
+class ConversionProbe
+{
+    public bool $called = false;
+
+    public function __toString(): string
+    {
+        $this->called = true;
+
+        return 'original';
+    }
+}
+
+class DestroyDuringConversion
+{
+    public function __construct(private Table $table)
+    {
+    }
+
+    public function __toString(): string
+    {
+        $this->table->destroy();
+
+        return 'original';
+    }
+}
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 16);
+$table->column('score', Table::TYPE_FLOAT);
+$table->create();
+$table->set('row', ['id' => 1, 'name' => 'original', 'score' => 1.0]);
+
+Assert::true($table->cmpset(
+    'row',
+    ['name'  => new NestedUpdate($table)],
+    ['score' => 2.0],
+));
+Assert::same($table->get('row'), [
+    'id'    => 2,
+    'name'  => 'original',
+    'score' => 2.0,
+]);
+
+$probe          = new ConversionProbe();
+$errorReporting = error_reporting(0);
+Assert::false($table->cmpset(
+    'row',
+    ['name' => $probe, 'missing' => 1],
+    ['id'   => 3],
+));
+error_reporting($errorReporting);
+Assert::false($probe->called);
+Assert::same($table->get('row'), [
+    'id'    => 2,
+    'name'  => 'original',
+    'score' => 2.0,
+]);
+
+try {
+    $table->cmpset(
+        'row',
+        ['name' => new DestroyDuringConversion($table)],
+        ['id'   => 3],
+    );
+    Assert::true(false);
+} catch (Error $error) {
+    Assert::contains($error->getMessage(), 'Cannot destroy Swoole\Table during value conversion');
+}
+Assert::same($table->get('row'), [
+    'id'    => 2,
+    'name'  => 'original',
+    'score' => 2.0,
+]);
+?>
+--EXPECT--

--- a/tests/swoole_table/conditional_lifecycle.phpt
+++ b/tests/swoole_table/conditional_lifecycle.phpt
@@ -1,0 +1,71 @@
+--TEST--
+swoole_table: conditional operation lifecycle guards
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Process;
+use Swoole\Table;
+
+class DestroyingKey
+{
+    public function __construct(private Table $table)
+    {
+    }
+
+    public function __toString(): string
+    {
+        $this->table->destroy();
+
+        return 'row';
+    }
+}
+
+$process = new Process(function (): void {
+    $table = new Table(128);
+    $table->column('id', Table::TYPE_INT);
+    $table->add('row', ['id' => 1]);
+}, true, SOCK_STREAM);
+$process->start();
+$output = $process->read();
+$status = Process::wait();
+Assert::contains($output, 'table is not created or has been destroyed');
+Assert::same($status['code'], 255);
+
+$process = new Process(function (): void {
+    $table = new Table(128);
+    $table->column('id', Table::TYPE_INT);
+    $table->create();
+    $table->getdel(new DestroyingKey($table));
+}, true, SOCK_STREAM);
+$process->start();
+$output = $process->read();
+$status = Process::wait();
+Assert::contains($output, 'must call constructor first');
+Assert::same($status['code'], 255);
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->create();
+$table->set('row', ['id' => 1]);
+$destroyed = new Atomic(0);
+
+$process = new Process(function () use ($table, $destroyed): void {
+    while ($destroyed->get() === 0) {
+        $destroyed->wait(1.0);
+    }
+    $table->getdel('row');
+}, true, SOCK_STREAM);
+$process->start();
+$table->destroy();
+$destroyed->set(1);
+$destroyed->wakeup();
+$output = $process->read();
+$status = Process::wait();
+Assert::contains($output, 'table is not created or has been destroyed');
+Assert::same($status['code'], 255);
+?>
+--EXPECT--

--- a/tests/swoole_table/conditional_race.phpt
+++ b/tests/swoole_table/conditional_race.phpt
@@ -1,0 +1,89 @@
+--TEST--
+swoole_table: conditional operations are atomic across processes
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Process;
+use Swoole\Table;
+
+const WORKERS = 4;
+
+function race(callable $operation): int
+{
+    $ready     = new Atomic(0);
+    $start     = new Atomic(0);
+    $successes = new Atomic(0);
+    $processes = [];
+
+    for ($i = 0; $i < WORKERS; $i++) {
+        $process = new Process(function () use ($ready, $start, $successes, $operation): void {
+            $ready->add();
+            while ($start->get() === 0) {
+                $start->wait(1.0);
+            }
+            if ($operation()) {
+                $successes->add();
+            }
+        });
+        Assert::greaterThan($process->start(), 0);
+        $processes[] = $process;
+    }
+
+    $deadline = microtime(true) + 5;
+    while ($ready->get() !== WORKERS) {
+        if (microtime(true) >= $deadline) {
+            throw new RuntimeException('workers did not become ready');
+        }
+        usleep(1000);
+    }
+
+    $start->set(1);
+    $start->wakeup(WORKERS);
+    foreach ($processes as $_) {
+        $status = Process::wait();
+        Assert::same($status['code'], 0);
+    }
+
+    return $successes->get();
+}
+
+$table = new Table(128);
+$table->column('value', Table::TYPE_INT);
+$table->column('version', Table::TYPE_INT);
+$table->create();
+
+Assert::same(race(fn (): bool => $table->add('add', ['value' => 1])), 1);
+
+$table->set('getdel', ['value' => 1]);
+Assert::same(race(fn (): bool => $table->getdel('getdel') !== false), 1);
+
+$table->set('cmpdel', ['value' => 1]);
+Assert::same(race(fn (): bool => $table->cmpdel('cmpdel', ['value' => 1])), 1);
+
+$table->set('counter', ['value' => 0, 'version' => 0]);
+$iterations = 50;
+Assert::same(race(function () use ($table, $iterations): bool {
+    for ($i = 0; $i < $iterations; $i++) {
+        do {
+            $current = $table->get('counter');
+        } while (!$table->cmpset(
+            'counter',
+            ['version' => $current['version']],
+            [
+                'value'   => $current['value'] + 1,
+                'version' => $current['version'] + 1,
+            ],
+        ));
+    }
+    return true;
+}), WORKERS);
+
+$counter = $table->get('counter');
+Assert::same($counter['value'], WORKERS * $iterations);
+Assert::same($counter['version'], WORKERS * $iterations);
+?>
+--EXPECT--

--- a/tests/swoole_table/conditional_stats.phpt
+++ b/tests/swoole_table/conditional_stats.phpt
@@ -1,0 +1,65 @@
+--TEST--
+swoole_table: conditional operation statistics
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('version', Table::TYPE_INT);
+$table->create();
+
+function assertDelta(array $before, array $after, array $delta): void
+{
+    foreach (['num', 'insert_count', 'update_count', 'delete_count'] as $name) {
+        Assert::same($after[$name], $before[$name] + ($delta[$name] ?? 0));
+    }
+}
+
+$before = $table->stats();
+Assert::true($table->add('row', ['id' => 1, 'version' => 1]));
+$after = $table->stats();
+assertDelta($before, $after, ['num' => 1, 'insert_count' => 1]);
+
+$before = $after;
+Assert::false($table->add('row', ['id' => 2]));
+Assert::false($table->update('missing', ['id' => 2]));
+Assert::false($table->cmpset('row', ['version' => 2], ['id' => 2]));
+Assert::false($table->cmpdel('row', ['version' => 2]));
+Assert::false($table->getdel('missing'));
+Assert::false($table->getdel('row', 'missing'));
+$errorReporting = error_reporting(0);
+Assert::false($table->cmpset('row', [], ['id' => 2]));
+error_reporting($errorReporting);
+$after = $table->stats();
+assertDelta($before, $after, []);
+
+$before = $after;
+Assert::true($table->update('row', []));
+$after = $table->stats();
+assertDelta($before, $after, ['update_count' => 1]);
+
+$before = $after;
+Assert::true($table->cmpset('row', ['version' => 1], ['id' => 2, 'version' => 2]));
+$after = $table->stats();
+assertDelta($before, $after, ['update_count' => 1]);
+
+$before = $after;
+Assert::true($table->cmpdel('row', ['version' => 2]));
+$after = $table->stats();
+assertDelta($before, $after, ['num' => -1, 'delete_count' => 1]);
+
+$before = $after;
+Assert::true($table->add('row', ['id' => 3]));
+Assert::same($table->getdel('row', 'id'), 3);
+$after = $table->stats();
+assertDelta($before, $after, ['insert_count' => 1, 'delete_count' => 1]);
+
+Assert::same($after['num'], 0);
+Assert::same($after['available_slice_num'], $after['total_slice_num']);
+?>
+--EXPECT--

--- a/tests/swoole_table/conditional_types.phpt
+++ b/tests/swoole_table/conditional_types.phpt
@@ -1,0 +1,52 @@
+--TEST--
+swoole_table: conditional value types
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 8);
+$table->column('score', Table::TYPE_FLOAT);
+$table->create();
+
+Assert::true($table->add('coerce', [
+    'id'    => '42',
+    'name'  => null,
+    'score' => '1.25',
+]));
+Assert::same($table->get('coerce'), [
+    'id'    => 42,
+    'name'  => '',
+    'score' => 1.25,
+]);
+Assert::true($table->cmpset(
+    'coerce',
+    ['id' => '42', 'name' => null, 'score' => '1.25'],
+    [],
+));
+
+$binary = "a\0b";
+Assert::true($table->add('binary', ['name' => $binary]));
+Assert::true($table->cmpset('binary', ['name' => $binary], []));
+Assert::false($table->cmpset('binary', ['name' => "a\0c"], []));
+
+Assert::true($table->add('long', ['name' => str_repeat('x', 16)]));
+Assert::same($table->get('long', 'name'), str_repeat('x', 8));
+Assert::false($table->cmpset('long', ['name' => str_repeat('x', 16)], []));
+
+Assert::true($table->add('zero', ['score' => 0.0]));
+Assert::false($table->cmpset('zero', ['score' => -0.0], []));
+Assert::true($table->cmpset('zero', ['score' => 0.0], []));
+
+Assert::true($table->add('nan', ['score' => NAN]));
+$nan = $table->get('nan', 'score');
+Assert::true(is_nan($nan));
+Assert::true($table->cmpset('nan', ['score' => $nan], []));
+?>
+--EXPECTF--
+[%s]	WARNING	table_marshal_values(): [key=long,field=name]string value is too long

--- a/tests/swoole_table/conditional_validation.phpt
+++ b/tests/swoole_table/conditional_validation.phpt
@@ -1,0 +1,70 @@
+--TEST--
+swoole_table: conditional validation
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 16);
+$table->create();
+$table->set('row', ['id' => 1, 'name' => 'original']);
+
+function assertUnchanged(Table $table, array $stats): void
+{
+    Assert::same($table->get('row'), ['id' => 1, 'name' => 'original']);
+    Assert::same($table->stats(), $stats);
+}
+
+$stats = $table->stats();
+
+var_dump($table->cmpset('row', [], ['id' => 2]));
+assertUnchanged($table, $stats);
+
+var_dump($table->cmpset('row', [1], ['id' => 2]));
+assertUnchanged($table, $stats);
+
+var_dump($table->cmpdel('row', ['missing' => 1]));
+assertUnchanged($table, $stats);
+
+var_dump($table->cmpset('row', ['id' => 1, 'missing' => 1], ['id' => 2]));
+assertUnchanged($table, $stats);
+
+var_dump($table->add('', ['id' => 2]));
+var_dump($table->update('', ['id' => 2]));
+var_dump($table->cmpset('', ['id' => 1], ['id' => 2]));
+var_dump($table->cmpdel('', ['id' => 1]));
+var_dump($table->getdel(''));
+assertUnchanged($table, $stats);
+?>
+--EXPECTF--
+Warning: Swoole\Table::cmpset(): expected values must not be empty in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::cmpset(): expected values must use column names in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::cmpdel(): column[missing] does not exist in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::cmpset(): column[missing] does not exist in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::add(): key must not be empty in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::update(): key must not be empty in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::cmpset(): key must not be empty in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::cmpdel(): key must not be empty in %s on line %d
+bool(false)
+
+Warning: Swoole\Table::getdel(): key must not be empty in %s on line %d
+bool(false)

--- a/tests/swoole_table/conditional_write.phpt
+++ b/tests/swoole_table/conditional_write.phpt
@@ -1,0 +1,72 @@
+--TEST--
+swoole_table: conditional writes
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 32);
+$table->column('score', Table::TYPE_FLOAT);
+$table->column('version', Table::TYPE_INT);
+$table->create();
+
+Assert::true($table->add('empty', []));
+Assert::same($table->get('empty'), [
+    'id'      => 0,
+    'name'    => '',
+    'score'   => 0.0,
+    'version' => 0,
+]);
+
+Assert::true($table->add('row', [
+    'id'      => 1,
+    'name'    => 'first',
+    'score'   => 1.5,
+    'version' => 1,
+]));
+Assert::false($table->add('row', ['name' => 'replaced']));
+Assert::same($table->get('row')['name'], 'first');
+
+Assert::false($table->update('missing', ['id' => 2]));
+Assert::true($table->update('row', ['name' => 'updated']));
+Assert::same($table->get('row'), [
+    'id'      => 1,
+    'name'    => 'updated',
+    'score'   => 1.5,
+    'version' => 1,
+]);
+Assert::true($table->update('row', []));
+Assert::true($table->update('row', [0 => 99, 'missing' => 99]));
+Assert::same($table->get('row')['id'], 1);
+
+Assert::false($table->cmpset('missing', ['version' => 1], ['version' => 2]));
+Assert::false($table->cmpset('row', ['id' => 2], ['name' => 'wrong']));
+Assert::same($table->get('row')['name'], 'updated');
+Assert::true($table->cmpset(
+    'row',
+    ['id'   => 1, 'name' => 'updated', 'version' => 1],
+    ['name' => 'compared', 'version' => 2],
+));
+Assert::same($table->get('row')['name'], 'compared');
+Assert::same($table->get('row')['version'], 2);
+Assert::true($table->cmpset('row', ['version' => 2], []));
+Assert::true($table->cmpset('row', ['version' => 2], [0 => 1, 'missing' => 1]));
+
+Assert::true($table->add('ignored', [
+    0         => 99,
+    'missing' => 99,
+    'id'      => 2,
+]));
+Assert::same($table->get('ignored'), [
+    'id'      => 2,
+    'name'    => '',
+    'score'   => 0.0,
+    'version' => 0,
+]);
+?>
+--EXPECT--

--- a/tests/swoole_table/getdel.phpt
+++ b/tests/swoole_table/getdel.phpt
@@ -1,0 +1,43 @@
+--TEST--
+swoole_table: get and delete
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 16);
+$table->column('score', Table::TYPE_FLOAT);
+$table->create();
+
+$binary = "a\0b";
+$table->set('row', ['id' => 42, 'name' => $binary, 'score' => 3.5]);
+Assert::same($table->getdel('row'), [
+    'id'    => 42,
+    'name'  => $binary,
+    'score' => 3.5,
+]);
+Assert::false($table->get('row'));
+Assert::false($table->getdel('row'));
+
+$table->set('id', ['id' => 7, 'name' => 'id', 'score' => 1.0]);
+Assert::same($table->getdel('id', 'id'), 7);
+Assert::false($table->get('id'));
+
+$table->set('score', ['id' => 8, 'name' => 'score', 'score' => 2.5]);
+Assert::same($table->getdel('score', 'score'), 2.5);
+Assert::false($table->get('score'));
+
+$table->set('name', ['id' => 9, 'name' => $binary, 'score' => 3.0]);
+Assert::same($table->getdel('name', 'name'), $binary);
+Assert::false($table->get('name'));
+
+$table->set('unknown', ['id' => 10, 'name' => 'kept', 'score' => 4.0]);
+Assert::false($table->getdel('unknown', 'missing'));
+Assert::same($table->get('unknown', 'name'), 'kept');
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

Add five atomic row operations to `Swoole\Table`:

```php
$table->add(string $key, array $values): bool;
$table->update(string $key, array $values): bool;
$table->cmpset(string $key, array $expected, array $values): bool;
$table->cmpdel(string $key, array $expected): bool;
$table->getdel(string $key, ?string $field = null): array|false|string|float|int;
```

Each method evaluates its condition and applies its mutation under one existing Table bucket lock.

## Motivation

Absent-only insertion currently requires separate calls:

```php
if (!$table->exists($key)) {
    $table->set($key, $values);
}
```

The bucket lock is released between those calls. Another process can change the row between the check and mutation, so callers need a second shared lock to make the operation safe. The same race affects read-compare-update and read-compare-delete sequences.

The new methods expose the transactions that the native Table lock can already serialize:

- `add()` inserts only when the physical row is absent.
- `update()` updates only when the row is present.
- `cmpset()` updates only when selected columns still match.
- `cmpdel()` deletes only when selected columns still match.
- `getdel()` returns and deletes a row atomically.

The names follow existing Swoole APIs such as `Swoole\Thread\Map::add()`, `Swoole\Thread\Map::update()`, and `Swoole\Atomic::cmpset()`.

## Implementation

Each operation hashes once, acquires one bucket lock, and traverses the collision chain once.

Comparisons use the stored representation. Integers and floats compare their exact native bytes. Strings compare their logical length and bytes. Expected strings are never truncated. This makes values read from Table suitable for later compare-and-set operations, including signed zero and NaN values.

Expected values are strict: they must contain at least one declared column, and any invalid key rejects the complete condition. Write values retain `set()` compatibility by ignoring numeric and unknown keys.

PHP values are converted before the shared-memory lock is acquired. This keeps callbacks, warnings, and string conversion outside the bucket spinlock. A small nesting guard prevents `destroy()` from invalidating native schema pointers during conversion.

`getdel()` copies the requested row or field while locked, deletes the row, releases the lock, and then converts the owned snapshot into a PHP value.

The existing `set()`, `get()`, and `del()` paths share the same collision lookup and deletion mechanics without changing their public behavior, flags, or statistics.

This change is limited to row existence and equality conditions. It does not add callbacks, predicates, TTL handling, aliases, or multi-row transactions.

## Testing

The native and PHP tests cover:

- absent-only and present-only writes;
- successful and failed comparisons;
- integer, float, binary-string, signed-zero, and NaN behavior;
- root, middle, and tail collision-chain mutations;
- allocation exhaustion and pool-slice reuse;
- operation statistics;
- full-row and field `getdel()` snapshots;
- multi-process contention and versioned compare-and-set retries;
- conversion re-entry and Table lifecycle safety.
