### PR TITLE
[6.2] Fix AIO worker starvation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ tests/.idea
 /tests/swoole_*/*.exp
 /tests/swoole_*/*.mem
 /tests/swoole_*/*.php
+/tests/swoole_*/*.db
+/tests/swoole_*/*.db-journal
 /tests/swoole_library/curl/skip
 /core-tests/server/*.log
 cmake-build-debug/

--- a/src/os/async_thread.cc
+++ b/src/os/async_thread.cc
@@ -113,49 +113,63 @@ class ThreadPool {
         event_mutex.unlock();
         _cv.notify_all();
 
-        for (auto &i : threads) {
+        std::unordered_map<std::thread::id, std::thread *> shutdown_threads;
+        {
+            std::lock_guard<std::mutex> lock(threads_mutex);
+            shutdown_threads.swap(threads);
+        }
+
+        for (auto &i : shutdown_threads) {
             std::thread *_thread = i.second;
             if (_thread->joinable()) {
                 _thread->join();
             }
             delete _thread;
         }
-        threads.clear();
 
         return true;
     }
 
     void schedule() {
-        if (n_waiting == 0 && threads.size() < worker_num && max_wait_time > 0) {
-            double _max_wait_time = queue_.get_max_wait_time();
-            if (_max_wait_time > max_wait_time) {
-                size_t n = 1;
-                /**
-                 * maybe we can find a better strategy
-                 */
-                if (threads.size() + n > worker_num) {
-                    n = worker_num - threads.size();
-                }
-                swoole_trace_log(SW_TRACE_AIO,
-                                 "Create %zu thread due to wait %fs, we will have %zu threads",
-                                 n,
-                                 _max_wait_time,
-                                 threads.size() + n);
-                while (n--) {
-                    create_thread();
-                }
-            }
+        const size_t thread_count = get_worker_num();
+        if (thread_count >= worker_num || queue_.empty()) {
+            return;
+        }
+
+        const size_t idle_worker_num = n_waiting.load();
+        const size_t queue_size = queue_.count();
+        const bool insufficient_idle_workers = queue_size > idle_worker_num;
+        const double queue_wait_time = queue_.get_max_wait_time();
+        const bool waited_too_long = max_wait_time > 0 && queue_wait_time > max_wait_time;
+        if (!insufficient_idle_workers && !waited_too_long) {
+            return;
+        }
+
+        size_t n = insufficient_idle_workers ? queue_size - idle_worker_num : 1;
+        n = SW_MIN(n, worker_num - thread_count);
+        swoole_trace_log(SW_TRACE_AIO,
+                         "Create %zu thread due to queue_size=%zu, idle_workers=%zu, wait=%fs, we will have %zu "
+                         "threads",
+                         n,
+                         queue_size,
+                         idle_worker_num,
+                         queue_wait_time,
+                         thread_count + n);
+        while (n--) {
+            create_thread();
         }
     }
 
     AsyncEvent *dispatch(const AsyncEvent *request) {
         auto _event_copy = new AsyncEvent(*request);
         event_mutex.lock();
-        schedule();
         _event_copy->task_id = current_task_id++;
         _event_copy->timestamp = microtime();
         _event_copy->pipe_socket = SwooleTG.async_threads->write_socket;
+        // Schedule after the push so the queued task is counted; a task that arrives while every
+        // worker is blocked would otherwise never trigger pool growth.
         queue_.push(_event_copy);
+        schedule();
         event_mutex.unlock();
         _cv.notify_one();
         swoole_debug("push and notify one: %f", microtime());
@@ -163,6 +177,7 @@ class ThreadPool {
     }
 
     size_t get_worker_num() const {
+        std::lock_guard<std::mutex> lock(threads_mutex);
         return threads.size();
     }
 
@@ -172,20 +187,26 @@ class ThreadPool {
     }
 
     void release_thread(std::thread::id tid) {
-        auto i = threads.find(tid);
-        if (i == threads.end()) {
-            swoole_warning("AIO thread#%s is missing", swoole_thread_id_to_str(tid).c_str());
-            return;
+        std::thread *_thread = nullptr;
+        size_t remaining_thread_num = 0;
+        {
+            std::lock_guard<std::mutex> lock(threads_mutex);
+            auto i = threads.find(tid);
+            if (i == threads.end()) {
+                swoole_warning("AIO thread#%s is missing", swoole_thread_id_to_str(tid).c_str());
+                return;
+            }
+            _thread = i->second;
+            threads.erase(i);
+            remaining_thread_num = threads.size();
         }
-        std::thread *_thread = i->second;
         swoole_trace_log(SW_TRACE_AIO,
                          "release idle thread#%s, we have %zu now",
                          swoole_thread_id_to_str(tid).c_str(),
-                         threads.size() - 1);
+                         remaining_thread_num);
         if (_thread->joinable()) {
             _thread->join();
         }
-        threads.erase(i);
         delete _thread;
     }
 
@@ -216,6 +237,7 @@ class ThreadPool {
     std::atomic<size_t> n_closing{0};
     size_t current_task_id = 0;
     std::unordered_map<std::thread::id, std::thread *> threads;
+    mutable std::mutex threads_mutex;
     EventQueue queue_;
     std::mutex event_mutex;
     std::condition_variable _cv;
@@ -291,6 +313,7 @@ void ThreadPool::main_func(const bool is_core_worker) {
 void ThreadPool::create_thread(const bool is_core_worker) {
     try {
         auto *_thread = new std::thread([this, is_core_worker]() { main_func(is_core_worker); });
+        std::lock_guard<std::mutex> lock(threads_mutex);
         threads[_thread->get_id()] = _thread;
     } catch (const std::system_error &e) {
         swoole_sys_notice("create aio thread failed, please check your system configuration or adjust aio_worker_num");

--- a/tests/swoole_coroutine_system/aio_worker_scheduling.phpt
+++ b/tests/swoole_coroutine_system/aio_worker_scheduling.phpt
@@ -1,0 +1,104 @@
+--TEST--
+swoole_coroutine_system: queued lock holder expands the AIO thread pool
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_defined('SWOOLE_HOOK_PDO_SQLITE');
+?>
+--FILE--
+<?php
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\System;
+
+use function Swoole\Coroutine\go;
+use function Swoole\Coroutine\run;
+
+swoole_async_set([
+    'aio_core_worker_num' => 2,
+    'aio_worker_num' => 4,
+]);
+Coroutine::set(['hook_flags' => SWOOLE_HOOK_PDO_SQLITE]);
+
+require __DIR__ . '/../include/bootstrap.php';
+
+$database = __DIR__ . '/aio_worker_scheduling.db';
+$dsn = 'sqlite:' . $database;
+@unlink($database);
+@unlink($database . '-journal');
+
+run(function () use ($dsn) {
+    // Start the pool before SQLite setup so setup tasks cannot affect the saturation boundary.
+    System::readFile(__FILE__);
+    System::sleep(0.05);
+    $workerNum = Coroutine::stats()['aio_worker_num'];
+
+    $holder = new PDO($dsn, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $holder->exec('CREATE TABLE counter (value INTEGER NOT NULL)');
+    $holder->exec('INSERT INTO counter VALUES (0)');
+
+    $waiters = [];
+    for ($i = 0; $i < 3; $i++) {
+        $waiters[$i] = new PDO($dsn, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $waiters[$i]->exec('PRAGMA busy_timeout = 5000');
+    }
+
+    $holder->exec('BEGIN IMMEDIATE');
+    $holder->exec('UPDATE counter SET value = value + 1');
+
+    System::sleep(0.05);
+    Assert::same(Coroutine::stats()['aio_worker_num'], $workerNum);
+    if ($workerNum >= 4) {
+        throw new RuntimeException('AIO pool has no capacity for the regression test');
+    }
+    $waiters = array_slice($waiters, 0, $workerNum);
+
+    $started = new Channel(1);
+    $results = new Channel($workerNum);
+
+    foreach ($waiters as $index => $waiter) {
+        go(function () use ($waiter, $started, $results) {
+            $started->push(true);
+            try {
+                $waiter->exec('UPDATE counter SET value = value + 1');
+                $results->push(true);
+            } catch (Throwable $exception) {
+                $results->push($exception->getMessage());
+            }
+        });
+
+        $started->pop();
+        $deadline = microtime(true) + 2;
+        do {
+            $stats = Coroutine::stats();
+            if ($stats['aio_task_num'] === $index + 1 &&
+                $stats['aio_worker_num'] === $workerNum &&
+                $stats['aio_queue_size'] === 0) {
+                break;
+            }
+            System::sleep(0.001);
+        } while (microtime(true) < $deadline);
+
+        Assert::same($stats['aio_task_num'], $index + 1);
+        Assert::same($stats['aio_worker_num'], $workerNum);
+        Assert::same($stats['aio_queue_size'], 0);
+    }
+
+    $holder->exec('COMMIT');
+    Assert::same(Coroutine::stats()['aio_worker_num'], $workerNum + 1);
+
+    for ($i = 0; $i < $workerNum; $i++) {
+        Assert::true($results->pop(5));
+    }
+    Assert::same($holder->query('SELECT value FROM counter')->fetchColumn(), $workerNum + 1);
+});
+
+echo "DONE\n";
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/aio_worker_scheduling.db');
+@unlink(__DIR__ . '/aio_worker_scheduling.db-journal');
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
## Summary

Backports the AIO worker scheduling correction from `51e108610` to the `6.2` branch.

The existing dispatcher checks whether the pool should grow before adding the incoming task to the queue. If every worker is blocked and that task would release them, the task is invisible to the scheduler and can remain queued indefinitely.

This change:

- enqueues the task before evaluating worker demand;
- creates only the workers needed for queued work not covered by idle workers, up to `aio_worker_num`;
- synchronizes the worker map across creation, release, shutdown, and statistics reads;
- adds a SQLite regression that saturates the active workers and verifies the transaction commit can trigger bounded pool growth.

This changes the pool's resource profile to match `master`: the first AIO operation may leave the pool at its core size or core size plus one, depending on thread-start timing, and bursts may create transient workers up to the configured limit. Dynamic workers still retire after the existing idle timeout. Dispatch also performs one synchronized worker-count read.

## Testing

- Built the extension with developer checks and coroutine SQLite enabled.
- Ran the new regression repeatedly against the corrected scheduler.
- Confirmed the regression fails against the previous `6.2` scheduler.
- Ran the existing AIO worker-growth regression and the applicable coroutine-system tests.
