### PR TITLE
Fix segfault when calling Process::signal() in manager process with thread-context

### DIFF
--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -495,14 +495,19 @@ static PHP_METHOD(swoole_process, signal) {
     if (zcallback == nullptr) {
         fci_cache = signal_fci_caches[signo];
         if (fci_cache) {
-#ifdef SW_USE_THREAD_CONTEXT
-            swoole_event_defer([signo](void *) { swoole_signal_set(signo, nullptr); }, nullptr);
-#else
-            swoole_signal_set(signo, nullptr);
-#endif
             signal_fci_caches[signo] = nullptr;
-            swoole_event_defer(sw_callable_free, fci_cache);
             SwooleG.signal_listener_num--;
+            if (swoole_event_is_available()) {
+#ifdef SW_USE_THREAD_CONTEXT
+                swoole_event_defer([signo](void *) { swoole_signal_set(signo, nullptr); }, nullptr);
+#else
+                swoole_signal_set(signo, nullptr);
+#endif
+                swoole_event_defer(sw_callable_free, fci_cache);
+            } else {
+                swoole_signal_set(signo, nullptr);
+                sw_callable_free(fci_cache);
+            }
             RETURN_TRUE;
         } else {
             php_swoole_error(E_WARNING, "unable to find the callback of signal [" ZEND_LONG_FMT "]", signo);
@@ -527,11 +532,11 @@ static PHP_METHOD(swoole_process, signal) {
         signal_fci_caches[signo] = fci_cache;
 #ifdef SW_USE_THREAD_CONTEXT
         /**
-         * In a sync process without an event loop (e.g. the manager process), SwooleTG.reactor is nullptr,
+         * In a sync process without an event loop (e.g. the manager process), there is no reactor,
          * so swoole_event_defer() would dereference a null pointer and the deferred callback would never run.
          * Set the signal handler directly instead.
          */
-        if (SwooleTG.reactor) {
+        if (swoole_event_is_available()) {
             swoole_event_defer([signo, handler](void *) { swoole_signal_set(signo, handler, true); }, nullptr);
         } else {
             swoole_signal_set(signo, handler, true);

--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -526,7 +526,16 @@ static PHP_METHOD(swoole_process, signal) {
         }
         signal_fci_caches[signo] = fci_cache;
 #ifdef SW_USE_THREAD_CONTEXT
-        swoole_event_defer([signo, handler](void *) { swoole_signal_set(signo, handler, true); }, nullptr);
+        /**
+         * In a sync process without an event loop (e.g. the manager process), SwooleTG.reactor is nullptr,
+         * so swoole_event_defer() would dereference a null pointer and the deferred callback would never run.
+         * Set the signal handler directly instead.
+         */
+        if (SwooleTG.reactor) {
+            swoole_event_defer([signo, handler](void *) { swoole_signal_set(signo, handler, true); }, nullptr);
+        } else {
+            swoole_signal_set(signo, handler, true);
+        }
 #else
         swoole_signal_set(signo, handler, true);
 #endif

--- a/tests/swoole_process/signal_in_manager_4.phpt
+++ b/tests/swoole_process/signal_in_manager_4.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_process: signal in manager (thread context null reactor regression)
+swoole_process: register and unregister signal in manager
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
@@ -15,11 +15,15 @@ $pm = new SwooleTest\ProcessManager;
 $pm->parentFunc = function ($pid) use ($pm) {
     usleep(100000);
     $manager_pid = file_get_contents(PID_FILE);
-    // The manager process must still be alive here. With SW_USE_THREAD_CONTEXT enabled,
-    // registering the signal handler in onManagerStart used to segfault the manager process,
-    // because swoole_event_defer() dereferenced the null reactor.
+    // The manager process must still be alive here. Registering or unregistering a signal
+    // handler in onManagerStart used to segfault the manager process, because
+    // swoole_event_defer() dereferenced the null reactor.
     Assert::true(Process::kill($manager_pid, 0));
+    // The removed callback must not be invoked (SIGINT is ignored after unregistration).
     Process::kill($manager_pid, SIGINT);
+    usleep(100000);
+    Assert::true(Process::kill($manager_pid, 0));
+    Process::kill($manager_pid, SIGTERM);
     $pm->wait();
     $pm->kill();
 };
@@ -32,10 +36,11 @@ $pm->childFunc = function () use ($pm) {
     ]);
     $serv->on('ManagerStart', function (Server $serv) use ($pm) {
         file_put_contents(PID_FILE, $serv->getManagerPid());
-        Process::signal(SIGINT, function () use ($pm) {
+        Process::signal(SIGINT, static function () {
             echo "SIGINT triggered\n";
-            $pm->wakeup();
         });
+        Assert::true(Process::signal(SIGINT, null));
+        echo "signal unregistered\n";
         $pm->wakeup();
     });
     $serv->on('Receive', function (Server $serv, $fd, $reactorId, $data) {
@@ -47,4 +52,4 @@ $pm->run();
 unlink(PID_FILE);
 ?>
 --EXPECT--
-SIGINT triggered
+signal unregistered

--- a/tests/swoole_process/signal_in_manager_4.phpt
+++ b/tests/swoole_process/signal_in_manager_4.phpt
@@ -1,0 +1,50 @@
+--TEST--
+swoole_process: signal in manager (thread context null reactor regression)
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+use Swoole\Process;
+use Swoole\Server;
+
+const PID_FILE = __DIR__ . '/manager.pid';
+
+$pm = new SwooleTest\ProcessManager;
+
+$pm->parentFunc = function ($pid) use ($pm) {
+    usleep(100000);
+    $manager_pid = file_get_contents(PID_FILE);
+    // The manager process must still be alive here. With SW_USE_THREAD_CONTEXT enabled,
+    // registering the signal handler in onManagerStart used to segfault the manager process,
+    // because swoole_event_defer() dereferenced the null reactor.
+    Assert::true(Process::kill($manager_pid, 0));
+    Process::kill($manager_pid, SIGINT);
+    $pm->wait();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $serv = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $serv->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null',
+    ]);
+    $serv->on('ManagerStart', function (Server $serv) use ($pm) {
+        file_put_contents(PID_FILE, $serv->getManagerPid());
+        Process::signal(SIGINT, function () use ($pm) {
+            echo "SIGINT triggered\n";
+            $pm->wakeup();
+        });
+        $pm->wakeup();
+    });
+    $serv->on('Receive', function (Server $serv, $fd, $reactorId, $data) {
+    });
+    $serv->start();
+};
+$pm->childFirst();
+$pm->run();
+unlink(PID_FILE);
+?>
+--EXPECT--
+SIGINT triggered


### PR DESCRIPTION
## Description

When Swoole is built with `--enable-thread-context` (`SW_USE_THREAD_CONTEXT`), calling `Swoole\Process::signal()` inside `onManagerStart` crashes the manager process with SIGSEGV.

Reproducer:

```php
<?php
$server = new Swoole\Server('127.0.0.1', 9501, SWOOLE_PROCESS);
$server->set(['worker_num' => 1]);
$server->on('ManagerStart', function () {
    Swoole\Process::signal(SIGTERM, function (int $signo) {});
});
$server->on('Receive', function () {});
$server->start();
```

Result:

```
WARNING Server::signal_handler_child_exit(): Fatal Error: manager process exit. status=0, signal=[Segmentation fault: 11]
```

Backtrace:

```
#0  swoole::Reactor::defer (this=0x0) at src/reactor/base.cc:380
#1  swoole_event_defer (...) at src/wrapper/event.cc:89
#2  zim_swoole_process_signal (...) at ext-src/swoole_process.cc:520
#9  php_swoole_server_onManagerStart (...) at ext-src/swoole_server.cc:1454
```

## Root cause

The manager process is a sync process (`Server::is_sync_process()`), but has no event loop: `SwooleTG.reactor` is `nullptr`. With `SW_USE_THREAD_CONTEXT`, the signal registration in the sync-process branch is deferred via `swoole_event_defer()`, which dereferences the null reactor. Deferring is also semantically wrong here: with no reactor loop, the callback would never run.

Related pr: https://github.com/crazywhalecc/static-php-cli/pull/1229

## Fix

Only defer when a reactor exists; otherwise call `swoole_signal_set()` directly (same behavior as non-thread-context builds).