### PR TITLE
Reject incomplete task serialization

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -671,6 +671,10 @@ static TaskId php_swoole_server_task_pack(zval *zdata, EventData *task) {
         php_var_serialize(&serialized_data, zdata, &var_hash);
         PHP_VAR_SERIALIZE_DESTROY(var_hash);
 
+        if (UNEXPECTED(EG(exception))) {
+            smart_str_free(&serialized_data);
+            return -1;
+        }
         if (!serialized_data.s) {
             return -1;
         }
@@ -1087,6 +1091,11 @@ static bool php_swoole_server_task_finish(Server *serv, zval *zdata, EventData *
         PHP_VAR_SERIALIZE_INIT(var_hash);
         php_var_serialize(&serialized_data, zdata, &var_hash);
         PHP_VAR_SERIALIZE_DESTROY(var_hash);
+
+        if (UNEXPECTED(EG(exception)) || !serialized_data.s) {
+            smart_str_free(&serialized_data);
+            return false;
+        }
         data_str = ZSTR_VAL(serialized_data.s);
         data_len = ZSTR_LEN(serialized_data.s);
 
@@ -1342,9 +1351,13 @@ static int php_swoole_server_onTask(Server *serv, EventData *req) {
         zval_ptr_dtor(&argv[1]);
     }
 
-    if (!ZVAL_IS_NULL(&retval)) {
+    if (Z_TYPE(retval) > IS_NULL) {
         php_swoole_server_task_finish(serv, &retval, req);
         zval_ptr_dtor(&retval);
+        // the result is serialized after zend::function::call() has already checked for callback exceptions
+        if (UNEXPECTED(EG(exception))) {
+            zend_exception_error(EG(exception), E_ERROR);
+        }
     }
 
     return SW_OK;

--- a/tests/swoole_server/sendMessage_serialize_exception.phpt
+++ b/tests/swoole_server/sendMessage_serialize_exception.phpt
@@ -1,0 +1,62 @@
+--TEST--
+swoole_server: sendMessage serialization exception
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Server;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager();
+
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'package_eof'    => "\r\n",
+        'open_eof_check' => true,
+        'open_eof_split' => true,
+    ]);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 10));
+    echo $client->recv();
+    echo $client->recv();
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS, SWOOLE_SOCK_TCP);
+    $server->set([
+        'log_file'   => '/dev/null',
+        'worker_num' => 2,
+    ]);
+    $server->on('workerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('connect', function (Server $server, int $fd) {
+        try {
+            $server->sendMessage([1, $server], 1 - $server->getWorkerId());
+        } catch (Throwable $exception) {
+            Assert::contains($exception->getMessage(), 'Serialization');
+            Assert::true($server->send($fd, "CAUGHT\r\n"));
+        }
+
+        Assert::true($server->sendMessage(['fd' => $fd], 1 - $server->getWorkerId()));
+    });
+    $server->on('receive', function () {});
+    $server->on('pipeMessage', function (Server $server, int $workerId, array $message) {
+        Assert::true($server->send($message['fd'], "OK\r\n"));
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+CAUGHT
+OK

--- a/tests/swoole_server/task/finish_serialize_exception.phpt
+++ b/tests/swoole_server/task/finish_serialize_exception.phpt
@@ -1,0 +1,81 @@
+--TEST--
+swoole_server/task: finish serialization exception
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Server;
+use Swoole\Server\Task;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager();
+
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'package_eof'    => "\r\n",
+        'open_eof_check' => true,
+        'open_eof_split' => true,
+    ]);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 10));
+    Assert::greaterThan($client->send("START\r\n"), 0);
+    echo $client->recv();
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS, SWOOLE_SOCK_TCP);
+    $server->set([
+        'log_file'              => '/dev/null',
+        'worker_num'            => 1,
+        'task_worker_num'       => 1,
+        'task_enable_coroutine' => true,
+        'package_eof'           => "\r\n",
+        'open_eof_check'        => true,
+    ]);
+    $server->on('workerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('receive', function (Server $server, int $fd) {
+        Assert::integer($server->task($fd));
+    });
+    $server->on('task', function (Server $server, Task $task) {
+        $markers = [];
+
+        try {
+            $task->finish([1, $server]);
+        } catch (Throwable $exception) {
+            Assert::contains($exception->getMessage(), 'Serialization');
+            $markers[] = 'NESTED';
+        }
+
+        try {
+            $task->finish($server);
+        } catch (Throwable $exception) {
+            Assert::contains($exception->getMessage(), 'Serialization');
+            $markers[] = 'ROOT';
+        }
+
+        $markers[] = 'OK';
+        Assert::true($task->finish([$task->data, $markers]));
+    });
+    $server->on('finish', function (Server $server, int $taskId, array $result) {
+        [$fd, $markers] = $result;
+        Assert::true($server->send($fd, implode("\n", $markers) . "\r\n"));
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+NESTED
+ROOT
+OK

--- a/tests/swoole_server/task/return_serialize_exception.phpt
+++ b/tests/swoole_server/task/return_serialize_exception.phpt
@@ -1,0 +1,123 @@
+--TEST--
+swoole_server/task: return serialization exception
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Server;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager();
+
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    $client->set([
+        'package_eof'    => "\r\n",
+        'open_eof_check' => true,
+        'open_eof_split' => true,
+    ]);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 10));
+
+    $request = function (string $command) use ($client) {
+        Assert::greaterThan($client->send($command . "\r\n"), 0);
+        $response = $client->recv();
+        Assert::string($response);
+
+        return unserialize(trim($response));
+    };
+
+    $labels = [];
+
+    $pid = $request('pid');
+    Assert::integer($pid);
+    $labels[] = 'PID';
+
+    Assert::false($request('throw'));
+    $labels[] = 'THROW';
+
+    Assert::false($request('invalid'));
+    $labels[] = 'INVALID';
+
+    Assert::same($request('zero'), 0);
+    $labels[] = 'ZERO';
+
+    Assert::same($request('valid'), [$pid, 'OK']);
+    $labels[] = 'VALID';
+
+    echo implode("\n", $labels), "\n";
+
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS, SWOOLE_SOCK_TCP);
+    $server->set([
+        'enable_coroutine' => false,
+        'log_file'         => '/dev/null',
+        'worker_num'       => 1,
+        'task_worker_num'  => 1,
+        'package_eof'      => "\r\n",
+        'open_eof_check'   => true,
+    ]);
+    $server->on('workerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('receive', function (Server $server, int $fd, int $reactorId, string $data) {
+        $command = trim($data);
+        $result  = in_array($command, ['throw', 'invalid'], true)
+            ? $server->taskwait($command)
+            : $server->taskwait($command, 5);
+        Assert::true($server->send($fd, serialize($result) . "\r\n"));
+    });
+    $server->on('task', function (Server $server, int $taskId, int $workerId, string $command) {
+        return match ($command) {
+            'pid'     => getmypid(),
+            'throw'   => throw new RuntimeException('task callback failed'),
+            'invalid' => $server,
+            'zero'    => 0,
+            'valid'   => [getmypid(), 'OK'],
+        };
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECTF--
+
+Fatal error: Uncaught RuntimeException: task callback failed in %s:%d
+Stack trace:
+#0 [internal function]: {closure%S}(Object(Swoole\Server), %d, %d, 'throw')
+#1 %s(%d): Swoole\Server->start()
+#2 [internal function]: {closure%S}()
+#3 %s(%d): call_user_func(Object(Closure))
+#4 %s(%d): SwooleTest\ProcessManager->runChildFunc()
+#5 [internal function]: SwooleTest\ProcessManager->%s(Object(Swoole\Process))
+#6 %s(%d): Swoole\Process->start()
+#7 %s(%d): SwooleTest\ProcessManager->run()
+#8 {main}
+  thrown in %s on line %d
+
+Fatal error: Uncaught Exception: Serialization of 'Swoole\Server' is not allowed in %s:%d
+Stack trace:
+#0 %s(%d): Swoole\Server->start()
+#1 [internal function]: {closure%S}()
+#2 %s(%d): call_user_func(Object(Closure))
+#3 %s(%d): SwooleTest\ProcessManager->runChildFunc()
+#4 [internal function]: SwooleTest\ProcessManager->%s(Object(Swoole\Process))
+#5 %s(%d): Swoole\Process->start()
+#6 %s(%d): SwooleTest\ProcessManager->run()
+#7 {main}
+  thrown in %s on line %d
+PID
+THROW
+INVALID
+ZERO
+VALID


### PR DESCRIPTION
## Summary

PHP serialization can throw after writing a partial buffer. The task packing path currently treats that non-null buffer as a complete payload, while task completion can dereference a missing buffer.

This change:

- rejects incomplete task and inter-worker payloads while preserving the original exception;
- rejects failed task results before they reach the completion transport;
- avoids treating an undefined callback return as an automatic result;
- preserves legitimate falsey results, including integer zero;
- handles automatic-result serialization exceptions at the boundary where they can actually occur.

There is no public API change. Existing task-worker lifecycle and batch behavior remain unchanged.

## Testing

Added focused PHPT coverage for:

- inter-worker messages after nested serialization failure;
- explicit task completion with partial and absent serializer buffers;
- thrown callbacks, invalid automatic results, legitimate zero results, and successful follow-up work in the same task worker.

The focused tests and the broader `swoole_server` test route pass with no new failures.
