### PR TITLE
Fix SocketPair deletion through base pointers

### DIFF
--- a/core-tests/src/os/pipe.cpp
+++ b/core-tests/src/os/pipe.cpp
@@ -1,7 +1,14 @@
 #include "test_core.h"
 #include "swoole_pipe.h"
 
+#include <type_traits>
+
 using namespace swoole;
+
+TEST(pipe, virtual_destructor) {
+    // AsyncThreads deletes its platform-specific pipe through SocketPair *.
+    ASSERT_TRUE(std::has_virtual_destructor<SocketPair>::value);
+}
 
 TEST(pipe, unixsock) {
     UnixSocket p(true, SOCK_DGRAM);

--- a/include/swoole_pipe.h
+++ b/include/swoole_pipe.h
@@ -49,7 +49,7 @@ class SocketPair {
         blocking = _blocking;
         timeout = network::Socket::default_read_timeout;
     }
-    ~SocketPair();
+    virtual ~SocketPair();
 
     ssize_t read(void *_buf, size_t length) const;
     ssize_t write(const void *_buf, size_t length) const;


### PR DESCRIPTION
## Summary

`AsyncThreads` owns either `Pipe` or `UnixSocket` through `SocketPair *` and deletes it through that base pointer during failure cleanup and normal teardown. `SocketPair` has a non-virtual destructor, so those deletes have undefined behavior.

ASAN reports a `new-delete-type-mismatch` when `swoole_event_free()` tears down the async thread pool. Make the base destructor virtual and add a deterministic core regression for the ownership contract.

SSH2 happened to expose the failure, but the defect is in the core async-thread teardown path.

## Testing

The focused pipe core tests pass in normal and ASAN builds. The original ASAN reproduction also completes without a sanitizer report.
