### PR TITLE
Fix NULL pointer dereference in server port-property lookup on close

### DIFF
--- a/ext-src/php_swoole_server.h
+++ b/ext-src/php_swoole_server.h
@@ -100,8 +100,12 @@ struct ServerObject {
     }
 
     bool isset_callback(ListenPort *port, int event_type) const {
-        return (php_swoole_server_get_port_property(port)->callbacks[event_type] ||
-                php_swoole_server_get_port_property(serv->get_primary_port())->callbacks[event_type]);
+        ServerPortProperty *port_property = php_swoole_server_get_port_property(port);
+        if (port_property && port_property->callbacks[event_type]) {
+            return true;
+        }
+        ServerPortProperty *primary_property = php_swoole_server_get_port_property(serv->get_primary_port());
+        return primary_property && primary_property->callbacks[event_type];
     }
 
     bool isset_callback(int event_type) const {

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -167,6 +167,9 @@ zval *php_swoole_server_zval_ptr(Server *serv) {
 }
 
 ServerPortProperty *php_swoole_server_get_port_property(ListenPort *port) {
+    if (sw_unlikely(!port)) {
+        return nullptr;
+    }
 #ifdef SW_THREAD
     return swoole_server_port_properties.at(port->object_id);
 #else
@@ -637,12 +640,12 @@ void php_swoole_server_minit(int module_number) {
 
 zend::Callable *php_swoole_server_get_callback(Server *serv, int server_fd, int event_type) {
     ListenPort *port = serv->get_port_by_server_fd(server_fd);
-    ServerPortProperty *property = php_swoole_server_get_port_property(port);
-    zend::Callable *cb;
-
     if (sw_unlikely(!port)) {
         return nullptr;
     }
+
+    ServerPortProperty *property = php_swoole_server_get_port_property(port);
+    zend::Callable *cb;
     if (property && ((cb = property->callbacks[event_type]))) {
         return cb;
     } else {


### PR DESCRIPTION
### What

`php_swoole_server_get_port_property()` reads `port->ptr` (or, under `SW_THREAD`, `port->object_id`) without checking `port` for NULL. On a connection close, `php_swoole_server_onClose()` resolves the handler via `php_swoole_server_get_callback(serv, info->server_fd, ...)`, and `get_port_by_server_fd()` returns NULL when that fd's connection slot has already been reused or torn down before the queued close event runs (a small TOCTOU window that opens under connection churn). `get_callback()` then calls `get_port_property()` on the NULL port and the worker segfaults at the offset of `ptr` in `ListenPort`.

### The fix

1. `php_swoole_server_get_port_property()`: return `nullptr` for a NULL port. Root-cause guard; protects every current and future caller, including the `SW_THREAD` path.
2. `php_swoole_server_get_callback()`: move the existing `if (sw_unlikely(!port)) return nullptr;` ahead of the property lookup, matching master's control flow.
3. `ServerObject::isset_callback(ListenPort *, int)`: null-check the property results before dereferencing them.

No behavior change on the normal path; only NULL inputs that previously crashed now resolve to "no handler" (`onClose` skips the call when the callback is NULL).

### On a regression test

I did not add one. The crash is a close-time race: the trigger (`get_port_by_server_fd()` returning NULL for an in-flight close) is not reachable deterministically from PHP userland, and the window is too small to hit reliably under synthetic load. A test that passes on the buggy build would be false assurance, so the change rests on the null-safety of the guarded dereferences, which is clear by inspection.

### Notes

- Diff is 2 files, +12/-5.
- Targeted at `6.1` (the oldest affected supported branch); the same NULL dereference is present on `6.2` and `master`, so this rides the `6.1 -> 6.2 -> master` forward-merge.
