### PR TITLE
Fix reentrant argument conversion in Table and constructors

### DIFF
--- a/core-tests/src/memory/table.cpp
+++ b/core-tests/src/memory/table.cpp
@@ -241,6 +241,80 @@ TEST(table, conditional_writes) {
     ASSERT_EQ(table.get("php").id, 2);
 }
 
+TEST(table, values_set) {
+    table_t table(128);
+    auto ptr = table.ptr();
+
+    bool out_of_space = true;
+    ASSERT_TRUE(ptr->set("new", 3, {table_int(ptr, "id", 1)}, &out_of_space));
+    ASSERT_FALSE(out_of_space);
+    auto row = table.get("new");
+    ASSERT_EQ(row.id, 1);
+    ASSERT_EQ(row.name, "");
+    ASSERT_EQ(row.score, 0);
+    ASSERT_EQ(table.count(), 1);
+    ASSERT_EQ(ptr->insert_count, 1);
+    ASSERT_EQ(ptr->update_count, 0);
+
+    ASSERT_TRUE(ptr->set("new", 3, {table_string(ptr, "name", "updated")}, &out_of_space));
+    ASSERT_FALSE(out_of_space);
+    row = table.get("new");
+    ASSERT_EQ(row.id, 1);
+    ASSERT_EQ(row.name, "updated");
+    ASSERT_EQ(row.score, 0);
+    ASSERT_EQ(table.count(), 1);
+    ASSERT_EQ(ptr->insert_count, 1);
+    ASSERT_EQ(ptr->update_count, 1);
+
+    ASSERT_TRUE(ptr->set("empty", 5, {}));
+    ASSERT_TRUE(ptr->set("empty", 5, {}));
+    ASSERT_EQ(table.count(), 2);
+    ASSERT_EQ(ptr->insert_count, 2);
+    ASSERT_EQ(ptr->update_count, 2);
+
+    const auto insert_count = ptr->insert_count;
+    const auto update_count = ptr->update_count;
+    out_of_space = true;
+    ASSERT_FALSE(ptr->set("", 0, {}, &out_of_space));
+    ASSERT_FALSE(out_of_space);
+    ASSERT_EQ(table.count(), 2);
+    ASSERT_EQ(ptr->insert_count, insert_count);
+    ASSERT_EQ(ptr->update_count, update_count);
+}
+
+TEST(table, values_set_exhaustion) {
+    table_t table(4, 1.0);
+    auto ptr = table.ptr();
+    ptr->set_hash_func([](const char *key, size_t len) -> uint64_t { return 1; });
+
+    const size_t capacity = 1 + ptr->get_total_slice_num();
+    for (size_t i = 0; i < capacity; i++) {
+        std::string key = "k" + std::to_string(i);
+        ASSERT_TRUE(ptr->set(key.data(), key.size(), table_row(ptr, {key, (long) i, (double) i})));
+    }
+
+    const auto insert_count = ptr->insert_count;
+    const auto update_count = ptr->update_count;
+    TableRow *root = nullptr;
+    ASSERT_NE(ptr->get("k0", 2, &root), nullptr);
+    root->unlock();
+
+    bool out_of_space = false;
+    ASSERT_FALSE(ptr->set("overflow", 8, table_row(ptr, {"overflow", 99, 99}), &out_of_space));
+    ASSERT_TRUE(out_of_space);
+    ASSERT_EQ(root->lock_, 0);
+    ASSERT_EQ(table.count(), capacity);
+    ASSERT_EQ(ptr->insert_count, insert_count);
+    ASSERT_EQ(ptr->update_count, update_count);
+
+    ASSERT_TRUE(ptr->update("k0", 2, {table_int(ptr, "id", 100)}));
+    ASSERT_EQ(table.get("k0").id, 100);
+    ASSERT_TRUE(ptr->cmpdel("k1", 2, {table_int(ptr, "id", 1)}));
+    ASSERT_TRUE(ptr->set("replacement", 11, table_row(ptr, {"replacement", 101, 101}), &out_of_space));
+    ASSERT_FALSE(out_of_space);
+    ASSERT_EQ(table.count(), capacity);
+}
+
 TEST(table, exact_comparisons) {
     table_t table(128);
     auto ptr = table.ptr();

--- a/ext-src/swoole_coroutine_lock.cc
+++ b/ext-src/swoole_coroutine_lock.cc
@@ -95,18 +95,19 @@ void php_swoole_coroutine_lock_minit(int module_number) {
 }
 
 static PHP_METHOD(swoole_coroutine_lock, __construct) {
-    CoroutineLock *lock = co_lock_get_ptr(ZEND_THIS);
-    if (lock != nullptr) {
-        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zend_bool shared = false;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
     Z_PARAM_BOOL(shared)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    CoroutineLock *lock = co_lock_get_ptr(ZEND_THIS);
+    if (lock != nullptr) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
 
     lock = new CoroutineLock(shared);
     co_lock_set_ptr(ZEND_THIS, lock);

--- a/ext-src/swoole_lock.cc
+++ b/ext-src/swoole_lock.cc
@@ -119,18 +119,19 @@ void php_swoole_lock_minit(int module_number) {
 }
 
 static PHP_METHOD(swoole_lock, __construct) {
-    Lock *lock = lock_get_ptr(ZEND_THIS);
-    if (lock != nullptr) {
-        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zend_long type = Lock::MUTEX;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
     Z_PARAM_LONG(type)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    Lock *lock = lock_get_ptr(ZEND_THIS);
+    if (lock != nullptr) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
 
     switch (type) {
 #ifdef HAVE_SPINLOCK

--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -258,9 +258,21 @@ void php_swoole_process_minit(int module_number) {
 }
 
 static PHP_METHOD(swoole_process, __construct) {
-    auto po = php_swoole_process_fetch_object(ZEND_THIS);
-    Server *server = sw_server();
+    zend::Function func;
+    zend_bool redirect_stdin_and_stdout = false;
+    zend_long pipe_type = PIPE_TYPE_DGRAM;
+    zend_bool enable_coroutine = false;
 
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 4)
+    Z_PARAM_FUNC(func.fci, func.fci_cache);
+    Z_PARAM_OPTIONAL
+    Z_PARAM_BOOL(redirect_stdin_and_stdout)
+    Z_PARAM_LONG(pipe_type)
+    Z_PARAM_BOOL(enable_coroutine)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    // Callable resolution can run user code, so inspect native state only after parsing.
+    auto po = php_swoole_process_fetch_object(ZEND_THIS);
     if (po->worker) {
         zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
         RETURN_FALSE;
@@ -272,6 +284,7 @@ static PHP_METHOD(swoole_process, __construct) {
         RETURN_FALSE;
     }
 
+    Server *server = sw_server();
     if (server && server->is_started() && server->is_master()) {
         zend_throw_error(nullptr, "%s can't be used in master process", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
         RETURN_FALSE;
@@ -282,21 +295,8 @@ static PHP_METHOD(swoole_process, __construct) {
         RETURN_FALSE;
     }
 
-    zend::Function func;
-    zend_bool redirect_stdin_and_stdout = false;
-    zend_long pipe_type = PIPE_TYPE_DGRAM;
-    zend_bool enable_coroutine = false;
-
-    po->worker = new Worker();
-    Worker *process = po->worker;
-
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 4)
-    Z_PARAM_FUNC(func.fci, func.fci_cache);
-    Z_PARAM_OPTIONAL
-    Z_PARAM_BOOL(redirect_stdin_and_stdout)
-    Z_PARAM_LONG(pipe_type)
-    Z_PARAM_BOOL(enable_coroutine)
-    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+    Worker *process = new Worker();
+    po->worker = process;
 
     if (server && server->is_worker_thread()) {
         Worker *shared_worker;

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -233,9 +233,9 @@ static void server_free_object(zend_object *object) {
     delete property;
 
     zend_object_std_dtor(object);
-    if (serv && serv->is_master()) {
+    if (serv && (serv->is_master() || !serv->is_created())) {
 #ifdef SW_THREAD
-        if (serv->is_thread_mode()) {
+        if (serv->is_thread_mode() && serv->private_data_4) {
             zend_string_release((zend_string *) serv->private_data_4);
         }
 #endif
@@ -1963,13 +1963,6 @@ static void server_ctor(zval *zserv, Server *serv) {
 }
 
 static PHP_METHOD(swoole_server, __construct) {
-    ServerObject *server_object = server_fetch_object(Z_OBJ_P(ZEND_THIS));
-    Server *serv = server_object->serv;
-    if (serv) {
-        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zval *zserv = ZEND_THIS;
     char *host;
     size_t host_len = 0;
@@ -1990,6 +1983,14 @@ static PHP_METHOD(swoole_server, __construct) {
     Z_PARAM_LONG(serv_mode)
     Z_PARAM_LONG(sock_type)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    ServerObject *server_object = server_fetch_object(Z_OBJ_P(ZEND_THIS));
+    Server *serv = server_object->serv;
+    if (serv) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
 
     if (serv_mode != Server::MODE_BASE
 #ifndef _WIN32
@@ -2033,6 +2034,7 @@ static PHP_METHOD(swoole_server, __construct) {
     if (serv_port == 0 && strcasecmp(host, "SYSTEMD") == 0) {
         if (serv->add_systemd_socket() <= 0) {
             zend_throw_error(nullptr, "failed to add systemd socket");
+            delete serv;
             RETURN_FALSE;
         }
     } else {
@@ -2045,6 +2047,7 @@ static PHP_METHOD(swoole_server, __construct) {
                                     serv_port,
                                     swoole_strerror(swoole_get_last_error()),
                                     swoole_get_last_error());
+            delete serv;
             RETURN_FALSE;
         }
     }

--- a/ext-src/swoole_table.cc
+++ b/ext-src/swoole_table.cc
@@ -293,12 +293,6 @@ void php_swoole_table_minit(int module_number) {
 }
 
 PHP_METHOD(swoole_table, __construct) {
-    Table *table = table_get_ptr(ZEND_THIS);
-    if (table) {
-        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zend_long table_size;
     double conflict_proportion = SW_TABLE_CONFLICT_PROPORTION;
 
@@ -307,6 +301,13 @@ PHP_METHOD(swoole_table, __construct) {
     Z_PARAM_OPTIONAL
     Z_PARAM_DOUBLE(conflict_proportion)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    Table *table = table_get_ptr(ZEND_THIS);
+    if (table) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
 
     table = Table::make(table_size, static_cast<float>(conflict_proportion));
     if (table == nullptr) {
@@ -790,14 +791,15 @@ static PHP_METHOD(swoole_table, cmpdel) {
 static PHP_METHOD(swoole_table, count) {
 #define COUNT_NORMAL 0
 #define COUNT_RECURSIVE 1
-    Table *table = table_get_ptr(ZEND_THIS);
-    if (!table) {
-        RETURN_LONG(0);
-    }
-
     zend_long mode = COUNT_NORMAL;
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &mode) == FAILURE) {
         RETURN_FALSE;
+    }
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    Table *table = table_get_ptr(ZEND_THIS);
+    if (!table) {
+        RETURN_LONG(0);
     }
 
     if (mode == COUNT_NORMAL) {

--- a/ext-src/swoole_table.cc
+++ b/ext-src/swoole_table.cc
@@ -320,7 +320,6 @@ PHP_METHOD(swoole_table, __construct) {
 }
 
 PHP_METHOD(swoole_table, column) {
-    Table *table = table_get_and_check_ptr(ZEND_THIS);
     char *name;
     size_t len;
     long type;
@@ -329,6 +328,8 @@ PHP_METHOD(swoole_table, column) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|l", &name, &len, &type, &size) == FAILURE) {
         RETURN_FALSE;
     }
+
+    Table *table = table_get_and_check_ptr(ZEND_THIS);
     if (type == TableColumn::TYPE_STRING) {
         if (size < 1) {
             php_swoole_fatal_error(E_WARNING, "the length of string type values has to be more than zero");
@@ -372,7 +373,6 @@ static PHP_METHOD(swoole_table, destroy) {
 }
 
 static PHP_METHOD(swoole_table, set) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     zval *array;
     char *key;
     size_t keylen;
@@ -382,75 +382,26 @@ static PHP_METHOD(swoole_table, set) {
     Z_PARAM_ARRAY(array)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-    if (!table->ready()) {
-        php_swoole_fatal_error(E_ERROR, "the table object does not exist");
-        RETURN_FALSE;
-    }
-
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(keylen)) {
         RETURN_FALSE;
     }
 
-    int out_flags;
-    TableRow *_rowlock = nullptr;
-    TableRow *row = table->set(key, keylen, &_rowlock, &out_flags);
-    if (!row) {
-        if (_rowlock) {
-            _rowlock->unlock();
+    TableValues values;
+    if (!table_marshal_values(ZEND_THIS, table, Z_ARRVAL_P(array), key, keylen, TABLE_VALUE_WRITE, &values)) {
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
         }
-        php_swoole_error(E_WARNING, "failed to set('%*s'), unable to allocate memory", (int) keylen, key);
         RETURN_FALSE;
     }
 
-    HashTable *ht = Z_ARRVAL_P(array);
-
-    if (out_flags & SW_TABLE_FLAG_NEW_ROW) {
-        for (const auto col : *table->column_list) {
-            zval *zv = zend_hash_str_find(ht, col->name.c_str(), col->name.length());
-            if (zv == nullptr || ZVAL_IS_NULL(zv)) {
-                col->clear(row);
-            } else {
-                if (col->type == TableColumn::TYPE_STRING) {
-                    zend_string *str = zval_get_string(zv);
-                    row->set_value(col, ZSTR_VAL(str), ZSTR_LEN(str));
-                    zend_string_release(str);
-                } else if (col->type == TableColumn::TYPE_FLOAT) {
-                    double _value = zval_get_double(zv);
-                    row->set_value(col, &_value, 0);
-                } else {
-                    long _value = zval_get_long(zv);
-                    row->set_value(col, &_value, 0);
-                }
-            }
+    bool out_of_space = false;
+    if (!table->set(key, keylen, values, &out_of_space)) {
+        if (out_of_space) {
+            php_swoole_error(E_WARNING, "failed to set('%*s'), unable to allocate memory", (int) keylen, key);
         }
-    } else {
-        const char *k;
-        uint32_t klen;
-        int ktype;
-        zval *zv;
-        SW_HASHTABLE_FOREACH_START2(ht, k, klen, ktype, zv) {
-            if (k == nullptr) {
-                continue;
-            }
-            TableColumn *col = table->get_column(std::string(k, klen));
-            if (col == nullptr) {
-                continue;
-            } else if (col->type == TableColumn::TYPE_STRING) {
-                zend_string *str = zval_get_string(zv);
-                row->set_value(col, ZSTR_VAL(str), ZSTR_LEN(str));
-                zend_string_release(str);
-            } else if (col->type == TableColumn::TYPE_FLOAT) {
-                double _value = zval_get_double(zv);
-                row->set_value(col, &_value, 0);
-            } else {
-                long _value = zval_get_long(zv);
-                row->set_value(col, &_value, 0);
-            }
-        }
-        (void) ktype;
-        SW_HASHTABLE_FOREACH_END();
+        RETURN_FALSE;
     }
-    _rowlock->unlock();
     RETURN_TRUE;
 }
 
@@ -549,7 +500,6 @@ static PHP_METHOD(swoole_table, cmpset) {
 }
 
 static PHP_METHOD(swoole_table, incr) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -560,6 +510,7 @@ static PHP_METHOD(swoole_table, incr) {
         RETURN_FALSE;
     }
 
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(key_len)) {
         RETURN_FALSE;
     }
@@ -574,6 +525,29 @@ static PHP_METHOD(swoole_table, incr) {
         RETURN_FALSE;
     }
 
+    double double_value = 1;
+    long long_value = 1;
+    if (incrby) {
+        // Convert before acquiring the bucket lock because conversion can execute user code.
+        {
+            TableObject *object = table_fetch_object(Z_OBJ_P(ZEND_THIS));
+            object->value_conversion_depth++;
+            ON_SCOPE_EXIT {
+                object->value_conversion_depth--;
+            };
+
+            if (column->type == TableColumn::TYPE_FLOAT) {
+                double_value = zval_get_double(incrby);
+            } else {
+                long_value = zval_get_long(incrby);
+            }
+        }
+
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+    }
+
     int out_flags;
     TableRow *_rowlock = nullptr;
     TableRow *row = table->set(key, key_len, &_rowlock, &out_flags);
@@ -592,21 +566,13 @@ static PHP_METHOD(swoole_table, incr) {
     if (column->type == TableColumn::TYPE_FLOAT) {
         double set_value = 0;
         memcpy(&set_value, row->data + column->index, sizeof(set_value));
-        if (incrby) {
-            set_value += zval_get_double(incrby);
-        } else {
-            set_value += 1;
-        }
+        set_value += double_value;
         row->set_value(column, &set_value, 0);
         RETVAL_DOUBLE(set_value);
     } else {
         long set_value = 0;
         memcpy(&set_value, row->data + column->index, sizeof(set_value));
-        if (incrby) {
-            set_value += zval_get_long(incrby);
-        } else {
-            set_value += 1;
-        }
+        set_value += long_value;
         row->set_value(column, &set_value, 0);
         RETVAL_LONG(set_value);
     }
@@ -614,7 +580,6 @@ static PHP_METHOD(swoole_table, incr) {
 }
 
 static PHP_METHOD(swoole_table, decr) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t key_len;
     char *col;
@@ -625,6 +590,7 @@ static PHP_METHOD(swoole_table, decr) {
         RETURN_FALSE;
     }
 
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(key_len)) {
         RETURN_FALSE;
     }
@@ -639,6 +605,29 @@ static PHP_METHOD(swoole_table, decr) {
         RETURN_FALSE;
     }
 
+    double double_value = 1;
+    long long_value = 1;
+    if (decrby) {
+        // Convert before acquiring the bucket lock because conversion can execute user code.
+        {
+            TableObject *object = table_fetch_object(Z_OBJ_P(ZEND_THIS));
+            object->value_conversion_depth++;
+            ON_SCOPE_EXIT {
+                object->value_conversion_depth--;
+            };
+
+            if (column->type == TableColumn::TYPE_FLOAT) {
+                double_value = zval_get_double(decrby);
+            } else {
+                long_value = zval_get_long(decrby);
+            }
+        }
+
+        if (UNEXPECTED(EG(exception))) {
+            RETURN_THROWS();
+        }
+    }
+
     int out_flags;
     TableRow *_rowlock = nullptr;
     TableRow *row = table->set(key, key_len, &_rowlock, &out_flags);
@@ -657,21 +646,13 @@ static PHP_METHOD(swoole_table, decr) {
     if (column->type == TableColumn::TYPE_FLOAT) {
         double set_value = 0;
         memcpy(&set_value, row->data + column->index, sizeof(set_value));
-        if (decrby) {
-            set_value -= zval_get_double(decrby);
-        } else {
-            set_value -= 1;
-        }
+        set_value -= double_value;
         row->set_value(column, &set_value, 0);
         RETVAL_DOUBLE(set_value);
     } else {
         long set_value = 0;
         memcpy(&set_value, row->data + column->index, sizeof(set_value));
-        if (decrby) {
-            set_value -= zval_get_long(decrby);
-        } else {
-            set_value -= 1;
-        }
+        set_value -= long_value;
         row->set_value(column, &set_value, 0);
         RETVAL_LONG(set_value);
     }
@@ -679,7 +660,6 @@ static PHP_METHOD(swoole_table, decr) {
 }
 
 static PHP_METHOD(swoole_table, get) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
     zend_string *field = nullptr;
@@ -690,6 +670,7 @@ static PHP_METHOD(swoole_table, get) {
     Z_PARAM_STR_OR_NULL(field)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(keylen)) {
         RETURN_FALSE;
     }
@@ -750,13 +731,14 @@ static PHP_METHOD(swoole_table, getdel) {
 }
 
 static PHP_METHOD(swoole_table, exists) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &keylen) == FAILURE) {
         RETURN_FALSE;
     }
+
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(keylen)) {
         RETURN_FALSE;
     }
@@ -764,7 +746,6 @@ static PHP_METHOD(swoole_table, exists) {
 }
 
 static PHP_METHOD(swoole_table, del) {
-    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     char *key;
     size_t keylen;
 
@@ -772,6 +753,7 @@ static PHP_METHOD(swoole_table, del) {
     Z_PARAM_STRING(key, keylen)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    Table *table = table_get_and_check_ptr2(ZEND_THIS);
     if (!table_check_key_length(keylen)) {
         RETURN_FALSE;
     }

--- a/ext-src/swoole_thread_barrier.cc
+++ b/ext-src/swoole_thread_barrier.cc
@@ -114,16 +114,17 @@ void php_swoole_thread_barrier_minit(int module_number) {
 }
 
 static PHP_METHOD(swoole_thread_barrier, __construct) {
+    zend_long count;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_LONG(count)
+    ZEND_PARSE_PARAMETERS_END();
+
+    // Parameter parsing can run user code, so inspect native state only after it.
     auto bo = barrier_fetch_object(Z_OBJ_P(ZEND_THIS));
     if (bo->barrier != nullptr) {
         zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
         return;
     }
-
-    zend_long count;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-    Z_PARAM_LONG(count)
-    ZEND_PARSE_PARAMETERS_END();
 
     if (count < 2) {
         zend_throw_exception(

--- a/ext-src/swoole_thread_lock.cc
+++ b/ext-src/swoole_thread_lock.cc
@@ -154,18 +154,19 @@ void php_swoole_thread_lock_minit(int module_number) {
 }
 
 static PHP_METHOD(swoole_thread_lock, __construct) {
-    auto o = thread_lock_fetch_object(Z_OBJ_P(ZEND_THIS));
-    if (o->lock != nullptr) {
-        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
-        RETURN_FALSE;
-    }
-
     zend_long type = Lock::MUTEX;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
     Z_PARAM_OPTIONAL
     Z_PARAM_LONG(type)
     ZEND_PARSE_PARAMETERS_END();
+
+    // Parameter parsing can run user code, so inspect native state only after it.
+    auto o = thread_lock_fetch_object(Z_OBJ_P(ZEND_THIS));
+    if (o->lock != nullptr) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
 
     o->lock = new ThreadLockResource(type);
 }

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -341,7 +341,7 @@ struct ListenPort {
     }
 
     explicit ListenPort(Server *server);
-    ~ListenPort() = default;
+    ~ListenPort();
     int listen();
     void close();
     bool import(int sock);

--- a/include/swoole_table.h
+++ b/include/swoole_table.h
@@ -165,6 +165,7 @@ class Table {
     bool add_column(const std::string &name, enum TableColumn::Type type, size_t size);
     TableColumn *get_column(const std::string &key) const;
     TableRow *set(const char *key, size_t keylen, TableRow **rowlock, int *out_flags);
+    bool set(const char *key, size_t keylen, const TableValues &values, bool *out_of_space = nullptr);
     TableRow *get(const char *key, size_t keylen, TableRow **rowlock) const;
     bool add(const char *key, size_t keylen, const TableValues &values, bool *out_of_space = nullptr);
     bool update(const char *key, size_t keylen, const TableValues &values);

--- a/src/memory/table.cc
+++ b/src/memory/table.cc
@@ -538,6 +538,35 @@ TableRow *Table::set(const char *key, size_t keylen, TableRow **rowlock, int *ou
     return row;
 }
 
+bool Table::set(const char *key, size_t keylen, const TableValues &values, bool *out_of_space) {
+    if (out_of_space) {
+        *out_of_space = false;
+    }
+    if (!is_valid_key_length(keylen)) {
+        return false;
+    }
+
+    TableRow *rowlock = nullptr;
+    int out_flags = 0;
+    TableRow *row = set(key, keylen, &rowlock, &out_flags);
+    if (row == nullptr) {
+        if (rowlock) {
+            rowlock->unlock();
+            if (out_of_space) {
+                *out_of_space = true;
+            }
+        }
+        return false;
+    }
+
+    if (out_flags & SW_TABLE_FLAG_NEW_ROW) {
+        clear_row(row);
+    }
+    apply_values(row, values);
+    rowlock->unlock();
+    return true;
+}
+
 bool Table::add(const char *key, size_t keylen, const TableValues &values, bool *out_of_space) {
     if (out_of_space) {
         *out_of_space = false;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -772,6 +772,9 @@ Server::~Server() {
     if (!is_shutdown() && getpid() == gs->master_pid) {
         destroy();
     }
+    if (SwooleG.server == this) {
+        SwooleG.server = nullptr;
+    }
     for (auto port : ports) {
         delete port;
     }

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -42,6 +42,16 @@ ListenPort::ListenPort(Server *server) {
     protocol.private_data_2 = server;
 }
 
+ListenPort::~ListenPort() {
+    if (socket) {
+        socket->free();
+        socket = nullptr;
+    }
+#ifdef SW_SUPPORT_DTLS
+    delete dtls_sessions;
+#endif
+}
+
 bool ListenPort::ssl_add_sni_cert(const std::string &name, const std::shared_ptr<SSLContext> &ctx) {
     if (!ssl_context_create(ctx.get())) {
         return false;
@@ -323,6 +333,7 @@ bool ListenPort::import(int sock) {
     _fail:
         tmp_sock->move_fd();
         delete tmp_sock;
+        socket = nullptr;
         return false;
     }
 
@@ -776,6 +787,7 @@ void ListenPort::close() {
         }
 #ifdef SW_SUPPORT_DTLS
         delete dtls_sessions;
+        dtls_sessions = nullptr;
 #endif
     }
 
@@ -882,6 +894,7 @@ int ListenPort::create_socket() {
     __cleanup:
         swoole_set_last_error(errno);
         socket->free();
+        socket = nullptr;
         return SW_ERR;
     }
 

--- a/tests/swoole_coroutine_lock/constructor_reentrancy.phpt
+++ b/tests/swoole_coroutine_lock/constructor_reentrancy.phpt
@@ -1,0 +1,37 @@
+--TEST--
+swoole_coroutine_lock: constructor parses before native state
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Lock;
+use function Swoole\Coroutine\run;
+
+$lock = (new ReflectionClass(Lock::class))->newInstanceWithoutConstructor();
+$reentered = false;
+set_error_handler(function () use ($lock, &$reentered): bool {
+    $reentered = true;
+    $lock->__construct(false);
+
+    return true;
+});
+try {
+    try {
+        $lock->__construct(null);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Coroutine\Lock can only be called once');
+    }
+} finally {
+    restore_error_handler();
+}
+
+Assert::true($reentered);
+run(function () use ($lock): void {
+    Assert::true($lock->lock());
+    Assert::true($lock->unlock());
+});
+?>
+--EXPECT--

--- a/tests/swoole_lock/constructor_reentrancy.phpt
+++ b/tests/swoole_lock/constructor_reentrancy.phpt
@@ -1,0 +1,34 @@
+--TEST--
+swoole_lock: constructor parses before native state
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Lock;
+
+$lock = (new ReflectionClass(Lock::class))->newInstanceWithoutConstructor();
+$reentered = false;
+set_error_handler(function () use ($lock, &$reentered): bool {
+    $reentered = true;
+    $lock->__construct(SWOOLE_MUTEX);
+
+    return true;
+});
+try {
+    try {
+        $lock->__construct(3.5);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Lock can only be called once');
+    }
+} finally {
+    restore_error_handler();
+}
+
+Assert::true($reentered);
+Assert::true($lock->lock());
+Assert::true($lock->unlock());
+?>
+--EXPECT--

--- a/tests/swoole_process/constructor_reentrancy.phpt
+++ b/tests/swoole_process/constructor_reentrancy.phpt
@@ -1,0 +1,51 @@
+--TEST--
+swoole_process: constructor parses before native state
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+
+$process = (new ReflectionClass(Process::class))->newInstanceWithoutConstructor();
+try {
+    $process->__construct('MissingProcessCallback::run');
+    Assert::true(false);
+} catch (TypeError $error) {
+    Assert::contains($error->getMessage(), 'must be a valid callback');
+}
+$process->__construct(function (): void {
+});
+
+final class ExistingProcessCallback
+{
+    public static function run(): void
+    {
+    }
+}
+
+$process = (new ReflectionClass(Process::class))->newInstanceWithoutConstructor();
+$reentered = false;
+spl_autoload_register($loader = function (string $class) use ($process, &$reentered): void {
+    if ($class !== 'ReentrantProcessCallback') {
+        return;
+    }
+    $reentered = true;
+    $process->__construct(function (): void {
+    });
+    class_alias(ExistingProcessCallback::class, $class);
+}, true, true);
+try {
+    try {
+        $process->__construct('ReentrantProcessCallback::run');
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Process can only be called once');
+    }
+} finally {
+    spl_autoload_unregister($loader);
+}
+Assert::true($reentered);
+?>
+--EXPECT--

--- a/tests/swoole_server/constructor_lifecycle.phpt
+++ b/tests/swoole_server/constructor_lifecycle.phpt
@@ -1,0 +1,110 @@
+--TEST--
+swoole_server: constructor lifecycle does not poison later construction
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+Co::set(['log_level' => SWOOLE_LOG_NONE]);
+
+function open_fds(): ?array
+{
+    if (!is_dir('/proc/self/fd')) {
+        return null;
+    }
+
+    $fds = scandir('/proc/self/fd');
+    if ($fds === false) {
+        return null;
+    }
+
+    return array_values(array_diff($fds, ['.', '..']));
+}
+
+function open_fd_count(): ?int
+{
+    $fds = open_fds();
+
+    return $fds === null ? null : count($fds);
+}
+
+function open_non_socket_fd(): array
+{
+    $stream = fopen('/dev/null', 'r');
+    Assert::notEmpty($stream);
+
+    $fd = null;
+    foreach (open_fds() as $candidate) {
+        if (@readlink('/proc/self/fd/' . $candidate) === '/dev/null') {
+            $fd = (int) $candidate;
+            break;
+        }
+    }
+
+    Assert::notNull($fd);
+
+    return [$stream, $fd];
+}
+
+$listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+Assert::notEmpty($listener);
+
+$port = (int) parse_url(stream_socket_get_name($listener, false), PHP_URL_PORT);
+Assert::greaterThan($port, 0);
+
+try {
+    new Server('127.0.0.1', $port, SWOOLE_BASE);
+    Assert::true(false);
+} catch (Swoole\Exception $exception) {
+    Assert::contains($exception->getMessage(), 'failed to listen server port');
+}
+
+$server = new Server('127.0.0.1', 0, SWOOLE_BASE);
+Assert::isInstanceOf($server, Server::class);
+
+unset($server);
+gc_collect_cycles();
+
+$server = new Server('127.0.0.1', 0, SWOOLE_BASE);
+Assert::isInstanceOf($server, Server::class);
+
+unset($server);
+gc_collect_cycles();
+
+$fd_count = open_fd_count();
+if ($fd_count !== null) {
+    for ($i = 0; $i < 3; $i++) {
+        $server = new Server('127.0.0.1', 0, SWOOLE_BASE);
+        unset($server);
+        gc_collect_cycles();
+
+        Assert::same(open_fd_count(), $fd_count);
+    }
+
+    [$stream, $fd] = open_non_socket_fd();
+
+    try {
+        putenv('LISTEN_PID=' . posix_getpid());
+        putenv('LISTEN_FDS=1');
+        putenv('LISTEN_FDS_START=' . $fd);
+
+        try {
+            new Server('SYSTEMD', 0, SWOOLE_BASE);
+            Assert::true(false);
+        } catch (Error $exception) {
+            Assert::contains($exception->getMessage(), 'failed to add systemd socket');
+        }
+    } finally {
+        putenv('LISTEN_PID');
+        putenv('LISTEN_FDS');
+        putenv('LISTEN_FDS_START');
+        fclose($stream);
+    }
+
+    Assert::same(open_fd_count(), $fd_count);
+}
+?>
+--EXPECT--

--- a/tests/swoole_table/argument_coercion_lifecycle.phpt
+++ b/tests/swoole_table/argument_coercion_lifecycle.phpt
@@ -1,0 +1,73 @@
+--TEST--
+swoole_table: argument coercion lifecycle
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+use Swoole\Table;
+
+final class DestroyingString
+{
+    public function __construct(
+        private Table $table,
+        private string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $this->table->destroy();
+
+        return $this->value;
+    }
+}
+
+function assertLifecycleFailure(Closure $operation): void
+{
+    $process = new Process(function () use ($operation): void {
+        $table = new Table(8);
+        $table->column('id', Table::TYPE_INT);
+        $table->create();
+        $table->set('row', ['id' => 1]);
+
+        $operation($table);
+    }, true, SOCK_STREAM);
+
+    $process->start();
+    $output = $process->read();
+    $status = Process::wait();
+
+    Assert::contains($output, 'must call constructor first');
+    Assert::same($status['code'], 255);
+    Assert::same($status['signal'], 0);
+}
+
+assertLifecycleFailure(
+    fn (Table $table) => $table->column(new DestroyingString($table, 'other'), Table::TYPE_INT),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->set(new DestroyingString($table, 'row'), ['id' => 2]),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->get(new DestroyingString($table, 'row')),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->get('row', new DestroyingString($table, 'id')),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->exists(new DestroyingString($table, 'row')),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->del(new DestroyingString($table, 'row')),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->incr(new DestroyingString($table, 'row'), 'id'),
+);
+assertLifecycleFailure(
+    fn (Table $table) => $table->decr('row', new DestroyingString($table, 'id')),
+);
+?>
+--EXPECT--

--- a/tests/swoole_table/constructor_count_reentrancy.phpt
+++ b/tests/swoole_table/constructor_count_reentrancy.phpt
@@ -1,0 +1,57 @@
+--TEST--
+swoole_table: constructor and count parse before native state
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+// These re-entry vectors are PHP 8 scalar-coercion diagnostics; PHP 9 promotes them to TypeError.
+$table = new Table(8);
+$table->column('id', Table::TYPE_INT);
+$table->create();
+$table->set('row', ['id' => 1]);
+Assert::same($table->count(), 1);
+
+$destroyed = false;
+set_error_handler(function () use ($table, &$destroyed): bool {
+    $destroyed = true;
+    $table->destroy();
+
+    return true;
+});
+try {
+    Assert::same($table->count(8.5), 0);
+} finally {
+    restore_error_handler();
+}
+Assert::true($destroyed);
+
+$table     = (new ReflectionClass(Table::class))->newInstanceWithoutConstructor();
+$reentered = false;
+set_error_handler(function () use ($table, &$reentered): bool {
+    $reentered = true;
+    $table->__construct(8);
+    $table->column('id', Table::TYPE_INT);
+    $table->create();
+    $table->set('row', ['id' => 1]);
+
+    return true;
+});
+try {
+    try {
+        $table->__construct(8.5);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Table can only be called once');
+    }
+} finally {
+    restore_error_handler();
+}
+Assert::true($reentered);
+Assert::same($table->get('row'), ['id' => 1]);
+Assert::same($table->count(), 1);
+?>
+--EXPECT--

--- a/tests/swoole_table/existing_conversion_safety.phpt
+++ b/tests/swoole_table/existing_conversion_safety.phpt
@@ -1,0 +1,155 @@
+--TEST--
+swoole_table: existing operation conversion safety
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Table;
+
+final class NestedUpdate
+{
+    public function __construct(private Table $table)
+    {
+    }
+
+    public function __toString(): string
+    {
+        Assert::true($this->table->update('row', ['id' => 2]));
+
+        return 'outer';
+    }
+}
+
+final class DestroyDuringConversion
+{
+    public function __construct(private Table $table)
+    {
+    }
+
+    public function __toString(): string
+    {
+        $this->table->destroy();
+
+        return 'destroyed';
+    }
+}
+
+final class ThrowingString
+{
+    public function __toString(): string
+    {
+        throw new RuntimeException('conversion failed');
+    }
+}
+
+final class NumericValue
+{
+}
+
+function assertRuntimeException(Closure $operation): void
+{
+    try {
+        $operation();
+        Assert::true(false);
+    } catch (RuntimeException $exception) {
+        Assert::same($exception->getMessage(), 'conversion failed');
+    }
+}
+
+$table = new Table(128);
+$table->column('id', Table::TYPE_INT);
+$table->column('name', Table::TYPE_STRING, 16);
+$table->column('score', Table::TYPE_FLOAT);
+$table->create();
+$table->set('row', ['id' => 1, 'name' => 'original', 'score' => 1.0]);
+
+Assert::true($table->set('row', ['name' => new NestedUpdate($table)]));
+Assert::same($table->get('row'), [
+    'id'    => 2,
+    'name'  => 'outer',
+    'score' => 1.0,
+]);
+
+$row   = $table->get('row');
+$stats = $table->stats();
+try {
+    $table->set('row', ['name' => new DestroyDuringConversion($table)]);
+    Assert::true(false);
+} catch (Error $error) {
+    Assert::contains($error->getMessage(), 'Cannot destroy Swoole\Table during value conversion');
+}
+Assert::same($table->get('row'), $row);
+Assert::same($table->stats(), $stats);
+
+$row   = $table->get('row');
+$stats = $table->stats();
+assertRuntimeException(
+    fn () => $table->set('row', ['id' => 3, 'name' => new ThrowingString()]),
+);
+Assert::same($table->get('row'), $row);
+Assert::same($table->stats(), $stats);
+
+$stats = $table->stats();
+assertRuntimeException(
+    fn () => $table->set('missing', ['id' => 3, 'name' => new ThrowingString()]),
+);
+Assert::false($table->exists('missing'));
+Assert::same($table->stats(), $stats);
+
+set_error_handler(function (int $severity, string $message) use ($table): bool {
+    Assert::contains($message, 'could not be converted');
+    Assert::true($table->update('row', ['score' => 10.0]));
+
+    return true;
+});
+try {
+    Assert::same($table->incr('row', 'score', new NumericValue()), 11.0);
+} finally {
+    restore_error_handler();
+}
+Assert::same($table->get('row')['score'], 11.0);
+
+$row   = $table->get('row');
+$stats = $table->stats();
+set_error_handler(
+    fn () => throw new RuntimeException('conversion failed'),
+);
+try {
+    assertRuntimeException(
+        fn () => $table->decr('row', 'id', new NumericValue()),
+    );
+    Assert::same($table->get('row'), $row);
+    Assert::same($table->stats(), $stats);
+
+    assertRuntimeException(
+        fn () => $table->decr('missing', 'id', new NumericValue()),
+    );
+    Assert::false($table->exists('missing'));
+    Assert::same($table->stats(), $stats);
+} finally {
+    restore_error_handler();
+}
+
+$row   = $table->get('row');
+$stats = $table->stats();
+set_error_handler(function () use ($table): bool {
+    $table->destroy();
+
+    return true;
+});
+try {
+    try {
+        $table->incr('row', 'id', new NumericValue());
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Cannot destroy Swoole\Table during value conversion');
+    }
+} finally {
+    restore_error_handler();
+}
+Assert::same($table->get('row'), $row);
+Assert::same($table->stats(), $stats);
+?>
+--EXPECT--

--- a/tests/swoole_thread/constructor_reentrancy.phpt
+++ b/tests/swoole_thread/constructor_reentrancy.phpt
@@ -27,11 +27,17 @@ final class ReentrantHost
     }
 }
 
-$lock = (new ReflectionClass(Lock::class))->newInstanceWithoutConstructor();
+$lock = new Lock(Lock::MUTEX);
 $reentered = false;
 set_error_handler(function () use ($lock, &$reentered): bool {
     $reentered = true;
-    $lock->__construct(Lock::MUTEX);
+
+    try {
+        $lock->__construct(Lock::MUTEX);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Thread\Lock can only be called once');
+    }
 
     return true;
 });
@@ -45,13 +51,20 @@ try {
 } finally {
     restore_error_handler();
 }
+// Broken constructors reject before parameter parsing, so this is the discriminating assertion.
 Assert::true($reentered);
 
-$barrier = (new ReflectionClass(Barrier::class))->newInstanceWithoutConstructor();
+$barrier = new Barrier(2);
 $reentered = false;
 set_error_handler(function () use ($barrier, &$reentered): bool {
     $reentered = true;
-    $barrier->__construct(2);
+
+    try {
+        $barrier->__construct(2);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Thread\Barrier can only be called once');
+    }
 
     return true;
 });
@@ -65,6 +78,7 @@ try {
 } finally {
     restore_error_handler();
 }
+// Broken constructors reject before parameter parsing, so this is the discriminating assertion.
 Assert::true($reentered);
 
 $server = (new ReflectionClass(Server::class))->newInstanceWithoutConstructor();

--- a/tests/swoole_thread/constructor_reentrancy.phpt
+++ b/tests/swoole_thread/constructor_reentrancy.phpt
@@ -1,0 +1,78 @@
+--TEST--
+swoole_thread: constructors parse before native state
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+use Swoole\Thread\Barrier;
+use Swoole\Thread\Lock;
+
+final class ReentrantHost
+{
+    public function __construct(private Server $server)
+    {
+    }
+
+    public function __toString(): string
+    {
+        $this->server->__construct('127.0.0.1', 0, SWOOLE_BASE);
+
+        return '127.0.0.1';
+    }
+}
+
+$lock = (new ReflectionClass(Lock::class))->newInstanceWithoutConstructor();
+$reentered = false;
+set_error_handler(function () use ($lock, &$reentered): bool {
+    $reentered = true;
+    $lock->__construct(Lock::MUTEX);
+
+    return true;
+});
+try {
+    try {
+        $lock->__construct(3.5);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Thread\Lock can only be called once');
+    }
+} finally {
+    restore_error_handler();
+}
+Assert::true($reentered);
+
+$barrier = (new ReflectionClass(Barrier::class))->newInstanceWithoutConstructor();
+$reentered = false;
+set_error_handler(function () use ($barrier, &$reentered): bool {
+    $reentered = true;
+    $barrier->__construct(2);
+
+    return true;
+});
+try {
+    try {
+        $barrier->__construct(2.5);
+        Assert::true(false);
+    } catch (Error $error) {
+        Assert::contains($error->getMessage(), 'Constructor of Swoole\Thread\Barrier can only be called once');
+    }
+} finally {
+    restore_error_handler();
+}
+Assert::true($reentered);
+
+$server = (new ReflectionClass(Server::class))->newInstanceWithoutConstructor();
+try {
+    $server->__construct(new ReentrantHost($server), 0, SWOOLE_BASE);
+    Assert::true(false);
+} catch (Error $error) {
+    Assert::contains($error->getMessage(), 'Constructor of Swoole\Server can only be called once');
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

PHP argument conversion can invoke user code. Several Table operations and object constructors inspected native state or acquired row locks before conversion completed. Re-entry could then initialize or destroy the same object while the outer call retained stale state.

Table values are now converted before row locks are acquired. A new internal C++ `Table::set()` overload applies the prepared values while holding the lock, preserving atomic row updates without changing the PHP API. `Table::count()` also parses its argument before reading the native Table pointer.

The same ordering is applied to the Table, Lock, Coroutine Lock, Thread Lock, Thread Barrier, Process, and Server constructors. Server construction now releases native Server and ListenPort state when setup fails before the object is published.

## Testing

- core coverage for prepared Table writes
- PHPT coverage for Table conversion, constructor, and count re-entry
- constructor re-entry coverage for locks, thread primitives, Process, and Server
