### PR TITLE
Fail tests on missing ProcessManager readiness signals

### DIFF
--- a/tests/include/api/http_server.php
+++ b/tests/include/api/http_server.php
@@ -10,9 +10,9 @@ $http->set(array(
     "http_parse_post" => 1,
     "upload_tmp_dir" => "/tmp",
 ));
-$http->on("WorkerStart", function (Swoole\Server $serv) {
+$http->on("WorkerStart", function (Swoole\Server $server, int $workerId) {
     global $pm;
-    if ($pm) {
+    if ($workerId === 0) {
         $pm->wakeup();
     }
 });

--- a/tests/include/lib/src/ProcessManager.php
+++ b/tests/include/lib/src/ProcessManager.php
@@ -39,9 +39,9 @@ class ProcessManager
     protected $randomDataArray = [];
 
     /**
-     * wait wakeup 1s default
+     * wait wakeup 10s default
      */
-    protected $waitTimeout = 1.0;
+    protected $waitTimeout = 10.0;
 
     public $parentFunc;
     public $childFunc;
@@ -90,7 +90,7 @@ class ProcessManager
         return $this->childPid;
     }
 
-    public function setWaitTimeout(int $value)
+    public function setWaitTimeout(float $value)
     {
         $this->waitTimeout = $value;
     }
@@ -101,7 +101,10 @@ class ProcessManager
         if ($this->alone || $this->waitTimeout == 0) {
             return false;
         }
-        return $this->atomic->wait($this->waitTimeout);
+        if (!$this->atomic->wait($this->waitTimeout)) {
+            throw new RuntimeException("ProcessManager did not receive a wakeup within {$this->waitTimeout}s");
+        }
+        return true;
     }
 
     //唤醒等待的进程
@@ -111,6 +114,26 @@ class ProcessManager
             return false;
         }
         return $this->atomic->wakeup();
+    }
+
+    private function terminateChildAfterReadinessFailure(): void
+    {
+        $this->kill();
+        // Servers may use their full three-second max_wait_time to stop workers gracefully.
+        $deadline = microtime(true) + 5;
+        do {
+            // Process::wait() is process-global and may discard another direct child's status while reaping ours.
+            $waitInfo = Process::wait(false);
+            if ($waitInfo && $waitInfo['pid'] === $this->childPid) {
+                return;
+            }
+            usleep(10000);
+        } while (microtime(true) < $deadline);
+
+        @Process::kill($this->childPid, SIGKILL);
+        do {
+            $waitInfo = Process::wait(true);
+        } while ($waitInfo && $waitInfo['pid'] !== $this->childPid);
     }
 
     public function runParentFunc($pid = 0)
@@ -303,16 +326,29 @@ class ProcessManager
             $this->runChildFunc();
             exit;
         }, $redirectStdout, $redirectStdout);
-        if (!$this->childProcess || !$this->childProcess->start()) {
+        if (!$this->childProcess || !($this->childPid = $this->childProcess->start())) {
             exit("ERROR: CAN NOT CREATE PROCESS\n");
         }
         register_shutdown_function(function () {
             $this->kill();
         });
         if (!$this->parentFirst) {
-            $this->wait();
+            try {
+                $this->wait();
+            } catch (RuntimeException $e) {
+                $waitInfo = Process::wait(false);
+                if ($waitInfo && $waitInfo['pid'] === $this->childPid) {
+                    $this->killed = true;
+                    throw new RuntimeException(
+                        "ProcessManager child exited with code {$waitInfo['code']} and signal {$waitInfo['signal']} " .
+                        'before sending a wakeup'
+                    );
+                }
+                $this->terminateChildAfterReadinessFailure();
+                throw $e;
+            }
         }
-        $this->runParentFunc($this->childPid = $this->childProcess->pid);
+        $this->runParentFunc($this->childPid);
         Event::wait();
         $waitInfo = Process::wait(true);
         $this->childExitStatus = $waitInfo['code'];

--- a/tests/swoole_client_coro/bug_2346.phpt
+++ b/tests/swoole_client_coro/bug_2346.phpt
@@ -40,6 +40,11 @@ $pm->parentFunc = function () use ($pm) {
 };
 $pm->childFunc = function () use ($pm) {
     $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('receive', function () { });
     $server->start();
 };

--- a/tests/swoole_client_coro/eof_02.phpt
+++ b/tests/swoole_client_coro/eof_02.phpt
@@ -74,6 +74,11 @@ $pm->childFunc = function () use ($pm) {
         'open_eof_split' => true,
         'package_eof' => "\r\n",
     ));
+    $serv->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $serv->on('receive', function ($serv, $fd, $rid, $data) {
         $ret = "server reply {" . trim($data) . "} \r\n";
         $serv->send($fd, $ret);

--- a/tests/swoole_client_coro/eof_04.phpt
+++ b/tests/swoole_client_coro/eof_04.phpt
@@ -37,6 +37,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
     $server->set(['log_file' => '/dev/null']);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('connect', function (Swoole\Server $server, int $fd) use ($pm) {
         do {
             $data = '';

--- a/tests/swoole_client_coro/fixed_package.phpt
+++ b/tests/swoole_client_coro/fixed_package.phpt
@@ -37,6 +37,11 @@ $pm->parentFunc = function () use ($pm) {
 };
 $pm->childFunc = function () use ($pm) {
     $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('connect', function (Swoole\Server $server, int $fd) use ($pm) {
         for ($n = MAX_REQUESTS; $n--;) {
             $server->send($fd, pack('n', $pm->getRandomData()));

--- a/tests/swoole_client_coro/length_types.phpt
+++ b/tests/swoole_client_coro/length_types.phpt
@@ -36,6 +36,11 @@ $pm->parentFunc = function () use ($pm) {
 };
 $pm->childFunc = function () use ($pm) {
     $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('connect', function (Swoole\Server $server, int $fd) use ($pm) {
         $length_type = array_keys(tcp_length_types())[$fd - 1];
         for ($n = MAX_REQUESTS; $n--;) {

--- a/tests/swoole_client_sync/recv_with_open_eof_check.phpt
+++ b/tests/swoole_client_sync/recv_with_open_eof_check.phpt
@@ -35,6 +35,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
     ]);
 
+    $serv->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $serv->on('receive', function (Server $serv, $fd, $reactor_id, $data) {
     });
 

--- a/tests/swoole_feature/full_duplex/client.phpt
+++ b/tests/swoole_feature/full_duplex/client.phpt
@@ -91,6 +91,7 @@ $pm->childFunc = function () use ($pm) {
         $server = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
         Assert::assert($server->bind('127.0.0.1', $pm->getFreePort()));
         Assert::assert($server->listen(MAX_CONCURRENCY));
+        $pm->wakeup();
         while ($conn = $server->accept(-1)) {
             if (!Assert::assert($conn instanceof Co\Socket)) {
                 throw new RuntimeException('accept failed');

--- a/tests/swoole_feature/full_duplex/socket.phpt
+++ b/tests/swoole_feature/full_duplex/socket.phpt
@@ -86,6 +86,7 @@ $pm->childFunc = function () use ($pm) {
         $server = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
         Assert::assert($server->bind('127.0.0.1', $pm->getFreePort()));
         Assert::assert($server->listen(MAX_CONCURRENCY));
+        $pm->wakeup();
         while ($conn = $server->accept(-1)) {
             if (!Assert::assert($conn instanceof Co\Socket)) {
                 throw new RuntimeException('accept failed');

--- a/tests/swoole_feature/full_duplex/socket_ssl.phpt
+++ b/tests/swoole_feature/full_duplex/socket_ssl.phpt
@@ -94,6 +94,7 @@ $pm->childFunc = function () use ($pm) {
         ]);
         Assert::assert($server->bind('127.0.0.1', $pm->getFreePort()));
         Assert::assert($server->listen(MAX_CONCURRENCY));
+        $pm->wakeup();
         /** @var $conn Socket */
         while ($conn = $server->accept(-1)) {
             if (!Assert::assert($conn instanceof Co\Socket)) {

--- a/tests/swoole_http2_client_coro/number.phpt
+++ b/tests/swoole_http2_client_coro/number.phpt
@@ -39,6 +39,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
         'open_http2_protocol' => true
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (\Swoole\Http\Request $request, \Swoole\Http\Response $response) {
         Coroutine::sleep(mt_rand(1, MAX_REQUESTS) / 1000);
         $response->end($request->rawContent());

--- a/tests/swoole_http2_server/issue_4365.phpt
+++ b/tests/swoole_http2_server/issue_4365.phpt
@@ -31,6 +31,11 @@ $pm->childFunc = function () use ($pm) {
         'log_level' => 1,
         'log_file' => TEST_LOG_FILE,
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function ($request, $response) {
         $response->end(str_repeat('x', N - 4) . "\r\n\r\n");
     });

--- a/tests/swoole_http2_server_coro/cookies.phpt
+++ b/tests/swoole_http2_server_coro/cookies.phpt
@@ -51,6 +51,7 @@ $pm->childFunc = function () use ($pm) {
                 }
                 $response->end('OK');
             });
+            $pm->wakeup();
             $http->start();
         });
     });

--- a/tests/swoole_http_client_coro/http_proxy_with_host_port.phpt
+++ b/tests/swoole_http_client_coro/http_proxy_with_host_port.phpt
@@ -32,6 +32,11 @@ $pm->childFunc = function () use ($pm) {
         'open_eof_check' => true,
         'package_eof'    => "\r\n\r\n",
     ]);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('Receive', function ($server, $fd, $reactor_id, $data) {
         echo $data;
         $server->close($fd);

--- a/tests/swoole_http_server/buffer_output_size.phpt
+++ b/tests/swoole_http_server/buffer_output_size.phpt
@@ -29,6 +29,11 @@ $pm->childFunc = function () use ($pm) {
         'http_compression' => false,
         'output_buffer_size' => OUTPUT_BUFFER_SIZE,
     ]);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($server) {
         $length = $request->server['request_uri'] === '/full' ? OUTPUT_BUFFER_SIZE + 4096 : OUTPUT_BUFFER_SIZE - HTTP_HEADER_SIZE;
         $response->end(str_repeat(RANDOM_CHAR, $length));

--- a/tests/swoole_http_server/bug_2368.phpt
+++ b/tests/swoole_http_server/bug_2368.phpt
@@ -27,6 +27,11 @@ $pm->childFunc = function () use ($pm) {
     $http->set(array(
         'log_file' => '/dev/null',
     ));
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->cookie('name', COOKIE);
         $response->end();

--- a/tests/swoole_http_server/bug_6007.phpt
+++ b/tests/swoole_http_server/bug_6007.phpt
@@ -23,6 +23,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $http = new Swoole\Http\Server('0.0.0.0', $pm->getFreePort(), SWOOLE_BASE);
     $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $cookie = new Swoole\Http\Cookie();
         $cookie->withName('userId')

--- a/tests/swoole_http_server/callback_new_obj_method.phpt
+++ b/tests/swoole_http_server/callback_new_obj_method.phpt
@@ -43,6 +43,11 @@ $pm->childFunc = function () use ($pm) {
         'worker_num' => 1,
         'log_file' => '/dev/null'
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', [new TestCo, 'foo']);
     $http->start();
 };

--- a/tests/swoole_http_server/callback_new_static_method.phpt
+++ b/tests/swoole_http_server/callback_new_static_method.phpt
@@ -45,6 +45,11 @@ $pm->childFunc = function () use ($pm) {
         'worker_num' => 1,
         'log_file' => '/dev/null'
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', [TestCo::class, 'foo']);
     $http->start();
 };

--- a/tests/swoole_http_server/callback_string.phpt
+++ b/tests/swoole_http_server/callback_string.phpt
@@ -41,6 +41,11 @@ $pm->childFunc = function () use ($pm) {
         'worker_num' => 1,
         'log_file' => '/dev/null'
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', 'foo');
     $http->start();
 };

--- a/tests/swoole_http_server/callback_with_internal_function.phpt
+++ b/tests/swoole_http_server/callback_with_internal_function.phpt
@@ -20,6 +20,11 @@ $pm->childFunc = function () use ($pm) {
         'worker_num' => 1,
         'log_file' => '/dev/null'
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', 'var_dump');
     $http->start();
 };

--- a/tests/swoole_http_server/co_switching.phpt
+++ b/tests/swoole_http_server/co_switching.phpt
@@ -28,6 +28,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
         'worker_num' => swoole_cpu_num()
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         go(function () {
             for ($i = 5; $i--;) {

--- a/tests/swoole_http_server/cookie_delete.phpt
+++ b/tests/swoole_http_server/cookie_delete.phpt
@@ -32,6 +32,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $http = new Swoole\Http\Server('0.0.0.0', $pm->getFreePort(), SWOOLE_BASE);
     $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->cookie('cookie1', null);
         $response->cookie('cookie2', '');

--- a/tests/swoole_http_server/cookie_samesite.phpt
+++ b/tests/swoole_http_server/cookie_samesite.phpt
@@ -23,6 +23,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $http = new Swoole\Http\Server('0.0.0.0', $pm->getFreePort(), SWOOLE_BASE);
     $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->cookie('a', '123', 0, '', '', false, false, 'Lax');
         $response->end();

--- a/tests/swoole_http_server/cookie_vs_rawcookie.phpt
+++ b/tests/swoole_http_server/cookie_vs_rawcookie.phpt
@@ -39,6 +39,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $http = new Swoole\Http\Server('0.0.0.0', $pm->getFreePort(), SWOOLE_BASE);
     $http->set(['worker_num' => 1, 'log_file' => '/dev/null']);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $cookie = $request->get['cookie'];
         $response->cookie('cookie', $cookie);

--- a/tests/swoole_http_server/disable_coroutine.phpt
+++ b/tests/swoole_http_server/disable_coroutine.phpt
@@ -23,6 +23,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
         'enable_coroutine' => false, // close build-in coroutine
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on("request", function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         go(function () use ($response) {
             co::sleep(0.001);

--- a/tests/swoole_http_server/enable_coroutine.phpt
+++ b/tests/swoole_http_server/enable_coroutine.phpt
@@ -22,6 +22,11 @@ $pm->childFunc = function () use ($pm) {
         'worker_num' => 1,
         'log_level' => SWOOLE_LOG_NONE,
     ]);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on("request", function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->header("Content-Type", "text/plain");
         if ($request->server['request_uri'] == '/co') {

--- a/tests/swoole_http_server/reset_concurrency_with_base.phpt
+++ b/tests/swoole_http_server/reset_concurrency_with_base.phpt
@@ -17,6 +17,7 @@ use function Swoole\Coroutine\run;
 const N = 64;
 
 $counter = new Atomic(0);
+$ready = new Atomic(0);
 $table = new Table(1024);
 $table->column('pid', Table::TYPE_INT);
 $table->create();
@@ -46,19 +47,19 @@ $pm->parentFunc = function () use ($pm) {
     });
 };
 
-$pm->childFunc = function () use ($pm, $counter, $table) {
+$pm->childFunc = function () use ($pm, $counter, $ready, $table) {
     $http = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
     $http->set([
         'worker_num' => 4,
         'max_concurrency' => 160,
         'log_file' => '/dev/null',
     ]);
-    $http->on('workerStart', function ($server, $wid) use ($pm, $table) {
-        if ($wid === 0) {
-            $pm->wakeup();
-        }
+    $http->on('workerStart', function ($server, $wid) use ($pm, $ready, $table) {
         $pid = posix_getpid();
         $table->set('worker_' . $wid, ['pid' => $pid]);
+        if ($ready->add() === $server->setting['worker_num']) {
+            $pm->wakeup();
+        }
         // echo "Worker #{$wid}(pid=$pid) is started\n";
     });
     $http->on('request', function (Request $request, Response $response) use ($http, $counter, $table) {

--- a/tests/swoole_http_server/reset_concurrency_with_process.phpt
+++ b/tests/swoole_http_server/reset_concurrency_with_process.phpt
@@ -17,6 +17,7 @@ use function Swoole\Coroutine\run;
 const N = 64;
 
 $counter = new Atomic(0);
+$ready = new Atomic(0);
 $table = new Table(1024);
 $table->column('pid', Table::TYPE_INT);
 $table->create();
@@ -53,19 +54,20 @@ $pm->parentFunc = function () use ($pm) {
     });
 };
 
-$pm->childFunc = function () use ($pm, $counter, $table) {
+$pm->childFunc = function () use ($pm, $counter, $ready, $table) {
     $http = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
     $http->set([
         'worker_num' => 4,
         'max_concurrency' => 160,
         'log_file' => '/dev/null',
     ]);
-    $http->on('workerStart', function ($server, $wid) use ($pm, $table) {
-        if ($wid === 0) {
-            $pm->wakeup();
-        }
+    $http->on('workerStart', function ($server, $wid) use ($pm, $ready, $table) {
         $pid = posix_getpid();
         $table->set('worker_' . $wid, ['pid' => $pid]);
+        // Signal after the initial workers start and again after their replacements start.
+        if ($ready->add() % $server->setting['worker_num'] === 0) {
+            $pm->wakeup();
+        }
         // echo "Worker #{$wid}(pid=$pid) is started\n";
     });
     $http->on('request', function (Request $request, Response $response) use ($http, $counter, $table) {

--- a/tests/swoole_http_server/too_many_special_chars_in_cookie.phpt
+++ b/tests/swoole_http_server/too_many_special_chars_in_cookie.phpt
@@ -27,6 +27,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
     $http->set(['log_file' => '/dev/null']);
+    $http->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($pm) {
         static $pre_cookie;
         if ($pre_cookie) {

--- a/tests/swoole_http_server/unixsocket.phpt
+++ b/tests/swoole_http_server/unixsocket.phpt
@@ -28,6 +28,11 @@ $pm->parentFunc = function () use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $server = new Swoole\Http\Server(UNIXSOCK_PATH, 0, SERVER_MODE_RANDOM, SWOOLE_UNIX_STREAM);
     $server->set(['log_file' => '/dev/null']);
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->end('Hello Swoole!');
     });

--- a/tests/swoole_http_server_coro/check_cookie_crlf.phpt
+++ b/tests/swoole_http_server_coro/check_cookie_crlf.phpt
@@ -47,6 +47,7 @@ $pm->childFunc = function () use ($pm) {
             $response->end('hello world');
         });
 
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_http_server_coro/check_http_header_crlf.phpt
+++ b/tests/swoole_http_server_coro/check_http_header_crlf.phpt
@@ -34,6 +34,7 @@ $pm->childFunc = function () use ($pm) {
             $response->end('Redirecting...');
         });
 
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_http_server_coro/close_socket.phpt
+++ b/tests/swoole_http_server_coro/close_socket.phpt
@@ -91,6 +91,7 @@ $pm->childFunc = function () use ($pm) {
             'http_parse_post' => false,
             'http_parse_files' => false,
         ]);
+        $pm->wakeup();
         go(function () use ($server) {
             $server->start();
         });

--- a/tests/swoole_http_server_coro/rawContent_get_big_data.phpt
+++ b/tests/swoole_http_server_coro/rawContent_get_big_data.phpt
@@ -29,6 +29,7 @@ $pm->childFunc = function () use ($pm) {
             Assert::assert($request->rawContent() === $pm->getRandomData());
             Assert::length($request->rawContent(), 64 * 1024);
         });
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_http_server_coro/slow_client.phpt
+++ b/tests/swoole_http_server_coro/slow_client.phpt
@@ -43,6 +43,7 @@ $pm->childFunc = function () use ($pm)
             Assert::eq($request->header['content-length'], strlen($request->getContent()));
             $response->end("OK");
         });
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_http_server_coro/slow_large_post.phpt
+++ b/tests/swoole_http_server_coro/slow_large_post.phpt
@@ -50,6 +50,7 @@ $pm->childFunc = function () use ($pm)
             Assert::eq(VALUE, $request->post[KEY]);
             $response->end("OK");
         });
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_http_server_coro/ssl_bad_client.phpt
+++ b/tests/swoole_http_server_coro/ssl_bad_client.phpt
@@ -47,6 +47,7 @@ $pm->childFunc = function () use ($pm) {
             $response->end('<h1>Stop</h1>');
             $server->shutdown();
         });
+        $pm->wakeup();
         $server->start();
     });
     Event::wait();

--- a/tests/swoole_http_server_coro/websocket_ping.phpt
+++ b/tests/swoole_http_server_coro/websocket_ping.phpt
@@ -47,8 +47,8 @@ $pm->childFunc = function () use ($pm) {
                 }
             }
         });
-        $server->start();
         $pm->wakeup();
+        $server->start();
     });
     Swoole\Event::wait();
 };

--- a/tests/swoole_http_server_coro/websocket_ping_pong.phpt
+++ b/tests/swoole_http_server_coro/websocket_ping_pong.phpt
@@ -69,8 +69,8 @@ $pm->childFunc = function () use ($pm) {
                 }
             }
         });
-        $server->start();
         $pm->wakeup();
+        $server->start();
     });
     Swoole\Event::wait();
 };

--- a/tests/swoole_process/process_manager_readiness.phpt
+++ b/tests/swoole_process/process_manager_readiness.phpt
@@ -1,0 +1,50 @@
+--TEST--
+swoole_process: ProcessManager readiness modes
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager();
+$pm->childFunc = function () use ($pm): void {
+    $pm->wakeup();
+};
+$pm->parentFunc = function (): void {
+};
+$pm->childFirst();
+$pm->run();
+
+$pm = new ProcessManager();
+$pm->childFunc = function (): void {
+};
+$pm->parentFunc = function () use ($pm): void {
+    $pm->wakeup();
+};
+$pm->parentFirst();
+$pm->run();
+
+$pm = new ProcessManager();
+$pm->wakeup();
+$pm->childFunc = function (): void {
+};
+$pm->parentFunc = function (): void {
+};
+$pm->childFirst();
+$pm->run();
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(0);
+$pm->childFunc = function (): void {
+};
+$pm->parentFunc = function (): void {
+};
+$pm->childFirst();
+$pm->run();
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_process/process_manager_timeout.phpt
+++ b/tests/swoole_process/process_manager_timeout.phpt
@@ -1,0 +1,76 @@
+--TEST--
+swoole_process: ProcessManager readiness timeouts fail
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(0.1);
+try {
+    $pm->wait();
+    Assert::true(false);
+} catch (RuntimeException $e) {
+    Assert::same($e->getMessage(), 'ProcessManager did not receive a wakeup within 0.1s');
+}
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(1);
+$pm->childFunc = function (): void {
+    sleep(60);
+};
+$pm->parentFunc = function (): void {
+};
+$pm->childFirst();
+try {
+    $pm->run();
+    Assert::true(false);
+} catch (RuntimeException $e) {
+    Assert::same($e->getMessage(), 'ProcessManager did not receive a wakeup within 1s');
+}
+Assert::false(@Process::kill($pm->getChildPid(), 0));
+Assert::false(Process::wait(false));
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(1);
+$pm->childFunc = function (): void {
+};
+$pm->parentFunc = function (): void {
+};
+$pm->parentFirst();
+$pm->run(true);
+$pm->expectExitCode(255);
+Assert::contains($pm->getChildOutput(), 'ProcessManager did not receive a wakeup within 1s');
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(1);
+try {
+    $pm->wait();
+    Assert::true(false);
+} catch (RuntimeException $e) {
+    Assert::same($e->getMessage(), 'ProcessManager did not receive a wakeup within 1s');
+}
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(1);
+$pm->childFunc = function (): void {
+};
+$pm->parentFunc = function (): void {
+};
+$pm->childFirst();
+try {
+    $pm->run();
+    Assert::true(false);
+} catch (RuntimeException $e) {
+    Assert::same($e->getMessage(), 'ProcessManager child exited with code 0 and signal 0 before sending a wakeup');
+}
+Assert::false(Process::wait(false));
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_process_pool/message.phpt
+++ b/tests/swoole_process_pool/message.phpt
@@ -9,7 +9,7 @@ require __DIR__ . '/../include/bootstrap.php';
 $pm = new ProcessManager;
 $pm->parentFunc = function ($pid) use ($pm) {
     $client = new Swoole\Client(SWOOLE_SOCK_TCP);
-    Assert::assert($client->connect('127.0.0.1', 8089, 5));
+    Assert::assert($client->connect('127.0.0.1', $pm->getFreePort(), 5));
     $data = "hello swoole!";
     $client->send(pack('N', strlen($data)) . $data);
     $ret = $client->recv();
@@ -24,16 +24,19 @@ $pm->parentFunc = function ($pid) use ($pm) {
 $pm->childFunc = function () use ($pm) {
     $pool = new Swoole\Process\Pool(1, SWOOLE_IPC_SOCKET);
 
-    $pool->on('workerStart', function (Swoole\Process\Pool $pool, int $workerId) {
+    $pool->on('workerStart', function (Swoole\Process\Pool $pool, int $workerId) use ($pm) {
         $client = new Swoole\Client(SWOOLE_SOCK_TCP);
-        Assert::assert($client->connect('127.0.0.1', 8089, 5));
+        Assert::assert($client->connect('127.0.0.1', $pm->getFreePort(), 5));
         $data = "hello swoole! (from workerStart)";
         $client->send(pack('N', strlen($data)) . $data);
         $client->close();
     });
 
-    $pool->on("message", function (Swoole\Process\Pool $pool, string $message) {
+    $pool->on("message", function (Swoole\Process\Pool $pool, string $message) use ($pm) {
         echo "{$message}\n";
+        if ($message === "hello swoole! (from workerStart)") {
+            $pm->wakeup();
+        }
         if ($message === "hello swoole!") {
             $pool->write("hello ");
             $pool->write("client!");
@@ -41,7 +44,7 @@ $pm->childFunc = function () use ($pm) {
         }
     });
 
-    $pool->listen('127.0.0.1', 8089);
+    $pool->listen('127.0.0.1', $pm->getFreePort());
 
     $pool->start();
 };

--- a/tests/swoole_server/bug_11000_01.phpt
+++ b/tests/swoole_server/bug_11000_01.phpt
@@ -11,16 +11,16 @@ use Swoole\Server;
 
 $pm = new SwooleTest\ProcessManager;
 
-$pm->childFunc = function () {
+$pm->childFunc = function () use ($pm) {
     $port = get_one_free_port();
     $serv = new Server(TCP_SERVER_HOST, $port, SWOOLE_PROCESS);
-    $process = new Process(function ($process) use ($serv) {
+    $process = new Process(function ($process) use ($serv, $pm) {
         usleep(10000);
         $stats = $serv->stats();
         Assert::isArray($stats);
         Assert::keyExists($stats, 'connection_num');
         Assert::keyExists($stats, 'request_count');
-        usleep(200000);
+        $pm->wakeup();
         $serv->shutdown();
     });
     $serv->set(['worker_num' => 2, 'log_file' => '/dev/null']);

--- a/tests/swoole_server/bug_2308.phpt
+++ b/tests/swoole_server/bug_2308.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_server: bug Github#2308
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_extension_not_exist('redis');
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';
@@ -14,21 +17,22 @@ $pm->parentFunc = function ($pid) use ($pm) {
 };
 
 $pm->childFunc = function () use ($pm) {
-    $server = new Server('0.0.0.0', 9501, SWOOLE_BASE, SWOOLE_SOCK_TCP);
+    $server = new Server('0.0.0.0', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP);
     $server->set([
         'worker_num' => MAX_PROCESS_NUM,
         'log_file' => '/dev/null',
         'enable_coroutine' => false,
         'hook_flags' => SWOOLE_HOOK_ALL,
     ]);
-    $server->on('start', function () {
-        Swoole\Coroutine::create(function () {
+    $server->on('start', function () use ($pm) {
+        Swoole\Coroutine::create(function () use ($pm) {
             $redis = new \Redis();
             $redis->connect(REDIS_SERVER_HOST, REDIS_SERVER_PORT);
             $ret = $redis->set('foo', 'bar');
             Assert::assert($ret);
             $ret = $redis->get('foo');
             Assert::same($ret, 'bar');
+            $pm->wakeup();
         });
     });
     $server->on('workerStart', function ($server) {

--- a/tests/swoole_server/close_max_fd.phpt
+++ b/tests/swoole_server/close_max_fd.phpt
@@ -41,6 +41,11 @@ $pm->childFunc = function () use ($pm) {
         'log_level' => SWOOLE_LOG_ERROR,
     ]);
 
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('receive', function (Swoole\Server $serv, int $fd, int $rid, string $data) use ($fp) {
         fputs($fp, "recv: $data\n");
         fputs($fp, 'getClientList: ' . implode(';', $serv->getClientList()) . "\n");

--- a/tests/swoole_server/dispatch_mode_10.phpt
+++ b/tests/swoole_server/dispatch_mode_10.phpt
@@ -18,6 +18,7 @@ use function Swoole\Coroutine\go;
 $table = new Table(64);
 $table->column('count', Table::TYPE_INT);
 $table->create();
+$ready = new Swoole\Atomic(0);
 
 const N = IS_MAC_OS ? 256 : 1024;
 const EOF = "\r\n\r\n";
@@ -56,7 +57,7 @@ $pm->parentFunc = function ($pid) use ($pm, $table) {
     echo 'DONE' . PHP_EOL;
 };
 
-$pm->childFunc = function () use ($pm, $table) {
+$pm->childFunc = function () use ($pm, $ready, $table) {
     $serv = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
 
     $serv->set(array(
@@ -65,8 +66,8 @@ $pm->childFunc = function () use ($pm, $table) {
         'log_file' => '/dev/null',
     ));
 
-    $serv->on(Constant::EVENT_WORKER_START, function (Server $serv, $worker_id) use ($pm) {
-        if ($worker_id == 0) {
+    $serv->on(Constant::EVENT_WORKER_START, function (Server $serv, $worker_id) use ($pm, $ready) {
+        if ($ready->add() === $serv->setting['worker_num']) {
             $pm->wakeup();
         }
     });

--- a/tests/swoole_server/getWorkerStatus.phpt
+++ b/tests/swoole_server/getWorkerStatus.phpt
@@ -7,6 +7,7 @@ swoole_server: getWorkerStatus
 require __DIR__ . '/../include/bootstrap.php';
 
 $pm = new SwooleTest\ProcessManager;
+$ready = new Swoole\Atomic(0);
 $pm->parentFunc = function () use ($pm) {
     Co\run(function () use ($pm) {
         $client = new Co\Client(SWOOLE_SOCK_TCP);
@@ -24,14 +25,16 @@ $pm->parentFunc = function () use ($pm) {
         $pm->kill();
     });
 };
-$pm->childFunc = function () use ($pm) {
+$pm->childFunc = function () use ($pm, $ready) {
     $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
     $server->set([
         'worker_num' => 2,
         'log_file' => '/dev/null'
     ]);
-    $server->on('workerStart', function (Swoole\Server $serv) use ($pm) {
-        $pm->wakeup();
+    $server->on('workerStart', function (Swoole\Server $serv) use ($pm, $ready) {
+        if ($ready->add() === $serv->setting['worker_num']) {
+            $pm->wakeup();
+        }
     });
 
     $server->on('receive', function (Swoole\Server $serv, int $fd, int $rid, string $data) {

--- a/tests/swoole_server/mqtt/length_offset.phpt
+++ b/tests/swoole_server/mqtt/length_offset.phpt
@@ -30,6 +30,11 @@ $pm->childFunc = function () use ($pm) {
         'open_mqtt_protocol' => 1,
     ]);
 
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('receive', function (Swoole\Server $serv, int $fd, int $rid, string $data) {
         $header = Helper::getHeader($data);
         Assert::eq($header['type'], 3);

--- a/tests/swoole_server/mqtt/recv_fail.phpt
+++ b/tests/swoole_server/mqtt/recv_fail.phpt
@@ -34,6 +34,11 @@ $pm->childFunc = function () use ($pm) {
         'open_mqtt_protocol' => 1,
     ]);
 
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('receive', function (Swoole\Server $serv, int $fd, int $rid, string $data) {
         $header = Helper::getHeader($data);
         Assert::eq($header['type'], 12);

--- a/tests/swoole_server/mqtt/send_big_pack.phpt
+++ b/tests/swoole_server/mqtt/send_big_pack.phpt
@@ -32,6 +32,11 @@ $pm->childFunc = function () use ($pm) {
         'package_max_length' => 5 * 1024 *1024
     ]);
 
+    $server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $server->on('receive', function (Swoole\Server $serv, int $fd, int $rid, string $data) {
         $header = Helper::getHeader($data);
         Assert::eq($header['type'], 3);

--- a/tests/swoole_server/sendMessage_in_manager.phpt
+++ b/tests/swoole_server/sendMessage_in_manager.phpt
@@ -6,11 +6,13 @@ require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
 <?php
 
+use Swoole\Atomic;
 use Swoole\Constant;
 use Swoole\Server;
 
 require __DIR__ . '/../include/bootstrap.php';
 $pm = new SwooleTest\ProcessManager;
+$connect = new Atomic();
 
 const N = 16;
 
@@ -34,24 +36,24 @@ $pm->parentFunc = function ($pid) use ($pm) {
     $pm->kill();
 };
 
-$pm->childFunc = function () use ($pm) {
+$pm->childFunc = function () use ($pm, $connect) {
     $serv = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS, SWOOLE_SOCK_TCP);
     $serv->set([
         'log_file' => '/dev/null',
         'worker_num' => 2,
         'task_worker_num' => 2,
     ]);
-    $serv->on(Constant::EVENT_MANAGER_START, function (Server $serv) use ($pm) {
+    $serv->on(Constant::EVENT_MANAGER_START, function (Server $serv) use ($pm, $connect) {
         $pm->wakeup();
-        $pm->wait();
+        Assert::true($connect->wait(10));
         usleep(10000);
         swoole_loop_n(N, function ($i) use ($serv) {
             $wid = rand(0, 3);
             $serv->sendMessage("msg-" . $i, $wid);
         });
     });
-    $serv->on(Constant::EVENT_CONNECT, function ($serv, $fd, $reactor_id) use ($pm) {
-        $pm->wakeup();
+    $serv->on(Constant::EVENT_CONNECT, function ($serv, $fd, $reactor_id) use ($connect) {
+        $connect->wakeup();
     });
     $serv->on(Constant::EVENT_RECEIVE, function ($serv, $fd, $reactor_id, $data) {
     });

--- a/tests/swoole_server/task/bug_2585.phpt
+++ b/tests/swoole_server/task/bug_2585.phpt
@@ -29,6 +29,11 @@ $pm->childFunc = function () use ($pm) {
         'enable_coroutine' => false,
         'task_enable_coroutine' => true
     ]);
+    $http->on('WorkerStart', function (Swoole\Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         Assert::assert($response->detach());
         if (mt_rand(0, 1)) {

--- a/tests/swoole_server/task/huge_data.phpt
+++ b/tests/swoole_server/task/huge_data.phpt
@@ -30,6 +30,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
         'task_worker_num' => 4
     ]);
+    $http->on('WorkerStart', function (Swoole\Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         Assert::assert($response->detach());
         $scope = IS_IN_CI ? [4, 16] : [16, 64];

--- a/tests/swoole_server/task/invalid_packet.phpt
+++ b/tests/swoole_server/task/invalid_packet.phpt
@@ -41,13 +41,15 @@ $pm->childFunc = function () use ($pm, $file, $result) {
         'message_queue_key' => MSGQ_KEY,
         'log_file' => $file,
     ]);
-    $serv->on('WorkerStart', function (Server $serv) use ($pm) {
-        $pm->wakeup();
+    $serv->on('WorkerStart', function (Server $serv, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
     });
     $serv->on('receive', function (Server $serv, $fd, $rid, $data) {});
     $serv->on('task', function (Server $serv, $task_id, $worker_id, $data) use ($pm, $result) {
-        $pm->wakeup();
         $result->add(1);
+        $pm->wakeup();
     });
 
     $serv->start();

--- a/tests/swoole_server/task/task_enable_coroutine.phpt
+++ b/tests/swoole_server/task/task_enable_coroutine.phpt
@@ -28,6 +28,11 @@ $pm->childFunc = function () use ($pm) {
         'task_worker_num' => 4,
         'task_enable_coroutine' => true
     ]);
+    $http->on('WorkerStart', function (Swoole\Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         Assert::assert($response->detach());
         if (mt_rand(0, 1)) {

--- a/tests/swoole_server/task/task_enable_coroutine_return.phpt
+++ b/tests/swoole_server/task/task_enable_coroutine_return.phpt
@@ -28,6 +28,11 @@ $pm->childFunc = function () use ($pm) {
         'task_worker_num' => 4,
         'task_enable_coroutine' => true
     ]);
+    $http->on('WorkerStart', function (Swoole\Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         Assert::assert($response->detach());
         $http->task($response->fd, -1, function ($server, $taskId, $data) {

--- a/tests/swoole_server/task/timer.phpt
+++ b/tests/swoole_server/task/timer.phpt
@@ -42,7 +42,7 @@ $pm->childFunc = function () use ($pm) {
     $http->on('message', function (Server $server, Frame $frame) {
         $server->task(['fd' => $frame->fd]);
     });
-    $http->on('WorkerStart', function (Server $server, int $workerId) {
+    $http->on('WorkerStart', function (Server $server, int $workerId) use ($pm) {
         if ($server->taskworker) {
             Timer::after(1, function () use ($server, $workerId) {
                 var_dump('after1 : ' . time());
@@ -51,6 +51,8 @@ $pm->childFunc = function () use ($pm) {
             Timer::after(10000, function () use ($server, $workerId) {
                 var_dump('after2 : ' . time());
             });
+        } else {
+            $pm->wakeup();
         }
     });
     $http->on('task', function (Server $server, Task $task) {

--- a/tests/swoole_server/task/without_onfinish.phpt
+++ b/tests/swoole_server/task/without_onfinish.phpt
@@ -23,6 +23,11 @@ $pm->childFunc = function () use ($pm) {
         'log_file' => '/dev/null',
         'task_worker_num' => 4
     ]);
+    $http->on('WorkerStart', function (Swoole\Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($http) {
         Assert::assert($response->detach());
         $http->task($response->fd);

--- a/tests/swoole_server/user_process_force_exit.phpt
+++ b/tests/swoole_server/user_process_force_exit.phpt
@@ -8,7 +8,6 @@ require __DIR__ . '/../include/bootstrap.php';
 
 use Swoole\Constant;
 
-$atomic = new Swoole\Atomic;
 $pm = new SwooleTest\ProcessManager;
 
 $pm->parentFunc = function () use ($pm) {
@@ -26,11 +25,12 @@ $pm->childFunc = function () use ($pm) {
 
     $server->on('packet', function () {
     });
-    $server->addProcess(new Swoole\Process(function () {
+    $server->addProcess(new Swoole\Process(function () use ($pm) {
         pcntl_signal(SIGTERM, function () {
         });
         Swoole\Timer::tick(1000, function () {
         });
+        $pm->wakeup();
     }));
     $server->start();
 };

--- a/tests/swoole_server_port/sub_handshake.phpt
+++ b/tests/swoole_server_port/sub_handshake.phpt
@@ -22,6 +22,11 @@ $pm->parentFunc = function () use ($pm) {
 };
 $pm->childFunc = function () use ($pm) {
     $main_server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(0), SWOOLE_BASE);
+    $main_server->on('WorkerStart', function ($server, $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
     $main_server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
         $response->write('hello world');
         $response->end();

--- a/tests/swoole_socket_coro/readv.phpt
+++ b/tests/swoole_socket_coro/readv.phpt
@@ -46,6 +46,7 @@ $pm->childFunc = function () use ($pm) {
             }
         });
 
+        $pm->wakeup();
         $server->start();
     });
 };

--- a/tests/swoole_socket_coro/writev.phpt
+++ b/tests/swoole_socket_coro/writev.phpt
@@ -43,6 +43,7 @@ $pm->childFunc = function () use ($pm) {
             $response->end('world');
         });
 
+        $pm->wakeup();
         $server->start();
     });
 };


### PR DESCRIPTION
`ProcessManager` currently ignores a failed readiness wait. A test then continues after a one-second delay even though its child is not ready, so broken startup ordering can pass, or fail later for the wrong reason.

This makes `ProcessManager` throw when an expected wakeup does not arrive, and terminates and reaps the child it owns when the parent-side barrier fails. Existing fixtures now signal only after their server or required workers are ready. Independent phases use separate `Atomic` values. Two hard-coded listener ports and a missing extension check were also corrected, because those failures would otherwise be reported as a missing wakeup.

This targets `optimize-atomic-wakeups` because the strict check depends on that branch retrying `EAGAIN` and `EINTR` within a single deadline. On `master`, a wakeup that lands between the wait's first check and its `FUTEX_WAIT` call returns `EAGAIN`, which is currently reported as a timeout. It should not move to `master` until that change lands there.
