### PR TITLE
Fix coroutine socket error reporting on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,7 +94,8 @@ jobs:
             'tests\swoole_windows\iocp_shutdown.phpt',
             'tests\swoole_windows\iocp_socket.phpt',
             'tests\swoole_windows\local_ip.phpt',
-            'tests\swoole_windows\local_mac.phpt'
+            'tests\swoole_windows\local_mac.phpt',
+            'tests\swoole_windows\socket_error_domain.phpt'
           )
           & .github\workflows\windows-phpt.ps1 -Path $tests -TimeoutSeconds 12
 

--- a/include/swoole_coroutine_socket.h
+++ b/include/swoole_coroutine_socket.h
@@ -316,7 +316,7 @@ class Socket {
     }
 
     void set_err() {
-        errCode = swoole_get_last_error() ? swoole_get_last_error() : errno;
+        errCode = swoole_get_last_error() ? swoole_get_last_error() : sw_errno();
         errMsg = swoole_strerror(errCode);
     }
 
@@ -460,7 +460,7 @@ class Socket {
         if (retval >= 0) {
             set_err(0);
         } else if (errCode == 0) {
-            set_err(errno);
+            set_err(sw_errno());
         }
     }
 

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -409,7 +409,7 @@ bool Socket::getsockname() const {
 bool Socket::getpeername(network::Address *sa) {
     sa->len = sizeof(sa->addr);
     if (::getpeername(sock_fd, reinterpret_cast<sockaddr *>(&sa->addr), &sa->len) != 0) {
-        set_err(errno);
+        set_err(sw_errno());
         return false;
     }
     sa->type = type;
@@ -661,7 +661,8 @@ bool Socket::check_liveness() {
         return false;
     }
     if (!socket->check_liveness()) {
-        set_err(errno ? errno : ECONNRESET);
+        const int error = sw_errno();
+        set_err(error ? error : ECONNRESET);
         return false;
     }
     set_err(0);
@@ -1079,7 +1080,7 @@ bool Socket::listen(int backlog) {
     }
     this->backlog = backlog <= 0 ? SW_BACKLOG : backlog;
     if (socket->listen(this->backlog) < 0) {
-        set_err(errno);
+        set_err(sw_errno());
         return false;
     }
     ssl_is_server = true;
@@ -1520,14 +1521,18 @@ ssize_t Socket::recv_packet(double timeout) {
 
 bool Socket::shutdown(int _how) {
     set_err(0);
+    int error = 0;
     if (!is_connected() || (_how == SHUT_RD && shutdown_read) || (_how == SHUT_WR && shutdown_write)) {
-        errno = ENOTCONN;
+        error = ENOTCONN;
     } else {
         if (socket->ssl) {
             socket->ssl_shutdown();
         }
-        if (::shutdown(sock_fd, _how) == 0 || errno == ENOTCONN) {
-            if (errno == ENOTCONN) {
+        if (::shutdown(sock_fd, _how) < 0) {
+            error = sw_errno();
+        }
+        if (error == 0 || error == ENOTCONN) {
+            if (error == ENOTCONN) {
                 // connection reset by server side
                 _how = SHUT_RDWR;
             }
@@ -1548,7 +1553,7 @@ bool Socket::shutdown(int _how) {
             return true;
         }
     }
-    set_err(errno);
+    set_err(error);
     return false;
 }
 

--- a/tests/swoole_windows/socket_error_domain.phpt
+++ b/tests/swoole_windows/socket_error_domain.phpt
@@ -1,0 +1,47 @@
+--TEST--
+swoole_windows: coroutine socket error domain
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+if (stripos(PHP_OS, 'WIN') !== 0) {
+    die('skip Windows only');
+}
+if (!class_exists(Swoole\Coroutine\Socket::class, false)) {
+    die('skip coroutine socket not available');
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Socket;
+
+use function Swoole\Coroutine\run;
+
+run(function () {
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::false($socket->getpeername());
+    Assert::same($socket->errCode, SOCKET_ENOTCONN);
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::false($socket->listen());
+    Assert::same($socket->errCode, SOCKET_EINVAL);
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->bind('127.0.0.1', 0));
+    Assert::false($socket->bind('127.0.0.1', 0));
+    Assert::same($socket->errCode, SOCKET_EINVAL);
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::false($socket->peek());
+    Assert::same($socket->errCode, SOCKET_ENOTCONN);
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::false($socket->checkLiveness());
+    Assert::same($socket->errCode, SOCKET_ENOTCONN);
+});
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
Several coroutine socket methods read the C runtime `errno` after Winsock failures. This can leave `errCode` unset, report an unrelated value, or hide the native error behind `ECONNRESET`. `shutdown()` can also reuse stale error state after a successful call.

This reads socket failures through the platform error abstraction while preserving Swoole address-validation errors. `shutdown()` now changes its state from the result of the current call only.

A focused Windows regression covers the affected public operations, and the existing socket suites cover the shared behavior.