### PR TITLE
Fix SSH2 exec completion metadata

### DIFF
--- a/ext-src/php_swoole_ssh2.h
+++ b/ext-src/php_swoole_ssh2.h
@@ -73,7 +73,7 @@ static inline int ssh2_async_call(LIBSSH2_SESSION *session,
         if (rc == LIBSSH2_ERROR_EAGAIN) {
             if (!socket->poll(event, timeout)) {
                 if (timeout_event) {
-                    *timeout_event = timeout > 0 && socket->errCode == ETIMEDOUT;
+                    *timeout_event = socket->errCode == ETIMEDOUT;
                 }
                 return LIBSSH2_ERROR_SOCKET_NONE;
             }

--- a/ext-src/php_swoole_ssh2_hook.h
+++ b/ext-src/php_swoole_ssh2_hook.h
@@ -78,9 +78,6 @@
 #undef libssh2_channel_send_eof
 #define libssh2_channel_send_eof(channel) SSH2_ASYNC_CALL(session, libssh2_channel_send_eof, channel)
 
-#undef libssh2_channel_get_exit_status
-#define libssh2_channel_get_exit_status(channel) SSH2_ASYNC_CALL(session, libssh2_channel_get_exit_status, channel)
-
 #undef libssh2_channel_request_pty_size_ex
 #define libssh2_channel_request_pty_size_ex(channel, width, height, width_px, height_px)                               \
     SSH2_ASYNC_CALL(session, libssh2_channel_request_pty_size_ex, channel, width, height, width_px, height_px)

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - 1.1.1.1
     environment:
       SWOOLE_BRANCH: "${SWOOLE_BRANCH}"
+      TEST_SSH2_HOSTNAME: localhost
+      TEST_SSH2_PORT: 22
+      TEST_SSH2_USER: swoole_ssh2_test_user
+      TEST_SSH2_PASS: swoole_ssh2_test_pass
+      TEST_SSH2_AUTH: password
     command: tail -f /etc/group
   mysql:
     container_name: "mysql"

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -15,9 +15,14 @@ bash ./install-deps-on-ubuntu.sh
 
 # sshd
 apt install -y openssh-server
+if ! id -u swoole_ssh2_test_user > /dev/null 2>&1; then
+    useradd -m -s /bin/bash swoole_ssh2_test_user
+fi
+echo 'swoole_ssh2_test_user:swoole_ssh2_test_pass' | chpasswd
 mkdir -p /etc/ssh/sshd_config.d
-echo 'AcceptEnv SWOOLE_TEST_*' > /etc/ssh/sshd_config.d/swoole-tests.conf
-sshd -t
+printf '%s\n' 'AcceptEnv SWOOLE_TEST_*' 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/swoole-tests.conf
+mkdir -p /run/sshd
+sshd -t || { echo 'sshd configuration is invalid'; exit 1; }
 service ssh start
 
 # MariaDB ODBC Connector

--- a/tests/swoole_ssh2/ssh2_exec_completion.phpt
+++ b/tests/swoole_ssh2/ssh2_exec_completion.phpt
@@ -1,0 +1,116 @@
+--TEST--
+SSH2 exec streams publish completion only after the remote command exits
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $startedAt = microtime(true);
+    $blocking = ssh2_exec($session, "printf blocking; exec 1>&- 2>&-; sleep 1; exit 7");
+
+    if ($blocking === false) {
+        throw new RuntimeException('Failed to open the blocking exec channel.');
+    }
+
+    var_dump(stream_get_contents($blocking));
+    var_dump(microtime(true) - $startedAt >= 0.5);
+    var_dump(stream_get_meta_data($blocking)['exit_status']);
+
+    $nonblocking = ssh2_exec(
+        $session,
+        "printf stdout; printf stderr >&2; exec 1>&- 2>&-; sleep 1; exit 7",
+    );
+
+    if ($nonblocking === false) {
+        throw new RuntimeException('Failed to open the nonblocking exec channel.');
+    }
+
+    $stderr = ssh2_fetch_stream($nonblocking, SSH2_STREAM_STDERR);
+
+    if ($stderr === false) {
+        throw new RuntimeException('Failed to open the stderr stream.');
+    }
+
+    stream_set_blocking($nonblocking, false);
+    stream_set_blocking($stderr, false);
+    var_dump(stream_set_read_buffer($nonblocking, 0));
+
+    $stdoutContents = '';
+    $stderrContents = '';
+    $deadline = microtime(true) + 5;
+
+    while (!feof($nonblocking) || !feof($stderr)) {
+        if (!feof($nonblocking)) {
+            $chunk = fread($nonblocking, 8192);
+            if ($chunk === false) {
+                throw new RuntimeException('Failed to read stdout.');
+            }
+            $stdoutContents .= $chunk;
+        }
+        if (!feof($stderr)) {
+            $chunk = fread($stderr, 8192);
+            if ($chunk === false) {
+                throw new RuntimeException('Failed to read stderr.');
+            }
+            $stderrContents .= $chunk;
+        }
+        if (microtime(true) >= $deadline) {
+            throw new RuntimeException('Timed out draining the nonblocking exec channel.');
+        }
+        Co::sleep(0.001);
+    }
+
+    var_dump($stdoutContents);
+    var_dump($stderrContents);
+    var_dump(stream_get_meta_data($nonblocking)['exit_status']);
+
+    $pty = ssh2_exec($session, 'sleep 0.1; exit 7', 'xterm');
+
+    if ($pty === false) {
+        throw new RuntimeException('Failed to open the PTY exec channel.');
+    }
+
+    stream_get_contents($pty);
+    var_dump(stream_get_meta_data($pty)['exit_status']);
+
+    $successful = ssh2_exec($session, 'exit 0');
+
+    if ($successful === false) {
+        throw new RuntimeException('Failed to open the successful exec channel.');
+    }
+
+    stream_get_contents($successful);
+    $metadata = stream_get_meta_data($successful);
+    var_dump($metadata['exit_status']);
+    var_dump($metadata['exit_signal']);
+
+    fclose($blocking);
+    fclose($stderr);
+    fclose($nonblocking);
+    fclose($pty);
+    fclose($successful);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+string(8) "blocking"
+bool(true)
+int(7)
+int(0)
+string(6) "stdout"
+string(6) "stderr"
+int(7)
+int(7)
+int(0)
+NULL

--- a/tests/swoole_ssh2/ssh2_exec_completion_timeout.phpt
+++ b/tests/swoole_ssh2/ssh2_exec_completion_timeout.phpt
@@ -1,0 +1,56 @@
+--TEST--
+SSH2 exec completion preserves timeout metadata and remains retryable
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co::set(['socket_timeout' => 0.3]);
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $channel = ssh2_exec($session, "exec 1>&- 2>&-; sleep 1; exit 7");
+
+    if ($channel === false) {
+        throw new RuntimeException('Failed to open the exec channel.');
+    }
+
+    $startedAt = microtime(true);
+    var_dump(fread($channel, 1));
+    $elapsed = microtime(true) - $startedAt;
+    $metadata = stream_get_meta_data($channel);
+
+    var_dump($elapsed >= 0.2 && $elapsed < 0.8);
+    var_dump($metadata['timed_out']);
+    var_dump($metadata['eof']);
+
+    stream_set_timeout($channel, 2);
+    var_dump(stream_get_contents($channel));
+
+    $metadata = stream_get_meta_data($channel);
+    var_dump($metadata['timed_out']);
+    var_dump($metadata['eof']);
+    var_dump($metadata['exit_status']);
+
+    fclose($channel);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+string(0) ""
+bool(false)
+bool(true)
+int(7)

--- a/tests/swoole_ssh2/ssh2_exec_metadata.phpt
+++ b/tests/swoole_ssh2/ssh2_exec_metadata.phpt
@@ -1,0 +1,67 @@
+--TEST--
+SSH2 exec metadata remains readable during IO and reports exit signals
+--SKIPIF--
+<?php
+require_once 'ssh2_skip.inc';
+ssh2t_needs_auth();
+?>
+--FILE--
+<?php
+require __DIR__ . '/ssh2_test.inc';
+
+Co\run(function (): void {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $channel = ssh2_exec($session, "printf output; exec 1>&- 2>&-; sleep 1; exit 7");
+
+    if ($channel === false) {
+        throw new RuntimeException('Failed to open the exec channel.');
+    }
+
+    $contents = null;
+    $cid = go(function () use ($channel, &$contents): void {
+        $contents = stream_get_contents($channel);
+    });
+
+    Co::sleep(0.05);
+    $metadata = stream_get_meta_data($channel);
+    var_dump($metadata['exit_status']);
+    var_dump($metadata['exit_signal']);
+
+    if (!Swoole\Coroutine::join([$cid], 5)) {
+        throw new RuntimeException('Timed out waiting for the exec reader.');
+    }
+
+    var_dump($contents);
+    $metadata = stream_get_meta_data($channel);
+    var_dump($metadata['exit_status']);
+    var_dump($metadata['exit_signal']);
+
+    $signalled = ssh2_exec($session, 'kill -KILL $$');
+
+    if ($signalled === false) {
+        throw new RuntimeException('Failed to open the signalled exec channel.');
+    }
+
+    stream_get_contents($signalled);
+    $metadata = stream_get_meta_data($signalled);
+    var_dump($metadata['exit_status']);
+    var_dump($metadata['exit_signal']);
+
+    fclose($channel);
+    fclose($signalled);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+int(0)
+NULL
+string(6) "output"
+int(7)
+NULL
+int(0)
+string(4) "KILL"

--- a/tests/swoole_ssh2/ssh2_exec_pty_metadata.phpt
+++ b/tests/swoole_ssh2/ssh2_exec_pty_metadata.phpt
@@ -1,7 +1,11 @@
 --TEST--
 ssh2_exec() publishes nullable PTY and environment metadata
 --SKIPIF--
-<?php require_once 'ssh2_skip.inc'; ?>
+<?php
+if (!function_exists('ssh2_exec')) {
+    echo 'skip SSH2 support is not enabled';
+}
+?>
 --FILE--
 <?php
 $parameters  = (new ReflectionFunction('ssh2_exec'))->getParameters();

--- a/tests/swoole_ssh2/ssh2_sftp_001.phpt
+++ b/tests/swoole_ssh2/ssh2_sftp_001.phpt
@@ -18,8 +18,11 @@ Co\run(function () {
     $linkname = ssh2t_tempnam();
 
     var_dump(ssh2_sftp_mkdir($sftp, $filename, 0644, true));
-    var_dump(ssh2_sftp_symlink($sftp, $filename, $linkname));
-    var_dump(ssh2_sftp_readlink($sftp, $linkname) == $filename);
+    // Released libssh2 reads the request id as the SSH_FXP_STATUS code in
+    // sftp_symlink, so this returns true only when it is the session's first
+    // SFTP request (fixed upstream by libssh2 4ed26f57). Verify the link itself.
+    ssh2_sftp_symlink($sftp, $filename, $linkname);
+    var_dump(ssh2_sftp_readlink($sftp, $linkname) === $filename);
     $stat = ssh2_sftp_stat($sftp, $filename);
     var_dump(ssh2_sftp_rmdir($sftp, $filename));
     var_dump(ssh2_sftp_unlink($sftp, $linkname));
@@ -27,7 +30,6 @@ Co\run(function () {
 });
 ?>
 --EXPECT--
-bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/tests/swoole_ssh2/ssh2_shell_incomplete_dimensions.phpt
+++ b/tests/swoole_ssh2/ssh2_shell_incomplete_dimensions.phpt
@@ -1,7 +1,11 @@
 --TEST--
 ssh2_shell() rejects a width without a height
 --SKIPIF--
-<?php require_once 'ssh2_skip.inc'; ?>
+<?php
+if (!function_exists('ssh2_shell')) {
+    echo 'skip SSH2 support is not enabled';
+}
+?>
 --FILE--
 <?php
 var_dump(ssh2_shell(null, 'xterm', [], 80));

--- a/tests/swoole_ssh2/ssh2_skip.inc
+++ b/tests/swoole_ssh2/ssh2_skip.inc
@@ -8,25 +8,22 @@
  */
 
 declare(strict_types=1);
+require_once __DIR__ . '/../include/skipif.inc';
 require_once 'ssh2_test.inc';
 
-if (!defined('SSH2_POLLIN')) {
-    echo 'skip extension not loaded';
-}
-if (TEST_SSH2_HOSTNAME === false) {
-    echo 'skip TEST_SSH2_HOSTNAME not set';
-}
+skip('SSH2 support is not enabled', !function_exists('ssh2_exec'));
+skip('TEST_SSH2_HOSTNAME not set', !TEST_SSH2_HOSTNAME);
 
 function ssh2t_needs_auth()
 {
     if (TEST_SSH2_AUTH == 'none') {
-        echo "skip TEST_SSH2_AUTH == 'none'";
+        skip("TEST_SSH2_AUTH == 'none'");
     }
 }
 
 function ssh2t_writes_remote()
 {
     if (!TEST_SSH2_TEMPDIR) {
-        echo 'skip TEST_SSH2_TEMPDIR is empty';
+        skip('TEST_SSH2_TEMPDIR is empty');
     }
 }

--- a/tests/swoole_ssh2/ssh2_test.inc
+++ b/tests/swoole_ssh2/ssh2_test.inc
@@ -7,10 +7,10 @@
  * @license  https://github.com/swoole/library/blob/master/LICENSE
  */
 
-ssh2t_defenv('TEST_SSH2_HOSTNAME', 'localhost');
+ssh2t_defenv('TEST_SSH2_HOSTNAME');
 ssh2t_defenv('TEST_SSH2_PORT', 22);
-ssh2t_defenv('TEST_SSH2_USER', 'swoole_ssh2_test_user');
-ssh2t_defenv('TEST_SSH2_PASS', 'swoole_ssh2_test_pass');
+ssh2t_defenv('TEST_SSH2_USER');
+ssh2t_defenv('TEST_SSH2_PASS');
 ssh2t_defenv('TEST_SSH2_TEMPDIR', '/tmp');
 ssh2t_defenv('TEST_SSH2_AUTH', TEST_SSH2_PASS ? 'password' : 'none');
 ssh2t_defenv('TEST_SSH2_PUB_KEY', __DIR__ . '/testkey_ed25519.pub');

--- a/thirdparty/php/ssh2/php_ssh2.h
+++ b/thirdparty/php/ssh2/php_ssh2.h
@@ -102,6 +102,7 @@ typedef struct _php_ssh2_channel_data {
     char is_blocking;
     long timeout;
     bool timeout_event;
+    bool wait_for_remote_close;
 
     /* Resource */
     zend_resource *session_rsrc;
@@ -110,6 +111,21 @@ typedef struct _php_ssh2_channel_data {
     unsigned char *refcount;
 
 } php_ssh2_channel_data;
+
+static inline php_ssh2_channel_data *php_ssh2_channel_data_create(LIBSSH2_CHANNEL *channel,
+                                                                  zend_resource *session_rsrc,
+                                                                  bool wait_for_remote_close) {
+    php_ssh2_channel_data *data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
+    data->channel = channel;
+    data->streamid = 0;
+    data->is_blocking = 1;
+    data->timeout = 0;
+    data->timeout_event = false;
+    data->wait_for_remote_close = wait_for_remote_close;
+    data->session_rsrc = session_rsrc;
+    data->refcount = NULL;
+    return data;
+}
 
 LIBSSH2_SESSION *php_ssh2_session_connect(const char *host, int port, zval *methods, zval *callbacks);
 void php_ssh2_sftp_dtor(zend_resource *rsrc);

--- a/thirdparty/php/ssh2/ssh2.cc
+++ b/thirdparty/php/ssh2/ssh2.cc
@@ -917,14 +917,7 @@ PHP_FUNCTION(ssh2_forward_accept) {
         RETURN_FALSE;
     }
 
-    channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
-    channel_data->channel = channel;
-    channel_data->streamid = 0;
-    channel_data->is_blocking = 1;
-    channel_data->timeout = 0;
-    channel_data->timeout_event = false;
-    channel_data->session_rsrc = data->session_rsrc;
-    channel_data->refcount = NULL;
+    channel_data = php_ssh2_channel_data_create(channel, data->session_rsrc, false);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
     if (!stream) {

--- a/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
+++ b/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
@@ -54,6 +54,45 @@ static inline int php_ssh2_channel_eof_raw(LIBSSH2_CHANNEL *channel) {
     return (libssh2_channel_eof)(channel);
 }
 
+enum php_ssh2_channel_completion_state {
+    PHP_SSH2_CHANNEL_COMPLETION_COMPLETE,
+    PHP_SSH2_CHANNEL_COMPLETION_INCOMPLETE,
+    PHP_SSH2_CHANNEL_COMPLETION_ERROR,
+};
+
+static php_ssh2_channel_completion_state php_ssh2_channel_complete(php_ssh2_channel_data *abstract, bool may_block) {
+    if (!php_ssh2_channel_eof_raw(abstract->channel)) {
+        return PHP_SSH2_CHANNEL_COMPLETION_INCOMPLETE;
+    }
+    if (!abstract->wait_for_remote_close) {
+        return PHP_SSH2_CHANNEL_COMPLETION_COMPLETE;
+    }
+
+    int state;
+    if (may_block) {
+        auto session = ssh2_get_session(abstract);
+#ifdef PHP_SSH2_SESSION_TIMEOUT
+        const double timeout = abstract->timeout / 1000.0;
+#else
+        const double timeout = 0;
+#endif
+        state = ssh2_async_call(session,
+                                [&]() { return libssh2_channel_wait_closed(abstract->channel); },
+                                timeout,
+                                &abstract->timeout_event);
+    } else {
+        state = libssh2_channel_wait_closed(abstract->channel);
+    }
+
+    if (state == 0) {
+        return PHP_SSH2_CHANNEL_COMPLETION_COMPLETE;
+    }
+    if (state == LIBSSH2_ERROR_EAGAIN) {
+        return PHP_SSH2_CHANNEL_COMPLETION_INCOMPLETE;
+    }
+    return PHP_SSH2_CHANNEL_COMPLETION_ERROR;
+}
+
 static ssize_t php_ssh2_channel_stream_write(php_stream *stream, const char *buf, size_t count) {
     php_ssh2_channel_data *abstract = (php_ssh2_channel_data *) stream->abstract;
     ssize_t writestate;
@@ -111,7 +150,12 @@ static ssize_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_
             return 0;
         }
         if (readstate == 0) {
-            stream->eof = php_ssh2_channel_eof_raw(abstract->channel);
+            auto completion = php_ssh2_channel_complete(abstract, false);
+            if (completion == PHP_SSH2_CHANNEL_COMPLETION_ERROR) {
+                /* Reads report the error; liveness publishes the terminal state. */
+                return -1;
+            }
+            stream->eof = completion == PHP_SSH2_CHANNEL_COMPLETION_COMPLETE;
             return 0;
         }
         return readstate;
@@ -135,7 +179,12 @@ static ssize_t php_ssh2_channel_stream_read(php_stream *stream, char *buf, size_
                                 &abstract->timeout_event);
 
     if (readstate == 0) {
-        stream->eof = libssh2_channel_eof(abstract->channel);
+        auto completion = php_ssh2_channel_complete(abstract, true);
+        if (completion == PHP_SSH2_CHANNEL_COMPLETION_ERROR) {
+            /* A completion timeout is retryable and must not be published as EOF. */
+            return -1;
+        }
+        stream->eof = completion == PHP_SSH2_CHANNEL_COMPLETION_COMPLETE;
     }
 
     return readstate;
@@ -215,7 +264,19 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
 
         if (php_ssh2_session_is_open(abstract->session_rsrc)) {
             auto session = ssh2_get_session(abstract);
+            char *exit_signal = NULL;
+            size_t exit_signal_len = 0;
+
+            /* A signalled command may have no exit-status, leaving libssh2's status at 0. */
             add_assoc_long((zval *) ptrparam, "exit_status", libssh2_channel_get_exit_status(abstract->channel));
+            if (libssh2_channel_get_exit_signal(
+                    abstract->channel, &exit_signal, &exit_signal_len, NULL, NULL, NULL, NULL) == 0 &&
+                exit_signal) {
+                add_assoc_stringl((zval *) ptrparam, "exit_signal", exit_signal, exit_signal_len);
+                libssh2_free(session, exit_signal);
+            } else {
+                add_assoc_null((zval *) ptrparam, "exit_signal");
+            }
         }
 
         return PHP_STREAM_OPTION_RETURN_OK;
@@ -233,14 +294,18 @@ static int php_ssh2_channel_stream_set_option(php_stream *stream, int option, in
     }
     case PHP_STREAM_OPTION_CHECK_LIVENESS: {
         if (!php_ssh2_session_is_open(abstract->session_rsrc)) {
-            return stream->eof = 1;
+            stream->eof = 1;
+            return PHP_STREAM_OPTION_RETURN_ERR;
         }
 
-        return stream->eof = php_ssh2_channel_eof_raw(abstract->channel);
+        auto completion = php_ssh2_channel_complete(abstract, false);
+        stream->eof = completion != PHP_SSH2_CHANNEL_COMPLETION_INCOMPLETE;
+        /* This check never blocks, so a completion error means the stream is dead. */
+        return stream->eof ? PHP_STREAM_OPTION_RETURN_ERR : PHP_STREAM_OPTION_RETURN_OK;
     }
     }
 
-    return -1;
+    return PHP_STREAM_OPTION_RETURN_NOTIMPL;
 }
 
 php_stream_ops php_ssh2_channel_stream_ops = {
@@ -613,14 +678,7 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session,
     }
 
     /* Turn it into a stream */
-    channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
-    channel_data->channel = channel;
-    channel_data->streamid = 0;
-    channel_data->is_blocking = 1;
-    channel_data->timeout = 0;
-    channel_data->timeout_event = false;
-    channel_data->session_rsrc = resource;
-    channel_data->refcount = NULL;
+    channel_data = php_ssh2_channel_data_create(channel, resource, false);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
 
@@ -884,14 +942,7 @@ static php_stream *php_ssh2_exec_command(LIBSSH2_SESSION *session,
     }
 
     /* Turn it into a stream */
-    channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
-    channel_data->channel = channel;
-    channel_data->streamid = 0;
-    channel_data->is_blocking = 1;
-    channel_data->timeout = 0;
-    channel_data->timeout_event = false;
-    channel_data->session_rsrc = rsrc;
-    channel_data->refcount = NULL;
+    channel_data = php_ssh2_channel_data_create(channel, rsrc, true);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
 
@@ -1073,14 +1124,7 @@ static php_stream *php_ssh2_scp_xfer(LIBSSH2_SESSION *session, zend_resource *rs
     }
 
     /* Turn it into a stream */
-    channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
-    channel_data->channel = channel;
-    channel_data->streamid = 0;
-    channel_data->is_blocking = 1;
-    channel_data->timeout = 0;
-    channel_data->timeout_event = false;
-    channel_data->session_rsrc = rsrc;
-    channel_data->refcount = NULL;
+    channel_data = php_ssh2_channel_data_create(channel, rsrc, false);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r");
 
@@ -1323,14 +1367,7 @@ static php_stream *php_ssh2_direct_tcpip(LIBSSH2_SESSION *session, zend_resource
     }
 
     /* Turn it into a stream */
-    channel_data = (php_ssh2_channel_data *) emalloc(sizeof(php_ssh2_channel_data));
-    channel_data->channel = channel;
-    channel_data->streamid = 0;
-    channel_data->is_blocking = 1;
-    channel_data->timeout = 0;
-    channel_data->timeout_event = false;
-    channel_data->session_rsrc = rsrc;
-    channel_data->refcount = NULL;
+    channel_data = php_ssh2_channel_data_create(channel, rsrc, false);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
 


### PR DESCRIPTION
## Summary

SSH2 exec streams can receive stdout and stderr EOF before the remote process sends its exit status and closes the channel. The stream wrapper currently treats that early EOF as command completion, which can expose libssh2's default status instead of the final result.

This change:

- waits for remote channel closure before marking exec streams complete
- exposes nullable `exit_signal` metadata alongside `exit_status` while the session is open
- preserves nonblocking reads and retryable timeout behavior
- enables close waiting only for exec streams; shell, SCP, tunnel, and forwarded channels retain their existing behavior
- provisions a usable SSH server in the Docker test environment and makes fixture prerequisites explicit

The SFTP symlink test also verifies the resulting link rather than relying on a return value that released libssh2 versions parse incorrectly.

## Testing

- built the extension with SSH2 and sockets enabled
- ran the complete SSH2 PHPT suite in parallel against the Docker fixture
- repeated the focused completion, timeout, and metadata tests

