### PR TITLE
Fix coroutine HTTP client response parsing

### DIFF
--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -86,6 +86,19 @@ static zend_object_handlers swoole_http_client_coro_handlers;
 static zend_class_entry *swoole_http_client_coro_exception_ce;
 static zend_object_handlers swoole_http_client_coro_exception_handlers;
 
+static zval *http_header_find(HashTable *headers, const char *name, size_t length) {
+    // Header arrays may retain caller-provided or wire casing.
+    zval *value;
+    zend_string *key;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(headers, key, value) {
+        if (key && swoole_strcaseeq(ZSTR_VAL(key), ZSTR_LEN(key), name, length)) {
+            return value;
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+    return nullptr;
+}
+
 static bool websocket_verify_server_handshake(zval *zobject) {
     zend_class_entry *ce = Z_OBJCE_P(zobject);
     zval *zrequest_headers = sw_zend_read_property_ex(ce, zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_REQUEST_HEADERS), 0);
@@ -99,19 +112,19 @@ static bool websocket_verify_server_handshake(zval *zobject) {
         return false;
     }
 
-    zval *zupgrade = zend_hash_str_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("upgrade"));
+    zval *zupgrade = http_header_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("upgrade"));
     if (zupgrade == nullptr || Z_TYPE_P(zupgrade) != IS_STRING ||
         !swoole_http_token_list_contains_value(Z_STRVAL_P(zupgrade), Z_STRLEN_P(zupgrade), "websocket")) {
         return false;
     }
 
-    zval *zconnection = zend_hash_str_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("connection"));
+    zval *zconnection = http_header_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("connection"));
     if (zconnection == nullptr || Z_TYPE_P(zconnection) != IS_STRING ||
         !swoole_http_token_list_contains_value(Z_STRVAL_P(zconnection), Z_STRLEN_P(zconnection), "Upgrade")) {
         return false;
     }
 
-    zval *zaccept = zend_hash_str_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("sec-websocket-accept"));
+    zval *zaccept = http_header_find(Z_ARRVAL_P(zresponse_headers), ZEND_STRL("sec-websocket-accept"));
     if (zaccept == nullptr || Z_TYPE_P(zaccept) != IS_STRING || Z_STRLEN_P(zaccept) == 0) {
         return false;
     }
@@ -158,7 +171,6 @@ class Client {
     uint8_t max_retries = 0;
     bool keep_alive = true;  // enable by default
     bool websocket = false;  // if upgrade successfully
-    bool chunked = false;    // Transfer-Encoding: chunked
 
     bool body_decompression = true;
     bool http_compression = true;
@@ -473,21 +485,22 @@ static int http_parser_on_header_value(llhttp_t *parser, const char *at, size_t 
 
     http->add_header(header_name, header_len, (char *) at, length);
 
-    if (parser->status_code == SW_HTTP_SWITCHING_PROTOCOLS && SW_STREQ(header_name, header_len, "upgrade")) {
+    if (parser->status_code == SW_HTTP_SWITCHING_PROTOCOLS && SW_STRCASEEQ(header_name, header_len, "upgrade")) {
         if (swoole_http_token_list_contains_value(at, length, "websocket")) {
             http->websocket = true;
         }
         /* TODO: protocol error? */
     }
 #ifdef SW_HAVE_ZLIB
-    else if (http->websocket && http->websocket_settings.compression &&
-             SW_STREQ(header_name, header_len, "sec-websocket-extensions")) {
+    // Extension negotiation must not depend on Upgrade appearing first on the wire.
+    else if (parser->status_code == SW_HTTP_SWITCHING_PROTOCOLS && http->websocket_settings.compression &&
+             SW_STRCASEEQ(header_name, header_len, "sec-websocket-extensions")) {
         if (swoole_strncasestr(at, length, SW_STRL("permessage-deflate"))) {
             http->accept_websocket_compression = true;
         }
     }
 #endif
-    else if (SW_STREQ(header_name, header_len, "set-cookie")) {
+    else if (SW_STRCASEEQ(header_name, header_len, "set-cookie")) {
         zval *zcookies =
             sw_zend_read_and_convert_property_array(swoole_http_client_coro_ce, zobject, ZEND_STRL("cookies"), 0);
         zval *zset_cookie_headers = sw_zend_read_and_convert_property_array(
@@ -495,7 +508,7 @@ static int http_parser_on_header_value(llhttp_t *parser, const char *at, size_t 
         php_swoole_http_parse_set_cookies(at, length, zcookies, zset_cookie_headers);
     }
 #ifdef SW_HAVE_COMPRESSION
-    else if (SW_STREQ(header_name, header_len, "content-encoding")) {
+    else if (SW_STRCASEEQ(header_name, header_len, "content-encoding")) {
         if (false) {
         }
 #ifdef SW_HAVE_BROTLI
@@ -517,11 +530,11 @@ static int http_parser_on_header_value(llhttp_t *parser, const char *at, size_t 
 #endif
     }
 #endif
-    else if (SW_STREQ(header_name, header_len, "transfer-encoding") && SW_STR_ISTARTS_WITH(at, length, "chunked")) {
-        http->chunked = true;
-    } else if (SW_STREQ(header_name, header_len, "connection")) {
-        http->connection_close = SW_STR_ISTARTS_WITH(at, length, "close");
-    } else if (SW_STREQ(header_name, header_len, "content-type")) {
+    else if (SW_STRCASEEQ(header_name, header_len, "connection")) {
+        if (swoole_http_token_list_contains_value(at, length, "close")) {
+            http->connection_close = true;
+        }
+    } else if (SW_STRCASEEQ(header_name, header_len, "content-type")) {
         http->event_stream = SW_STR_ISTARTS_WITH(at, length, "text/event-stream");
     }
 
@@ -986,8 +999,7 @@ bool Client::send_request() {
     // ============   host   ============
     zend::String str_host;
 
-    if ((ZVAL_IS_ARRAY(zheaders)) && (((zvalue = zend_hash_str_find(Z_ARRVAL_P(zheaders), ZEND_STRL("Host")))) ||
-                                      ((zvalue = zend_hash_str_find(Z_ARRVAL_P(zheaders), ZEND_STRL("host")))))) {
+    if (ZVAL_IS_ARRAY(zheaders) && (zvalue = http_header_find(Z_ARRVAL_P(zheaders), ZEND_STRL("Host")))) {
         str_host = zvalue;
     }
 
@@ -1095,8 +1107,8 @@ bool Client::send_request() {
 
             if (SW_STRCASEEQ(key, keylen, "Connection")) {
                 header_flag |= HTTP_HEADER_CONNECTION;
-                if (SW_STRCASEEQ(str_value.val(), str_value.len(), "close")) {
-                    keep_alive = false;
+                if (swoole_http_token_list_contains_value(str_value.val(), str_value.len(), "close")) {
+                    connection_close = true;
                 }
             }
         }
@@ -1115,7 +1127,7 @@ bool Client::send_request() {
         if (keep_alive) {
             add_headers(buffer, ZEND_STRL("Connection"), ZEND_STRL("keep-alive"));
         } else {
-            add_headers(buffer, ZEND_STRL("Connection"), ZEND_STRL("closed"));
+            add_headers(buffer, ZEND_STRL("Connection"), ZEND_STRL("close"));
         }
     }
 #ifdef SW_HAVE_COMPRESSION
@@ -1412,7 +1424,6 @@ bool Client::send_request() {
             buffer->append(ZEND_STRL("\r\n"));
         }
         if (header_too_large(buffer)) {
-            close();
             return false;
         }
     }
@@ -1447,6 +1458,8 @@ bool Client::exec(const std::string &_path) {
     }
     SW_LOOP_N(max_retries + 1) {
         if (send_request() == false) {
+            // Pre-send validation failures do not close and therefore need explicit cleanup.
+            reset();
             return false;
         }
         if (defer) {
@@ -1491,9 +1504,10 @@ bool Client::recv_response(double timeout) {
         if (sw_unlikely(retval <= 0)) {
             if (retval == 0) {
                 socket->set_err(ECONNRESET);
-                if (total_bytes > 0 && !llhttp_should_keep_alive(&parser)) {
+                if (total_bytes > 0 && llhttp_message_needs_eof(&parser)) {
                     llhttp_finish(&parser);
-                    success = true;
+                    // The message-complete callback pauses the parser, so its flag is authoritative.
+                    success = completed;
                     break;
                 }
             }
@@ -1670,6 +1684,7 @@ bool Client::push(zval *zdata, zend_long opcode, uint8_t flags, zend_long code) 
 
 void Client::reset() {
     wait_response = false;
+    connection_close = false;
     completed = false;
     event_stream = false;
 #ifdef SW_HAVE_COMPRESSION
@@ -1697,7 +1712,8 @@ void Client::reset() {
     if (has_upload_files) {
         zend_update_property_null(swoole_http_client_coro_ce, SW_Z8_OBJ_P(zobject), ZEND_STRL("uploadFiles"));
     }
-    if (download_file != nullptr) {
+    // Empty-body downloads have a target name but never open the file.
+    if (download_file != nullptr || download_file_name.get()) {
         download_file.reset();
         download_file_name.release();
         download_offset = 0;

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -353,30 +353,23 @@ static void http_request_add_upload_file(HttpContext *ctx, const char *file, siz
 }
 
 bool swoole_http_token_list_contains_value(const char *at, size_t length, const char *value) {
-    if (0 == length) {
-        return false;
-    }
-    if (SW_STRCASEEQ(at, length, value)) {
-        return true;
-    }
+    const char *end = at + length;
+    const size_t value_length = strlen(value);
 
-    char *var;
-    const char *separator = ",\0";
-    char *strtok_buf = nullptr;
-    size_t var_len;
-
-    char *_c = sw_tg_buffer()->str;
-    memcpy(_c, at, length);
-    _c[length] = '\0';
-
-    var = php_strtok_r(_c, separator, &strtok_buf);
-    while (var) {
-        var_len = swoole::ltrim(&var, strlen(var));
-        var_len = swoole::rtrim(var, var_len);
-        if (swoole_strcaseeq(var, var_len, value, strlen(value))) {
+    while (at < end) {
+        const char *separator = static_cast<const char *>(memchr(at, ',', end - at));
+        const char *token_end = separator ? separator : end;
+        while (at < token_end && isspace(static_cast<unsigned char>(*at))) {
+            at++;
+        }
+        const size_t token_length = swoole::rtrim(at, token_end - at);
+        if (token_length > 0 && swoole_strcaseeq(at, token_length, value, value_length)) {
             return true;
         }
-        var = php_strtok_r(nullptr, separator, &strtok_buf);
+        if (!separator) {
+            break;
+        }
+        at = separator + 1;
     }
     return false;
 }

--- a/include/swoole_util.h
+++ b/include/swoole_util.h
@@ -204,7 +204,7 @@ std::string intersection(const std::vector<std::string> &vec1, std::set<std::str
 static inline size_t ltrim(char **str, size_t len) {
     size_t i;
     for (i = 0; i < len; ++i) {
-        if ('\0' != **str && isspace(**str)) {
+        if ('\0' != **str && isspace(static_cast<unsigned char>(**str))) {
             ++*str;
         } else {
             break;
@@ -215,7 +215,7 @@ static inline size_t ltrim(char **str, size_t len) {
 
 static inline size_t rtrim(char *str, size_t len) {
     for (size_t i = len; i > 0;) {
-        if (isspace(str[--i])) {
+        if (isspace(static_cast<unsigned char>(str[--i]))) {
             str[i] = 0;
             len--;
         } else {
@@ -227,7 +227,7 @@ static inline size_t rtrim(char *str, size_t len) {
 
 static inline size_t rtrim(const char *str, size_t len) {
     for (size_t i = len; i > 0;) {
-        if (isspace(str[--i])) {
+        if (isspace(static_cast<unsigned char>(str[--i]))) {
             len--;
         } else {
             break;

--- a/tests/swoole_http_client_coro/connection_close.phpt
+++ b/tests/swoole_http_client_coro/connection_close.phpt
@@ -13,31 +13,51 @@ $pm = new ProcessManager;
 $pm->parentFunc = function () use ($pm) {
     run(function () use ($pm) {
         $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
-        var_dump($client->get('/close'));
-        var_dump($client->getHeaders());
-
-        var_dump($client->get('/keep_alive'));
-        var_dump($client->getHeaders());
+        Assert::true($client->get('/response-close'));
+        Assert::false($client->connected);
+        Assert::true($client->get('/response-next'));
+        Assert::true($client->connected);
         $client->close();
 
-        var_dump($client->errMsg);
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        Assert::true($client->get('/response-token-close'));
+        Assert::false($client->connected);
+
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $client->setHeaders(['Connection' => 'close']);
+        Assert::true($client->get('/request-close'));
+        Assert::false($client->connected);
+        $client->setHeaders([]);
+        Assert::true($client->get('/request-next'));
+        Assert::true($client->connected);
+        $client->close();
+
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $client->setHeaders(['Connection' => 'keep-alive, close']);
+        Assert::true($client->get('/request-token-close'));
+        Assert::false($client->connected);
         echo "DONE\n";
         $pm->kill();
     });
 };
 
 $pm->childFunc = function () use ($pm) {
-    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort());
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
 
     $server->on('workerStart', function () use ($pm) {
         $pm->wakeup();
     });
 
-    $server->on('request', function($request, $response) {
-        if ($request->server['request_uri'] == '/close') {
-            $response->header('connection', 'close');
+    $server->on('receive', function (Swoole\Server $server, int $fd, int $reactorId, string $data) {
+        if (str_contains($data, '/response-token-close')) {
+            $connection = "Connection: keep-alive, close\r\n";
+        } elseif (str_contains($data, '/response-close')) {
+            $connection = "Connection: close\r\n";
+        } else {
+            $connection = '';
         }
-        $response->end();
+        $server->send($fd, "HTTP/1.1 200 OK\r\n{$connection}Content-Length: 0\r\n\r\n");
     });
 
     $server->start();
@@ -46,32 +66,5 @@ $pm->childFunc = function () use ($pm) {
 $pm->childFirst();
 $pm->run();
 ?>
---EXPECTF--
-bool(true)
-array(5) {
-  ["connection"]=>
-  string(5) "close"
-  ["server"]=>
-  string(18) "swoole-http-server"
-  ["date"]=>
-  string(%d) "%s"
-  ["content-type"]=>
-  string(9) "text/html"
-  ["content-length"]=>
-  string(1) "0"
-}
-bool(true)
-array(5) {
-  ["server"]=>
-  string(18) "swoole-http-server"
-  ["date"]=>
-  string(%d) "%s"
-  ["connection"]=>
-  string(10) "keep-alive"
-  ["content-type"]=>
-  string(9) "text/html"
-  ["content-length"]=>
-  string(1) "0"
-}
-string(0) ""
+--EXPECT--
 DONE

--- a/tests/swoole_http_client_coro/connection_header.phpt
+++ b/tests/swoole_http_client_coro/connection_header.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_http_client_coro: host
+swoole_http_client_coro: generated connection header
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
@@ -10,17 +10,10 @@ $pm = new ProcessManager;
 $pm->parentFunc = function () use ($pm) {
     Co\run(function () use ($pm) {
         $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
-        $client->setHeaders(['hOsT' => 'example.test']);
+        $client->set(['keep_alive' => false]);
         Assert::true($client->get('/'));
-        Assert::same(substr_count($client->body, "Host: example.test\r\n"), 1);
-        Assert::notContains($client->body, "Host: 127.0.0.1");
-        $client->close();
-
-        $port = $pm->getFreePort();
-        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $port);
-        Assert::true($client->get('/'));
-        Assert::contains($client->body, "Host: 127.0.0.1:{$port}\r\n");
-        $client->close();
+        Assert::contains($client->body, "Connection: close\r\n");
+        Assert::notContains($client->body, "Connection: closed\r\n");
         echo "DONE\n";
         $pm->kill();
     });

--- a/tests/swoole_http_client_coro/download_empty_body.phpt
+++ b/tests/swoole_http_client_coro/download_empty_body.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_http_client_coro: empty download state does not affect the next request
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$filename = '/tmp/swoole-http-client-empty-download-' . getmypid();
+file_put_contents($filename, 'unchanged');
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm, $filename) {
+    Co\run(function () use ($pm, $filename) {
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        Assert::true($client->download('/empty', $filename));
+        Assert::true($client->get('/body'));
+        Assert::same($client->body, 'response body');
+        Assert::same(file_get_contents($filename), 'unchanged');
+        $client->close();
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        if ($request->server['request_uri'] === '/empty') {
+            $response->status(204);
+            $response->end();
+        } else {
+            $response->end('response body');
+        }
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+@unlink($filename);
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_client_coro/event_stream_header_case.phpt
+++ b/tests/swoole_http_client_coro/event_stream_header_case.phpt
@@ -1,0 +1,41 @@
+--TEST--
+swoole_http_client_coro: preserved Content-Type casing selects event stream completion
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Co\run(function () use ($pm) {
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $client->set([
+            'lowercase_header' => false,
+            'timeout' => 2,
+        ]);
+        Assert::true($client->get('/'));
+        Assert::same($client->body, "data: hello\n\n");
+        Assert::keyExists($client->getHeaders(), 'Content-Type');
+        $client->close();
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('receive', function (Swoole\Server $server, int $fd) {
+        // Keep the connection open so only event-stream recognition can complete the response.
+        $server->send($fd, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\ndata: hello\n\n");
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_client_coro/header_and_cookie_limits.phpt
+++ b/tests/swoole_http_client_coro/header_and_cookie_limits.phpt
@@ -1,73 +1,61 @@
 --TEST--
 swoole_http_client_coro: header and cookie limits
 --SKIPIF--
-<?php
-require __DIR__ . '/../include/skipif.inc';
-if (!function_exists('pcntl_fork')) {
-    die('skip pcntl required');
-}
-?>
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
 <?php
-function free_port(): int
-{
-    $server = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
-    if ($server === false) {
-        throw new RuntimeException("failed to find free port: $errstr");
-    }
-    $name = stream_socket_get_name($server, false);
-    fclose($server);
-    return (int) substr(strrchr($name, ':'), 1);
-}
+require __DIR__ . '/../include/bootstrap.php';
 
-$port = free_port();
-$pid = pcntl_fork();
-if ($pid === -1) {
-    throw new RuntimeException('pcntl_fork() failed');
-}
-if ($pid === 0) {
-    $http = new Swoole\Http\Server('127.0.0.1', $port, SWOOLE_BASE);
-    $http->set([
-        'log_file' => '/dev/null',
-    ]);
-    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Swoole\Coroutine\run(function () use ($pm) {
+        $headerClient = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $headerClient->set(['timeout' => 3]);
+        Assert::true($headerClient->get('/'));
+        $headerClient->setHeaders([
+            'Connection' => str_repeat('keep-alive, ', 8 * 1024),
+        ]);
+        try {
+            $headerClient->get('/');
+            Assert::true(false);
+        } catch (Swoole\Coroutine\Http\Client\Exception $e) {
+            Assert::contains($e->getMessage(), 'header block is too large');
+        }
+
+        $cookieClient = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $cookieClient->set(['timeout' => 3]);
+        $cookieClient->setHeaders(['Connection' => 'close']);
+        $cookieClient->setCookies([
+            'token' => str_repeat('b', 4097),
+        ]);
+        try {
+            $cookieClient->get('/');
+            Assert::true(false);
+        } catch (Swoole\Coroutine\Http\Client\Exception $e) {
+            Assert::contains($e->getMessage(), 'cookie header is too large');
+        }
+        $cookieClient->setHeaders([]);
+        $cookieClient->setCookies([]);
+        Assert::true($cookieClient->get('/'));
+        Assert::true($cookieClient->connected);
+        $cookieClient->close();
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->end('OK');
     });
-    $http->start();
-    exit(0);
-}
-
-usleep(200000);
-
-Swoole\Coroutine\run(function () use ($port) {
-    $header_client = new Swoole\Coroutine\Http\Client('127.0.0.1', $port);
-    $header_client->set(['timeout' => 3]);
-    $header_client->setHeaders([
-        'X-Big-Header' => str_repeat('a', 64 * 1024),
-    ]);
-    try {
-        $header_client->get('/');
-        echo "HEADER_NOT_THROWN\n";
-    } catch (Swoole\Coroutine\Http\Client\Exception $e) {
-        echo "HEADER_THROWN\n";
-    }
-
-    $cookie_client = new Swoole\Coroutine\Http\Client('127.0.0.1', $port);
-    $cookie_client->set(['timeout' => 3]);
-    $cookie_client->setCookies([
-        'token' => str_repeat('b', 4097),
-    ]);
-    try {
-        $cookie_client->get('/');
-        echo "COOKIE_NOT_THROWN\n";
-    } catch (Swoole\Coroutine\Http\Client\Exception $e) {
-        echo "COOKIE_THROWN\n";
-    }
-});
-
-posix_kill($pid, SIGTERM);
-pcntl_waitpid($pid, $status);
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
 ?>
 --EXPECT--
-HEADER_THROWN
-COOKIE_THROWN
+DONE

--- a/tests/swoole_http_client_coro/response_eof_framing.phpt
+++ b/tests/swoole_http_client_coro/response_eof_framing.phpt
@@ -1,0 +1,58 @@
+--TEST--
+swoole_http_client_coro: EOF only completes close-delimited responses
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Co\run(function () use ($pm) {
+        foreach (['/content-length', '/chunked'] as $path) {
+            $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+            Assert::false($client->get($path));
+            Assert::same($client->statusCode, SWOOLE_HTTP_CLIENT_ESTATUS_SERVER_RESET);
+            Assert::same($client->errCode, SOCKET_ECONNRESET);
+            Assert::false($client->connected);
+        }
+
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        Assert::true($client->get('/close-delimited'));
+        Assert::same($client->statusCode, 200);
+        Assert::same($client->body, 'complete');
+
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        Assert::true($client->get('/exact'));
+        Assert::same($client->statusCode, 200);
+        Assert::same($client->body, 'exact');
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('receive', function (Swoole\Server $server, int $fd, int $reactorId, string $data) {
+        if (str_contains($data, '/content-length')) {
+            $response = "HTTP/1.1 200 OK\r\nContent-Length: 20\r\nConnection: close\r\n\r\nshort";
+        } elseif (str_contains($data, '/chunked')) {
+            $response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n5\r\nabc";
+        } elseif (str_contains($data, '/close-delimited')) {
+            $response = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\ncomplete";
+        } else {
+            $response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nexact";
+        }
+        $server->send($fd, $response);
+        $server->close($fd);
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_client_coro/response_header_semantics.phpt
+++ b/tests/swoole_http_client_coro/response_header_semantics.phpt
@@ -1,0 +1,68 @@
+--TEST--
+swoole_http_client_coro: response semantics preserve header casing
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_constant_not_defined('SWOOLE_HAVE_ZLIB');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$body = 'compressed response';
+$compressedBody = gzencode($body);
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm, $body) {
+    Co\run(function () use ($pm, $body) {
+        foreach ([false, true] as $lowercaseHeader) {
+            $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+            $client->set([
+                'lowercase_header' => $lowercaseHeader,
+                'timeout' => 2,
+            ]);
+            Assert::true($client->get('/'));
+            Assert::same($client->body, $body);
+            Assert::same($client->getCookies()['session'], 'swoole');
+            Assert::same($client->set_cookie_headers, ['session=swoole; Path=/']);
+            Assert::false($client->connected);
+
+            $headers = $client->getHeaders();
+            if ($lowercaseHeader) {
+                Assert::keyExists($headers, 'content-encoding');
+                Assert::keyExists($headers, 'set-cookie');
+                Assert::keyExists($headers, 'connection');
+            } else {
+                Assert::keyExists($headers, 'Content-Encoding');
+                Assert::keyExists($headers, 'Set-Cookie');
+                Assert::keyExists($headers, 'Connection');
+            }
+        }
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+
+$pm->childFunc = function () use ($pm, $compressedBody) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('receive', function (Swoole\Server $server, int $fd) use ($compressedBody) {
+        $response = "HTTP/1.1 200 OK\r\n";
+        $response .= "Content-Encoding: gzip\r\n";
+        $response .= "Set-Cookie: session=swoole; Path=/\r\n";
+        $response .= "Connection: close\r\n";
+        $response .= "Content-Length: " . strlen($compressedBody) . "\r\n\r\n";
+        $server->send($fd, $response . $compressedBody);
+        $server->close($fd);
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_client_coro/websocket/bug_01.phpt
+++ b/tests/swoole_http_client_coro/websocket/bug_01.phpt
@@ -14,6 +14,7 @@ $pm = new ProcessManager();
 $pm->parentFunc = function ($pid) use ($pm) {
     Co\run(function () use ($pm) {
         $cli = new Co\http\Client('127.0.0.1', $pm->getFreePort());
+        $cli->set(['lowercase_header' => false]);
         $ret = $cli->upgrade('/');
         if (!$ret) {
             echo "ERROR\n";

--- a/tests/swoole_http_client_coro/websocket/compression_header_case.phpt
+++ b/tests/swoole_http_client_coro/websocket/compression_header_case.phpt
@@ -1,0 +1,56 @@
+--TEST--
+swoole_http_client_coro/websocket: compression negotiation preserves response header casing
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_constant_not_defined('SWOOLE_HAVE_ZLIB');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\WebSocket\Frame;
+use Swoole\WebSocket\Server;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Co\run(function () use ($pm) {
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $client->set([
+            'lowercase_header' => false,
+            'websocket_compression' => true,
+        ]);
+        Assert::true($client->upgrade('/'));
+        Assert::keyExists($client->getHeaders(), 'Sec-Websocket-Extensions');
+        Assert::true($client->push(
+            'compressed request',
+            SWOOLE_WEBSOCKET_OPCODE_TEXT,
+            SWOOLE_WEBSOCKET_FLAG_FIN
+        ));
+        Assert::same($client->recv()->data, 'OK');
+        $client->close();
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'log_file' => '/dev/null',
+        'websocket_compression' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('message', function (Server $server, Frame $frame) {
+        Assert::same($frame->data, 'compressed request');
+        Assert::true((bool) ($frame->flags & SWOOLE_WEBSOCKET_FLAG_COMPRESS));
+        $server->push($frame->fd, 'OK');
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_client_coro/websocket/compression_header_order.phpt
+++ b/tests/swoole_http_client_coro/websocket/compression_header_order.phpt
@@ -1,0 +1,71 @@
+--TEST--
+swoole_http_client_coro/websocket: compression negotiation is independent of response header order
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_constant_not_defined('SWOOLE_HAVE_ZLIB');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\WebSocket\Frame;
+use Swoole\WebSocket\Server;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Co\run(function () use ($pm) {
+        $client = new Swoole\Coroutine\Http\Client('127.0.0.1', $pm->getFreePort());
+        $client->set([
+            'websocket_compression' => true,
+        ]);
+        Assert::true($client->upgrade('/'));
+        Assert::true($client->push(
+            'compressed request',
+            SWOOLE_WEBSOCKET_OPCODE_TEXT,
+            SWOOLE_WEBSOCKET_FLAG_FIN
+        ));
+        Assert::same($client->recv()->data, 'OK');
+        $client->close();
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'log_file' => '/dev/null',
+        'websocket_compression' => true,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('handshake', function (Request $request, Response $response) {
+        $accept = base64_encode(sha1(
+            $request->header['sec-websocket-key'] . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11',
+            true
+        ));
+        // The extension must precede Upgrade to exercise order-independent negotiation.
+        $response->header('Sec-WebSocket-Extensions', 'permessage-deflate');
+        $response->header('Upgrade', 'websocket');
+        $response->header('Connection', 'Upgrade');
+        $response->header('Sec-WebSocket-Accept', $accept);
+        $response->header('Sec-WebSocket-Version', '13');
+        $response->status(101);
+        $response->end();
+        return true;
+    });
+    $server->on('message', function (Server $server, Frame $frame) {
+        Assert::same($frame->data, 'compressed request');
+        Assert::true((bool) ($frame->flags & SWOOLE_WEBSOCKET_FLAG_COMPRESS));
+        $server->push($frame->fd, 'OK');
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
Several coroutine HTTP client behaviors depended on response header casing, field order, or state left by the previous request.

This change:

- parses comma-separated header tokens directly without copying or changing the input
- applies response semantics independently of public header casing and wire order
- scopes connection-close and download state to one exchange
- handles request `Host` keys case-insensitively and emits `Connection: close`
- rejects EOF before a framed response is complete

The tests use local fixtures for request reuse, compression, event streams, WebSocket negotiation, downloads, and truncated responses.
