### PR TITLE
Fix ProcessPool listener ownership and partial-start cleanup

### DIFF
--- a/core-tests/src/os/process_pool.cpp
+++ b/core-tests/src/os/process_pool.cpp
@@ -100,6 +100,30 @@ TEST(process_pool, unix_sock) {
     test_func_task_protocol(pool);
 }
 
+TEST(process_pool, failed_unix_listen_can_retry) {
+    std::string socket_file = "/tmp/swoole-process-pool-listen-" + std::to_string(getpid()) + ".sock";
+    unlink(socket_file.c_str());
+    ON_SCOPE_EXIT {
+        unlink(socket_file.c_str());
+    };
+
+    int file_fd = open(socket_file.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0600);
+    ASSERT_GE(file_fd, 0);
+    ASSERT_EQ(close(file_fd), 0);
+
+    ProcessPool pool{};
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen(socket_file.c_str(), 128), SW_ERR);
+    ASSERT_EQ(pool.stream_info_->socket_file, nullptr);
+    ASSERT_EQ(pool.stream_info_->socket, nullptr);
+    ASSERT_EQ(access(socket_file.c_str(), F_OK), 0);
+
+    ASSERT_EQ(unlink(socket_file.c_str()), 0);
+    ASSERT_EQ(pool.listen(socket_file.c_str(), 128), SW_OK);
+    pool.destroy();
+    ASSERT_EQ(access(socket_file.c_str(), F_OK), -1);
+}
+
 TEST(process_pool, push_message_too_large) {
     ProcessPool pool{};
     ASSERT_EQ(pool.create(1, 0, SW_IPC_UNIXSOCK), SW_OK);

--- a/core-tests/src/os/process_pool.cpp
+++ b/core-tests/src/os/process_pool.cpp
@@ -124,6 +124,42 @@ TEST(process_pool, failed_unix_listen_can_retry) {
     ASSERT_EQ(access(socket_file.c_str(), F_OK), -1);
 }
 
+TEST(process_pool, listen_only_once) {
+    ProcessPool pool{};
+    int svr_port = TEST_PORT + __LINE__;
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen(TEST_HOST, svr_port, 128), SW_OK);
+
+    auto *listening = pool.stream_info_->socket;
+    auto *listening_address = pool.stream_info_->socket_file;
+    ASSERT_EQ(pool.listen(TEST_HOST, svr_port + 1, 128), SW_ERR);
+    ASSERT_ERREQ(SW_ERROR_WRONG_OPERATION);
+    ASSERT_EQ(pool.stream_info_->socket, listening);
+    ASSERT_EQ(pool.stream_info_->socket_file, listening_address);
+    ASSERT_EQ(pool.stream_info_->socket_port, svr_port);
+
+    pool.destroy();
+}
+
+TEST(process_pool, kill_all_workers_before_start) {
+    // Unspawned worker slots hold pid 0. Without the guard in kill_all_workers() this becomes
+    // kill(0, SIGTERM) and signals the whole process group, so the child moves into its own group
+    // first and the parent checks it exited normally rather than dying from the signal.
+    auto status = test::spawn_exec_and_wait([]() {
+        if (setpgid(0, 0) < 0) {
+            exit(1);
+        }
+        ProcessPool pool{};
+        if (pool.create(2) != SW_OK) {
+            exit(1);
+        }
+        pool.kill_all_workers(SIGTERM);
+        pool.destroy();
+    });
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+}
+
 TEST(process_pool, push_message_too_large) {
     ProcessPool pool{};
     ASSERT_EQ(pool.create(1, 0, SW_IPC_UNIXSOCK), SW_OK);

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -172,15 +172,18 @@ int ProcessPool::listen(const char *socket_file, int backlog) const {
         swoole_error_log(SW_LOG_WARNING, SW_ERROR_OPERATION_NOT_SUPPORT, "not support, ipc_mode must be SW_IPC_SOCKET");
         return SW_ERR;
     }
-    stream_info_->socket_file = sw_strdup(socket_file);
-    if (stream_info_->socket_file == nullptr) {
+    char *_socket_file = sw_strdup(socket_file);
+    if (_socket_file == nullptr) {
         return SW_ERR;
     }
+    auto _socket = make_server_socket(SW_SOCK_UNIX_STREAM, socket_file, 0, backlog);
+    if (!_socket) {
+        sw_free(_socket_file);
+        return SW_ERR;
+    }
+    stream_info_->socket_file = _socket_file;
     stream_info_->socket_port = 0;
-    stream_info_->socket = make_server_socket(SW_SOCK_UNIX_STREAM, stream_info_->socket_file, 0, backlog);
-    if (!stream_info_->socket) {
-        return SW_ERR;
-    }
+    stream_info_->socket = _socket;
     return SW_OK;
 }
 
@@ -189,15 +192,18 @@ int ProcessPool::listen(const char *host, int port, int backlog) const {
         swoole_error_log(SW_LOG_WARNING, SW_ERROR_OPERATION_NOT_SUPPORT, "not support, ipc_mode must be SW_IPC_SOCKET");
         return SW_ERR;
     }
-    stream_info_->socket_file = sw_strdup(host);
-    if (stream_info_->socket_file == nullptr) {
+    char *_socket_file = sw_strdup(host);
+    if (_socket_file == nullptr) {
         return SW_ERR;
     }
+    auto _socket = make_server_socket(SW_SOCK_TCP, host, port, backlog);
+    if (!_socket) {
+        sw_free(_socket_file);
+        return SW_ERR;
+    }
+    stream_info_->socket_file = _socket_file;
     stream_info_->socket_port = port;
-    stream_info_->socket = make_server_socket(SW_SOCK_TCP, host, port, backlog);
-    if (!stream_info_->socket) {
-        return SW_ERR;
-    }
+    stream_info_->socket = _socket;
     return SW_OK;
 }
 
@@ -472,8 +478,11 @@ void ProcessPool::reopen_logger() {
 }
 
 void ProcessPool::kill_all_workers(int signo) {
+    // A zero pid would signal the entire process group while unwinding a partial spawn.
     SW_LOOP_N(worker_num) {
-        swoole_kill(workers[i].pid, signo);
+        if (workers[i].pid > 0) {
+            swoole_kill(workers[i].pid, signo);
+        }
     }
 }
 
@@ -1007,6 +1016,9 @@ int ProcessPool::wait() {
     // concurrent kill
     for (i = 0; i < worker_num; i++) {
         worker = &workers[i];
+        if (worker->pid <= 0) {
+            continue;
+        }
         if (swoole_kill(worker->pid, SIGTERM) < 0) {
             swoole_sys_warning("kill(%d, SIGTERM) failed", worker->pid);
             continue;
@@ -1017,6 +1029,9 @@ int ProcessPool::wait() {
     }
     for (i = 0; i < worker_num; i++) {
         worker = &workers[i];
+        if (worker->pid <= 0) {
+            continue;
+        }
         if (swoole_waitpid(worker->pid, &status, 0) < 0) {
             swoole_sys_warning("waitpid(%d) failed", worker->pid);
         }

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -167,44 +167,37 @@ int ProcessPool::create_message_bus() {
     return SW_OK;
 }
 
-int ProcessPool::listen(const char *socket_file, int backlog) const {
-    if (ipc_mode != SW_IPC_SOCKET) {
+static int ProcessPool_listen(
+    const ProcessPool *pool, SocketType socket_type, const char *address, int port, int backlog) {
+    if (pool->ipc_mode != SW_IPC_SOCKET) {
         swoole_error_log(SW_LOG_WARNING, SW_ERROR_OPERATION_NOT_SUPPORT, "not support, ipc_mode must be SW_IPC_SOCKET");
         return SW_ERR;
     }
-    char *_socket_file = sw_strdup(socket_file);
+    if (pool->stream_info_->socket) {
+        swoole_error_log(SW_LOG_WARNING, SW_ERROR_WRONG_OPERATION, "the process pool is already listening");
+        return SW_ERR;
+    }
+    char *_socket_file = sw_strdup(address);
     if (_socket_file == nullptr) {
         return SW_ERR;
     }
-    auto _socket = make_server_socket(SW_SOCK_UNIX_STREAM, socket_file, 0, backlog);
+    auto _socket = make_server_socket(socket_type, address, port, backlog);
     if (!_socket) {
         sw_free(_socket_file);
         return SW_ERR;
     }
-    stream_info_->socket_file = _socket_file;
-    stream_info_->socket_port = 0;
-    stream_info_->socket = _socket;
+    pool->stream_info_->socket_file = _socket_file;
+    pool->stream_info_->socket_port = port;
+    pool->stream_info_->socket = _socket;
     return SW_OK;
 }
 
+int ProcessPool::listen(const char *socket_file, int backlog) const {
+    return ProcessPool_listen(this, SW_SOCK_UNIX_STREAM, socket_file, 0, backlog);
+}
+
 int ProcessPool::listen(const char *host, int port, int backlog) const {
-    if (ipc_mode != SW_IPC_SOCKET) {
-        swoole_error_log(SW_LOG_WARNING, SW_ERROR_OPERATION_NOT_SUPPORT, "not support, ipc_mode must be SW_IPC_SOCKET");
-        return SW_ERR;
-    }
-    char *_socket_file = sw_strdup(host);
-    if (_socket_file == nullptr) {
-        return SW_ERR;
-    }
-    auto _socket = make_server_socket(SW_SOCK_TCP, host, port, backlog);
-    if (!_socket) {
-        sw_free(_socket_file);
-        return SW_ERR;
-    }
-    stream_info_->socket_file = _socket_file;
-    stream_info_->socket_port = port;
-    stream_info_->socket = _socket;
-    return SW_OK;
+    return ProcessPool_listen(this, SW_SOCK_TCP, host, port, backlog);
 }
 
 void ProcessPool::set_protocol(swProtocolType _protocol_type) {
@@ -478,7 +471,8 @@ void ProcessPool::reopen_logger() {
 }
 
 void ProcessPool::kill_all_workers(int signo) {
-    // A zero pid would signal the entire process group while unwinding a partial spawn.
+    // reopen_logger() can run from a signal handler before start() has spawned every worker.
+    // Unspawned slots still hold pid 0, and kill(0, ...) would signal the whole process group.
     SW_LOOP_N(worker_num) {
         if (workers[i].pid > 0) {
             swoole_kill(workers[i].pid, signo);
@@ -1016,9 +1010,6 @@ int ProcessPool::wait() {
     // concurrent kill
     for (i = 0; i < worker_num; i++) {
         worker = &workers[i];
-        if (worker->pid <= 0) {
-            continue;
-        }
         if (swoole_kill(worker->pid, SIGTERM) < 0) {
             swoole_sys_warning("kill(%d, SIGTERM) failed", worker->pid);
             continue;
@@ -1029,9 +1020,6 @@ int ProcessPool::wait() {
     }
     for (i = 0; i < worker_num; i++) {
         worker = &workers[i];
-        if (worker->pid <= 0) {
-            continue;
-        }
         if (swoole_waitpid(worker->pid, &status, 0) < 0) {
             swoole_sys_warning("waitpid(%d) failed", worker->pid);
         }


### PR DESCRIPTION
## Summary

ProcessPool publishes listener state before socket creation succeeds. A failed task-worker stream listen can therefore leak the copied address, leave stale state behind, and prevent a clean retry. A second successful listen can also overwrite the active listener.

Build listener state locally and publish it only after socket creation succeeds. Share that setup between the Unix and TCP overloads, and reject attempts to replace an active listener.

Signal-driven log reopening can run before initial worker spawning completes. Skip zero-valued pid slots in `kill_all_workers()` so `kill(0, ...)` cannot target the master process group.

## Testing

- focused ProcessPool core tests