### PR TITLE
Skip Redis tests when ext/redis is unavailable

### DIFF
--- a/tests/swoole_channel_coro/pool.phpt
+++ b/tests/swoole_channel_coro/pool.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_channel_coro: connection pool
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';

--- a/tests/swoole_coroutine/bailout/co_redis_in_shutdown_function.phpt
+++ b/tests/swoole_coroutine/bailout/co_redis_in_shutdown_function.phpt
@@ -1,7 +1,11 @@
 --TEST--
 swoole_coroutine/bailout: call co redis in shutdown function
 --SKIPIF--
-<?php require __DIR__ . '/../../include/skipif.inc'; skip_if_win(); ?>
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_win();
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../../include/bootstrap.php';

--- a/tests/swoole_feature/cross_close/redis.phpt
+++ b/tests/swoole_feature/cross_close/redis.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_feature/cross_close: redis
 --SKIPIF--
-<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../../include/bootstrap.php';

--- a/tests/swoole_feature/cross_close/redis_by_server.phpt
+++ b/tests/swoole_feature/cross_close/redis_by_server.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_feature/cross_close: redis closed by server
 --SKIPIF--
-<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../../include/bootstrap.php';

--- a/tests/swoole_redis_server/big_packet.phpt
+++ b/tests/swoole_redis_server/big_packet.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_redis_server: test big packet
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';

--- a/tests/swoole_runtime/destruct.phpt
+++ b/tests/swoole_runtime/destruct.phpt
@@ -3,6 +3,7 @@ swoole_runtime: socket destruct close
 --SKIPIF--
 <?php
 require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
 ?>
 --FILE--
 <?php

--- a/tests/swoole_runtime/persistent.phpt
+++ b/tests/swoole_runtime/persistent.phpt
@@ -3,6 +3,7 @@ swoole_runtime: socket persistent then destruct
 --SKIPIF--
 <?php
 require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
 ?>
 --FILE--
 <?php

--- a/tests/swoole_runtime/redis_connect.phpt
+++ b/tests/swoole_runtime/redis_connect.phpt
@@ -2,7 +2,7 @@
 swoole_runtime: hook stream redis connect
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc';
-skip_if_class_not_exist('Redis');
+skip_if_extension_not_exist('redis');
 ?>
 --FILE--
 <?php

--- a/tests/swoole_runtime/redis_pconnect.phpt
+++ b/tests/swoole_runtime/redis_pconnect.phpt
@@ -2,7 +2,7 @@
 swoole_runtime: hook stream redis pconnect
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc';
-skip_if_class_not_exist('Redis');
+skip_if_extension_not_exist('redis');
 ?>
 --FILE--
 <?php

--- a/tests/swoole_server/bug_2308.phpt
+++ b/tests/swoole_server/bug_2308.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_server: bug Github#2308
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';


### PR DESCRIPTION
Several PHPTs use the optional ext/redis client without checking that the extension is loaded. Those configurations fail in the test body instead of reporting a skip.

This applies the existing extension guard to every ext/redis-dependent PHPT and replaces the two class guards with the same convention. It only checks the extension; the tests still require their configured Redis endpoint.

The `Redis::class` reference in `tests/include/config.php` resolves to `Swoole\NameResolver\Redis`, so the name-resolver tests do not need this guard.