### PR TITLE
Guard io_uring core tests when the feature is disabled

### DIFF
--- a/core-tests/src/coroutine/iouring.cpp
+++ b/core-tests/src/coroutine/iouring.cpp
@@ -190,7 +190,6 @@ TEST(iouring, ftruncate) {
     });
 }
 #endif
-#endif
 
 TEST(iouring, connect) {
     signal(SIGPIPE, SIG_IGN);
@@ -467,3 +466,4 @@ TEST(iouring, accept_timeout) {
         Iouring::close(server_sock);
     });
 }
+#endif


### PR DESCRIPTION
Core builds always include `iouring.cpp`, but `swoole::Iouring` is declared only when `SW_USE_IOURING` is enabled. The file-level guard ended before the network and wait cases, so builds without io_uring could not compile the test target.

Move the existing guard to the end of the file so the complete suite follows the feature it tests. Enabled builds are unchanged.

No CI job builds core tests with io_uring disabled, so that configuration was built and linked locally. The resulting test list correctly omits the io_uring suite.