### PR TITLE
Fix HTTP/2 HEAD response framing: end stream on HEADERS, keep Content-Length

### DIFF
--- a/ext-src/php_swoole_http.h
+++ b/ext-src/php_swoole_http.h
@@ -328,7 +328,7 @@ class Stream {
     Stream(const Session *client, uint32_t _id);
     ~Stream();
 
-    bool send_header(const String *body, bool end_stream) const;
+    bool send_header(const String *body, bool end_stream, bool is_head = false) const;
     bool send_body(const String *body,
                    bool end_stream,
                    const std::shared_ptr<Session> &session,

--- a/ext-src/swoole_http2_server.cc
+++ b/ext-src/swoole_http2_server.cc
@@ -508,7 +508,7 @@ bool swoole_http2_server_goaway(HttpContext *ctx, zend_long error_code, const ch
     return rv;
 }
 
-bool Http2Stream::send_header(const String *body, bool end_stream) const {
+bool Http2Stream::send_header(const String *body, bool end_stream, bool is_head) const {
     char header_buffer[SW_BUFFER_SIZE_STD];
     ssize_t bytes = http2_server_build_header(ctx, (uchar *) header_buffer, body);
     if (bytes < 0) {
@@ -533,7 +533,9 @@ bool Http2Stream::send_header(const String *body, bool end_stream) const {
      */
     char frame_header[SW_HTTP2_FRAME_HEADER_SIZE];
 
-    if (end_stream && (!body || body->length == 0)) {
+    // A HEAD response must not include content: end the stream on the HEADERS frame, no DATA.
+    // See: https://www.rfc-editor.org/rfc/rfc9110#section-9.3.2
+    if (end_stream && (is_head || !body || body->length == 0)) {
         http2::set_frame_header(
             frame_header, SW_HTTP2_TYPE_HEADERS, bytes, SW_HTTP2_FLAG_END_HEADERS | SW_HTTP2_FLAG_END_STREAM, id);
         ctx->end_ = 1;
@@ -695,9 +697,18 @@ static bool http2_server_respond(HttpContext *ctx, const String *body) {
         ztrailer = nullptr;
     }
 
-    bool end_stream = (ztrailer == nullptr);
+    // A HEAD response carries GET's header fields but no content; suppress the body below.
+    bool is_head = false;
+    zval *zrequest_method = zend_hash_str_find(Z_ARR_P(ctx->request.zserver), ZEND_STRL("request_method"));
+    if (zrequest_method && Z_TYPE_P(zrequest_method) == IS_STRING &&
+        SW_STRCASEEQ(Z_STRVAL_P(zrequest_method), Z_STRLEN_P(zrequest_method), "HEAD")) {
+        is_head = true;
+    }
 
-    if (!ctx->send_header_ && !stream->send_header(body, end_stream)) {
+    // HEAD ends the stream on the HEADERS frame even when a trailer was set; there is no content for it to follow.
+    bool end_stream = (ztrailer == nullptr) || is_head;
+
+    if (!ctx->send_header_ && !stream->send_header(body, end_stream, is_head)) {
         return false;
     }
 
@@ -713,7 +724,9 @@ static bool http2_server_respond(HttpContext *ctx, const String *body) {
 #endif
 
     SW_LOOP {
-        if (ctx->send_chunked && body->length == 0 && !stream->send_end_stream_data_frame()) {
+        if (is_head) {
+            // HEAD: no body
+        } else if (ctx->send_chunked && body->length == 0 && !stream->send_end_stream_data_frame()) {
             break;
         } else if (!stream->send_body(body, end_stream, client)) {
             break;

--- a/tests/swoole_http2_server/head_response.phpt
+++ b/tests/swoole_http2_server/head_response.phpt
@@ -1,0 +1,51 @@
+--TEST--
+swoole_http2_server: a HEAD response carries GET's headers but no content, even with a trailer set (RFC 9110 9.3.2)
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+const BODY = '<h1>Hello Swoole.</h1>';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $cli = new Swoole\Coroutine\Http2\Client('127.0.0.1', $pm->getFreePort());
+        $cli->connect();
+        $request = new Swoole\Http2\Request;
+        $request->method = 'HEAD';
+        $request->path = '/';
+        Assert::assert($cli->send($request));
+        $response = $cli->recv(5);
+        // Same status and header fields the equivalent GET would send, including Content-Length ...
+        Assert::same($response->statusCode, 200);
+        Assert::same($response->headers['content-length'], (string) strlen(BODY));
+        // ... but no content in the response body (the HEADERS frame ends the stream, no DATA frame).
+        Assert::same((string) $response->data, '');
+        echo "DONE\n";
+        $pm->kill();
+    });
+};
+$pm->childFunc = function () use ($pm) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $http->set([
+        'log_file' => '/dev/null',
+        'open_http2_protocol' => true,
+    ]);
+    $http->on('workerStart', function ($serv, $wid) use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        // A trailer has no content to follow on a HEAD response: the server must drop it and still
+        // end the stream on the HEADERS frame (without that, the client blocks waiting for END_STREAM).
+        $response->trailer('x-checksum', 'deadbeef');
+        $response->end(BODY);
+    });
+    $http->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
### HTTP/2 HEAD requests 

A response to a HEAD request must not include content (RFC 9110 S 9.3.2), but the HTTP/2 server decides END_STREAM purely from the response body length (`send_header()` sets it only when `body->length == 0`). 

A HEAD request handled by ordinary code that calls `$response->end($body)` gets a HEADERS frame without END_STREAM followed by a DATA frame carrying the body. 

nghttp (libnghttp2 strict mode) rejects that stream with PROTOCOL_ERROR. 

Lenient clients such as curl tolerate the extra DATA frame.

### This change

- detects HEAD in the response path and sets END_STREAM on the HEADERS frame;
- leaves Content-Length as the value the equivalent GET would send and sends no DATA frame, which a no-content response is permitted and should do (a non-zero Content-Length with no DATA frames, RFC 9113 S 8.1.1);

- this matches nginx and Apache httpd, which return the header fields (including Content-Length) but no DATA frame.

Non-HEAD responses are unchanged; the added path only branches on the request method.

### Testing

- built the extension and confirmed the framing with nghttp: HEAD returns a HEADERS frame with `flags=0x05` (END_STREAM), Content-Length intact, and no DATA frame, while GET is unchanged.
- added `tests/swoole_http2_server/head_response.phpt` (local server plus coroutine HTTP/2 client, no external dependencies) asserting a HEAD response has status 200, Content-Length equal to the GET body length, and an empty body; it fails without the fix.
