### PR TITLE
Preserve Atomic wakeups across interrupted waits

### DIFF
--- a/core-tests/src/core/base.cpp
+++ b/core-tests/src/core/base.cpp
@@ -26,6 +26,10 @@
 
 #include "swoole_api.h"
 
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <pthread.h>
 #include <sys/resource.h>
 
 using namespace swoole;
@@ -462,16 +466,74 @@ TEST(base, futex) {
     std::thread t2([&value] {
         usleep(100000);
         DEBUG() << "wakeup 1\n";
+#ifdef HAVE_FUTEX
         ASSERT_EQ(sw_atomic_futex_wakeup(&value, 1), 1);
+#else
+        ASSERT_EQ(sw_atomic_futex_wakeup(&value, 1), 0);
+#endif
 
         DEBUG() << "wakeup 2\n";
         usleep(100000);
+#ifdef HAVE_FUTEX
         ASSERT_EQ(sw_atomic_futex_wakeup(&value, 1), 1);
+#else
+        ASSERT_EQ(sw_atomic_futex_wakeup(&value, 1), 0);
+#endif
     });
 
     t1.join();
     t2.join();
 }
+
+#ifdef HAVE_FUTEX
+static volatile sig_atomic_t atomic_wait_signal_count;
+
+static void atomic_wait_signal_handler(int) {
+    atomic_wait_signal_count++;
+}
+
+TEST(base, futex_interrupted) {
+    struct sigaction action = {};
+    struct sigaction old_action = {};
+    action.sa_handler = atomic_wait_signal_handler;
+    sigemptyset(&action.sa_mask);
+    ASSERT_EQ(sigaction(SIGUSR1, &action, &old_action), 0);
+
+    sw_atomic_t value = 0;
+    std::atomic<bool> started{false};
+    std::atomic<bool> completed{false};
+    int wait_result = SW_ERR;
+    atomic_wait_signal_count = 0;
+
+    std::thread waiter([&] {
+        started = true;
+        wait_result = sw_atomic_futex_wait(&value, 5);
+        completed = true;
+    });
+
+    while (!started) {
+        std::this_thread::yield();
+    }
+    usleep(20000);
+    const int kill_result = pthread_kill(waiter.native_handle(), SIGUSR1);
+    const auto signal_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (atomic_wait_signal_count == 0 && std::chrono::steady_clock::now() < signal_deadline) {
+        std::this_thread::yield();
+    }
+    usleep(20000);
+    const bool completed_after_interrupt = completed;
+
+    sw_atomic_futex_wakeup(&value, 1);
+    waiter.join();
+    const int restore_result = sigaction(SIGUSR1, &old_action, nullptr);
+
+    EXPECT_EQ(kill_result, 0);
+    EXPECT_GT(atomic_wait_signal_count, 0);
+    EXPECT_FALSE(completed_after_interrupt);
+    EXPECT_EQ(wait_result, SW_OK);
+    EXPECT_EQ(restore_result, 0);
+}
+#endif
 
 static int test_fork_fail(const std::function<void(void)> &after_fork_fail = nullptr) {
     rlimit rl{};

--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -16,6 +16,7 @@
 
 #include "swoole.h"
 
+#include <chrono>
 #include <thread>
 
 void sw_spinlock(sw_atomic_t *lock) {
@@ -44,23 +45,42 @@ void sw_spinlock(sw_atomic_t *lock) {
 #include <sys/syscall.h>
 
 int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout) {
-    if (sw_atomic_cmp_set(atomic, 1, 0)) {
-        return 0;
-    }
+    using Clock = std::chrono::steady_clock;
 
-    int ret;
-    timespec _timeout;
+    const bool timed = timeout > 0;
+    const auto deadline =
+        timed ? Clock::now() + std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(timeout))
+              : Clock::time_point{};
 
-    if (timeout > 0) {
-        _timeout.tv_sec = static_cast<long>(timeout);
-        _timeout.tv_nsec = (timeout - _timeout.tv_sec) * 1000 * 1000 * 1000;
-        ret = syscall(SYS_futex, atomic, FUTEX_WAIT, 0, &_timeout, NULL, 0);
-    } else {
-        ret = syscall(SYS_futex, atomic, FUTEX_WAIT, 0, NULL, NULL, 0);
-    }
-    if (ret == 0 && sw_atomic_cmp_set(atomic, 1, 0)) {
-        return 0;
-    } else {
+    while (true) {
+        if (sw_atomic_cmp_set(atomic, 1, 0)) {
+            return 0;
+        }
+
+        timespec _timeout;
+        timespec *timeout_ptr = nullptr;
+        if (timed) {
+            const auto remaining = deadline - Clock::now();
+            if (remaining <= Clock::duration::zero()) {
+                return -1;
+            }
+            const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(remaining);
+            _timeout.tv_sec = seconds.count();
+            _timeout.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(remaining - seconds).count();
+            timeout_ptr = &_timeout;
+        }
+
+        const int ret = syscall(SYS_futex, atomic, FUTEX_WAIT, 0, timeout_ptr, NULL, 0);
+        if (ret == 0) {
+            // FUTEX_WAKE may release multiple waiters, but only one can consume the shared wakeup flag. The others
+            // must still report success because wakeup(n) releases n waiters.
+            sw_atomic_cmp_set(atomic, 1, 0);
+            return 0;
+        }
+        // A wakeup can set the flag just before FUTEX_WAIT, and signals may interrupt an otherwise valid wait.
+        if (errno == EAGAIN || errno == EINTR) {
+            continue;
+        }
         return -1;
     }
 }
@@ -77,18 +97,30 @@ int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout) {
     if (sw_atomic_cmp_set(atomic, (sw_atomic_t) 1, (sw_atomic_t) 0)) {
         return 0;
     }
-    timeout = timeout <= 0 ? INT_MAX : timeout;
+
+    using Clock = std::chrono::steady_clock;
+
+    const bool timed = timeout > 0;
+    const auto deadline =
+        timed ? Clock::now() + std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(timeout))
+              : Clock::time_point{};
     int32_t i = (int32_t) sw_atomic_sub_fetch(atomic, 1);
-    while (timeout > 0) {
+    if (i >= 0) {
+        return 0;
+    }
+    while (true) {
         if ((int32_t) *atomic > i) {
             return 0;
-        } else {
-            sw_usleep(1000);
-            timeout -= 0.001;
         }
+        if (timed && Clock::now() >= deadline) {
+            break;
+        }
+        sw_usleep(1000);
     }
-    sw_atomic_fetch_add(atomic, 1);
-    return -1;
+    if (sw_atomic_cmp_set(atomic, (sw_atomic_t) i, (sw_atomic_t) (i + 1))) {
+        return -1;
+    }
+    return 0;
 }
 
 int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n) {

--- a/tests/swoole_table/conditional_lifecycle.phpt
+++ b/tests/swoole_table/conditional_lifecycle.phpt
@@ -55,14 +55,13 @@ $destroyed = new Atomic(0);
 
 $process = new Process(function () use ($table, $destroyed): void {
     while ($destroyed->get() === 0) {
-        $destroyed->wait(1.0);
+        usleep(1000);
     }
     $table->getdel('row');
 }, true, SOCK_STREAM);
 $process->start();
 $table->destroy();
 $destroyed->set(1);
-$destroyed->wakeup();
 $output = $process->read();
 $status = Process::wait();
 Assert::contains($output, 'table is not created or has been destroyed');

--- a/tests/swoole_table/conditional_race.phpt
+++ b/tests/swoole_table/conditional_race.phpt
@@ -23,7 +23,7 @@ function race(callable $operation): int
         $process = new Process(function () use ($ready, $start, $successes, $operation): void {
             $ready->add();
             while ($start->get() === 0) {
-                $start->wait(1.0);
+                usleep(1000);
             }
             if ($operation()) {
                 $successes->add();
@@ -42,7 +42,6 @@ function race(callable $operation): int
     }
 
     $start->set(1);
-    $start->wakeup(WORKERS);
     foreach ($processes as $_) {
         $status = Process::wait();
         Assert::same($status['code'], 0);


### PR DESCRIPTION
Atomic waits could report failure after a signal interruption, a wakeup race, or a multi-waiter wake. This retries recoverable futex results within the original deadline and resolves the matching timeout race in the polling fallback.

A wakeup that arrives after the kernel has committed a timeout remains pending for the next wait. The futex and polling implementations use different internal mechanisms for `wakeup($n)`, but now expose the same result to callers.

This also removes mixed flag/wait usage from two Table tests that could consume their readiness flag and hang.

The focused Atomic core tests and affected PHPTs pass on both futex and forced polling builds.