### PR TITLE
Fix Windows IOCP and interface tests

### DIFF
--- a/tests/swoole_function/swoole_get_local_ip.phpt
+++ b/tests/swoole_function/swoole_get_local_ip.phpt
@@ -7,10 +7,16 @@ swoole_function: get local ip
 require __DIR__ . '/../include/bootstrap.php';
 
 $ips = swoole_get_local_ip();
-foreach ($ips as $ip) {
-    Assert::same(filter_var($ip, FILTER_VALIDATE_IP), $ip);
-    Assert::assert(strstr($ip, ".", true) !== "127");
+Assert::isArray($ips);
+Assert::notEmpty($ips);
+
+foreach ($ips as $name => $ip) {
+    Assert::stringNotEmpty($name);
+    Assert::same(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
+    Assert::false(str_starts_with($ip, '127.'));
 }
 
+echo "DONE\n";
 ?>
 --EXPECT--
+DONE

--- a/tests/swoole_function/swoole_get_local_mac.phpt
+++ b/tests/swoole_function/swoole_get_local_mac.phpt
@@ -7,10 +7,15 @@ swoole_function: get mac address
 require __DIR__ . '/../include/bootstrap.php';
 
 $macs = swoole_get_local_mac();
-Assert::assert(is_array($macs));
-foreach ($macs as $mac) {
+Assert::isArray($macs);
+Assert::notEmpty($macs);
+
+foreach ($macs as $name => $mac) {
+    Assert::stringNotEmpty($name);
     Assert::same(filter_var($mac, FILTER_VALIDATE_MAC), $mac);
 }
 
+echo "DONE\n";
 ?>
 --EXPECT--
+DONE

--- a/tests/swoole_windows/iocp_curl.phpt
+++ b/tests/swoole_windows/iocp_curl.phpt
@@ -17,51 +17,78 @@ require __DIR__ . '/../include/bootstrap.php';
 use Swoole\Runtime;
 use function Swoole\Coroutine\run;
 
-$pm = new SwooleTest\ProcessManager();
-$pm->parentFunc = function () use ($pm) {
-    Runtime::enableCoroutine(SWOOLE_HOOK_CURL);
+Runtime::enableCoroutine(SWOOLE_HOOK_CURL);
 
-    run(function () use ($pm) {
+run(function (): void {
+    $server = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    try {
+        if (!Assert::true($server->bind('127.0.0.1', 0))) {
+            return;
+        }
+        if (!Assert::true($server->listen())) {
+            return;
+        }
+
+        $address = $server->getsockname();
+        if (!Assert::isArray($address)) {
+            return;
+        }
+        if (!Assert::greaterThan($address['port'], 0)) {
+            return;
+        }
+        $port = $address['port'];
+
+        $completed = new Swoole\Coroutine\Channel(1);
+        go(function () use ($server, $completed): void {
+            try {
+                $connection = $server->accept(5);
+                if (!Assert::assert($connection !== false, 'failed to accept http request')) {
+                    return;
+                }
+                try {
+                    $request = '';
+                    while (!str_contains($request, "\r\n\r\n")) {
+                        $chunk = $connection->recv(1024, 5);
+                        if (!Assert::assert($chunk !== false && $chunk !== '', 'failed to read http request')) {
+                            return;
+                        }
+                        $request .= $chunk;
+                    }
+                    Assert::contains($request, 'GET / HTTP/1.1');
+
+                    $response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nPONG\n";
+                    Assert::same($connection->sendAll($response, 5), strlen($response));
+                } finally {
+                    $connection->close();
+                }
+            } finally {
+                $completed->push(true);
+            }
+        });
+
         $ch = curl_init();
         Assert::isInstanceOf($ch, Swoole\Curl\Handler::class);
+        try {
+            curl_setopt($ch, CURLOPT_URL, 'http://127.0.0.1:' . $port . '/');
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_HEADER, false);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 
-        curl_setopt($ch, CURLOPT_URL, 'http://127.0.0.1:' . $pm->getFreePort() . '/');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HEADER, false);
+            $body = curl_exec($ch);
+            Assert::same($body, "PONG\n");
+            Assert::same(curl_getinfo($ch, CURLINFO_HTTP_CODE), 200);
+        } finally {
+            curl_close($ch);
 
-        $body = curl_exec($ch);
-        Assert::same($body, "PONG\n");
-        Assert::same(curl_getinfo($ch, CURLINFO_HTTP_CODE), 200);
-        curl_close($ch);
-    });
-
-    echo "DONE\n";
-};
-$pm->childFunc = function () use ($pm) {
-    $port = $pm->getFreePort();
-    $server = stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
-    Assert::assert($server !== false, $errstr ?: 'failed to create socket server');
-    $pm->wakeup();
-
-    $conn = stream_socket_accept($server, 10);
-    Assert::assert($conn !== false, 'failed to accept http request');
-
-    $request = '';
-    while (!str_contains($request, "\r\n\r\n")) {
-        $chunk = fread($conn, 1024);
-        if ($chunk === '' || $chunk === false) {
-            break;
+            $acceptCompleted = $completed->pop(6);
+            Assert::same($acceptCompleted, true);
         }
-        $request .= $chunk;
+    } finally {
+        $server->close();
     }
-    Assert::contains($request, 'GET / HTTP/1.1');
+});
 
-    fwrite($conn, "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nPONG\n");
-    fclose($conn);
-    fclose($server);
-};
-$pm->childFirst();
-$pm->run();
+echo "DONE\n";
 ?>
 --EXPECT--
 DONE

--- a/tests/swoole_windows/iocp_socket.phpt
+++ b/tests/swoole_windows/iocp_socket.phpt
@@ -6,9 +6,6 @@ require __DIR__ . '/../include/skipif.inc';
 if (stripos(PHP_OS, 'WIN') !== 0) {
     die('skip Windows only');
 }
-if (!class_exists(Swoole\Coroutine\Socket::class, false)) {
-    die('skip coroutine socket not available');
-}
 ?>
 --FILE--
 <?php
@@ -16,33 +13,66 @@ require __DIR__ . '/../include/bootstrap.php';
 
 use function Swoole\Coroutine\run;
 
-$pm = new SwooleTest\ProcessManager();
-$pm->parentFunc = function () use ($pm) {
-    run(function () use ($pm) {
-        $sock = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-        Assert::assert($sock->connect('127.0.0.1', $pm->getFreePort()));
-        Assert::assert($sock->send('ping'));
-        Assert::same($sock->recv(4, 1.0), 'pong');
-        $sock->close();
-    });
-    echo "DONE\n";
-};
-$pm->childFunc = function () use ($pm) {
-    $port = $pm->getFreePort();
-    $server = stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
-    Assert::assert($server !== false, $errstr ?: 'failed to create socket server');
-    $pm->wakeup();
+run(function (): void {
+    $server = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    try {
+        if (!Assert::true($server->bind('127.0.0.1', 0))) {
+            return;
+        }
+        if (!Assert::true($server->listen())) {
+            return;
+        }
 
-    $conn = stream_socket_accept($server, 10);
-    Assert::assert($conn !== false, 'failed to accept socket');
-    $data = fread($conn, 4);
-    Assert::same('ping', $data);
-    fwrite($conn, 'pong');
-    fclose($conn);
-    fclose($server);
-};
-$pm->childFirst();
-$pm->run();
+        $address = $server->getsockname();
+        if (!Assert::isArray($address)) {
+            return;
+        }
+        if (!Assert::greaterThan($address['port'], 0)) {
+            return;
+        }
+        $port = $address['port'];
+
+        $completed = new Swoole\Coroutine\Channel(1);
+        go(function () use ($server, $completed): void {
+            try {
+                $connection = $server->accept(5);
+                if (!Assert::assert($connection !== false, 'failed to accept socket')) {
+                    return;
+                }
+                try {
+                    if (!Assert::same($connection->recvAll(4, 5), 'ping')) {
+                        return;
+                    }
+                    Assert::same($connection->sendAll('pong', 5), 4);
+                } finally {
+                    $connection->close();
+                }
+            } finally {
+                $completed->push(true);
+            }
+        });
+
+        $client = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        try {
+            if (!Assert::true($client->connect('127.0.0.1', $port, 5))) {
+                return;
+            }
+            if (!Assert::same($client->sendAll('ping', 5), 4)) {
+                return;
+            }
+            Assert::same($client->recvAll(4, 5), 'pong');
+        } finally {
+            $client->close();
+
+            $acceptCompleted = $completed->pop(6);
+            Assert::same($acceptCompleted, true);
+        }
+    } finally {
+        $server->close();
+    }
+});
+
+echo "DONE\n";
 ?>
 --EXPECT--
 DONE

--- a/tests/swoole_windows/local_ip.phpt
+++ b/tests/swoole_windows/local_ip.phpt
@@ -12,12 +12,13 @@ if (stripos(PHP_OS, 'WIN') !== 0) {
 require __DIR__ . '/../include/bootstrap.php';
 
 $ips = swoole_get_local_ip();
-Assert::assert(is_array($ips));
-Assert::assert(!empty($ips));
-Assert::same('127.0.0.1', $ips[0]);
+Assert::isArray($ips);
+Assert::notEmpty($ips);
 
-foreach ($ips as $ip) {
+foreach ($ips as $name => $ip) {
+    Assert::stringNotEmpty($name);
     Assert::same(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4), $ip);
+    Assert::false(str_starts_with($ip, '127.'));
 }
 
 echo "DONE\n";

--- a/tests/swoole_windows/local_mac.phpt
+++ b/tests/swoole_windows/local_mac.phpt
@@ -12,10 +12,11 @@ if (stripos(PHP_OS, 'WIN') !== 0) {
 require __DIR__ . '/../include/bootstrap.php';
 
 $macs = swoole_get_local_mac();
-Assert::assert(is_array($macs));
-Assert::assert(!empty($macs));
+Assert::isArray($macs);
+Assert::notEmpty($macs);
 
-foreach ($macs as $mac) {
+foreach ($macs as $name => $mac) {
+    Assert::stringNotEmpty($name);
     Assert::same(filter_var($mac, FILTER_VALIDATE_MAC), $mac);
 }
 


### PR DESCRIPTION
The Windows IOCP tests never reached IOCP. `ProcessManager` requires `Swoole\Atomic`, which is unavailable on Windows, and the socket test used the undefined `IPPROTO_TCP` constant.

This replaces the process fixtures with local coroutine socket listeners and bounded cleanup. It also updates the IP and MAC tests to verify the associative interface map returned by the API.

The focused fixture and interface tests pass locally. The Windows workflow will cover the IOCP and Windows adapter paths.

EDIT: The previously failing Unit Test on Windows (windows-2022, ts) job now passes.