### PR TITLE
Fix masked compressed WebSocket frame unpacking

### DIFF
--- a/ext-src/stubs/php_swoole_websocket.stub.php
+++ b/ext-src/stubs/php_swoole_websocket.stub.php
@@ -5,7 +5,7 @@ namespace Swoole\WebSocket {
 		public function push(int $fd, \Swoole\WebSocket\Frame|string $data, int $opcode = WEBSOCKET_OPCODE_TEXT, int $flags = SWOOLE_WEBSOCKET_FLAG_FIN): bool {}
 		public function isEstablished(int $fd): bool {}
 		public static function pack(\Swoole\WebSocket\Frame|string $data, int $opcode = WEBSOCKET_OPCODE_TEXT, int $flags = SWOOLE_WEBSOCKET_FLAG_FIN): string {}
-        public static function unpack(string $data): \Swoole\WebSocket\Frame {}
+		public static function unpack(string $data): \Swoole\WebSocket\Frame|false {}
 		public function disconnect(int $fd, int $code = SWOOLE_WEBSOCKET_CLOSE_NORMAL, string $reason = ""): bool {}
 		public function ping(int $fd, string $data = ""): bool {}
 	}
@@ -13,6 +13,6 @@ namespace Swoole\WebSocket {
 	class Frame {
 		public function __toString(): string {}
 		public static function pack(\Swoole\WebSocket\Frame|string $data, int $opcode = WEBSOCKET_OPCODE_TEXT, int $flags = SWOOLE_WEBSOCKET_FLAG_FIN): string {}
-        public static function unpack(string $data): \Swoole\WebSocket\Frame {}
+		public static function unpack(string $data): \Swoole\WebSocket\Frame|false {}
 	}
 }

--- a/ext-src/stubs/php_swoole_websocket_arginfo.h
+++ b/ext-src/stubs/php_swoole_websocket_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b2cfb2530844a6e0ea1dc7cb8f62af47010d0057 */
+ * Stub hash: 60475040a55f12a9c319e65f5d567cfc0bb57f6f */
 
 #if !defined(_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_WebSocket_Server_push, 0, 2, _IS_BOOL, 0)
@@ -19,7 +19,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_WebSocket_Server_pa
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SWOOLE_WEBSOCKET_FLAG_FIN")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Swoole_WebSocket_Server_unpack, 0, 1, Swoole\\WebSocket\\Frame, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Swoole_WebSocket_Server_unpack, 0, 1, Swoole\\WebSocket\\Frame, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -44,7 +44,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_WebSocket_Frame_pac
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SWOOLE_WEBSOCKET_FLAG_FIN")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Swoole_WebSocket_Frame_unpack, 0, 1, Swoole\\WebSocket\\Frame, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Swoole_WebSocket_Frame_unpack, 0, 1, Swoole\\WebSocket\\Frame, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext-src/swoole_websocket_server.cc
+++ b/ext-src/swoole_websocket_server.cc
@@ -913,19 +913,25 @@ static PHP_METHOD(swoole_websocket_server, unpack) {
         RETURN_FALSE;
     }
 
-    zval zpayload{};
     uint8_t flags = frame.get_flags();
 
+    // The payload is masked after it is compressed, and the input string may be interned,
+    // so unmask a copy before decompressing it.
+    zval zpayload;
+    ZVAL_STRINGL(&zpayload, frame.payload, frame.payload_length);
+    if (frame.header.MASK && frame.payload_length > 0) {
+        WebSocket::mask(Z_STRVAL(zpayload), frame.payload_length, frame.mask_key);
+    }
+
     if (frame.compressed()) {
-        if (sw_unlikely(!FrameObject::uncompress(&zpayload, frame.payload, frame.payload_length))) {
+        zval zuncompressed;
+        bool rs = FrameObject::uncompress(&zuncompressed, Z_STRVAL(zpayload), Z_STRLEN(zpayload));
+        zval_ptr_dtor(&zpayload);
+        if (sw_unlikely(!rs)) {
             swoole_set_last_error(SW_ERROR_PROTOCOL_ERROR);
             RETURN_FALSE;
         }
-    } else {
-        ZVAL_STRINGL(&zpayload, frame.payload, frame.payload_length);
-        if (frame.header.MASK && frame.payload_length > 0) {
-            WebSocket::mask(Z_STRVAL(zpayload), frame.payload_length, frame.mask_key);
-        }
+        zpayload = zuncompressed;
     }
 
     WebSocket::construct_frame(return_value, frame.header.OPCODE, &zpayload, flags);

--- a/ext-src/swoole_websocket_server.cc
+++ b/ext-src/swoole_websocket_server.cc
@@ -914,24 +914,35 @@ static PHP_METHOD(swoole_websocket_server, unpack) {
     }
 
     uint8_t flags = frame.get_flags();
-
-    // The payload is masked after it is compressed, and the input string may be interned,
-    // so unmask a copy before decompressing it.
-    zval zpayload;
-    ZVAL_STRINGL(&zpayload, frame.payload, frame.payload_length);
-    if (frame.header.MASK && frame.payload_length > 0) {
-        WebSocket::mask(Z_STRVAL(zpayload), frame.payload_length, frame.mask_key);
-    }
+    zval zpayload{};
 
     if (frame.compressed()) {
-        zval zuncompressed;
-        bool rs = FrameObject::uncompress(&zuncompressed, Z_STRVAL(zpayload), Z_STRLEN(zpayload));
-        zval_ptr_dtor(&zpayload);
-        if (sw_unlikely(!rs)) {
+        const char *payload = frame.payload;
+        zval zmasked_payload;
+        bool masked = frame.header.MASK && frame.payload_length > 0;
+
+        if (masked) {
+            // The payload is masked after compression, and mask() modifies its buffer in place,
+            // so unmask a copy rather than the caller's string.
+            ZVAL_STRINGL(&zmasked_payload, frame.payload, frame.payload_length);
+            WebSocket::mask(Z_STRVAL(zmasked_payload), frame.payload_length, frame.mask_key);
+            payload = Z_STRVAL(zmasked_payload);
+        }
+
+        bool result = FrameObject::uncompress(&zpayload, payload, frame.payload_length);
+        if (masked) {
+            zval_ptr_dtor(&zmasked_payload);
+        }
+
+        if (sw_unlikely(!result)) {
             swoole_set_last_error(SW_ERROR_PROTOCOL_ERROR);
             RETURN_FALSE;
         }
-        zpayload = zuncompressed;
+    } else {
+        ZVAL_STRINGL(&zpayload, frame.payload, frame.payload_length);
+        if (frame.header.MASK && frame.payload_length > 0) {
+            WebSocket::mask(Z_STRVAL(zpayload), frame.payload_length, frame.mask_key);
+        }
     }
 
     WebSocket::construct_frame(return_value, frame.header.OPCODE, &zpayload, flags);

--- a/tests/swoole_websocket_server/unpack_compressed.phpt
+++ b/tests/swoole_websocket_server/unpack_compressed.phpt
@@ -1,0 +1,45 @@
+--TEST--
+swoole_websocket_server: unpack compressed frame with and without mask
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_defined('SWOOLE_HAVE_ZLIB');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\WebSocket\Frame;
+use Swoole\WebSocket\Server;
+
+$payload = str_repeat('swoole-websocket-frame:', 20) . 'x';
+$cases = [
+    SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_MASK | SWOOLE_WEBSOCKET_FLAG_COMPRESS,
+    SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_COMPRESS,
+];
+
+foreach ($cases as $flags) {
+    $packed = Frame::pack($payload, WEBSOCKET_OPCODE_TEXT, $flags);
+    $original = $packed;
+    $expectedFlags = $flags | SWOOLE_WEBSOCKET_FLAG_RSV1;
+
+    Assert::same(ord($packed[0]) & 0x40, 0x40);
+    Assert::same(ord($packed[1]) & 0x80, ($flags & SWOOLE_WEBSOCKET_FLAG_MASK) ? 0x80 : 0);
+
+    foreach ([Frame::class, Server::class] as $class) {
+        $frame = $class::unpack($packed);
+        if (!Assert::isInstanceOf($frame, Frame::class)) {
+            continue;
+        }
+        Assert::same($frame->data, $payload);
+        Assert::same($frame->opcode, WEBSOCKET_OPCODE_TEXT);
+        Assert::true($frame->finish);
+        Assert::same($frame->flags, $expectedFlags);
+        Assert::same($packed, $original);
+    }
+}
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_websocket_server/unpack_compressed.phpt
+++ b/tests/swoole_websocket_server/unpack_compressed.phpt
@@ -20,7 +20,7 @@ $cases = [
 
 foreach ($cases as $flags) {
     $packed = Frame::pack($payload, WEBSOCKET_OPCODE_TEXT, $flags);
-    $original = $packed;
+    $originalHex = bin2hex($packed);
     $expectedFlags = $flags | SWOOLE_WEBSOCKET_FLAG_RSV1;
 
     Assert::same(ord($packed[0]) & 0x40, 0x40);
@@ -28,16 +28,31 @@ foreach ($cases as $flags) {
 
     foreach ([Frame::class, Server::class] as $class) {
         $frame = $class::unpack($packed);
-        if (!Assert::isInstanceOf($frame, Frame::class)) {
-            continue;
-        }
+        Assert::isInstanceOf($frame, Frame::class);
         Assert::same($frame->data, $payload);
         Assert::same($frame->opcode, WEBSOCKET_OPCODE_TEXT);
         Assert::true($frame->finish);
         Assert::same($frame->flags, $expectedFlags);
-        Assert::same($packed, $original);
+        Assert::same(bin2hex($packed), $originalHex);
     }
 }
+
+// Invalid compressed frames fail with and without a temporary unmasked copy.
+$invalidCases = [
+    SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_MASK | SWOOLE_WEBSOCKET_FLAG_RSV1,
+    SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_RSV1,
+];
+
+foreach ($invalidCases as $invalidFlags) {
+    $invalid = Frame::pack('not-deflate-data', WEBSOCKET_OPCODE_TEXT, $invalidFlags);
+    Assert::false(@Frame::unpack($invalid));
+    Assert::same(swoole_last_error(), SWOOLE_ERROR_PROTOCOL_ERROR);
+}
+
+// A zero-length compressed frame has no payload pointer.
+$empty = Frame::pack('', WEBSOCKET_OPCODE_TEXT, SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_RSV1);
+Assert::false(@Frame::unpack($empty));
+Assert::same(swoole_last_error(), SWOOLE_ERROR_PROTOCOL_ERROR);
 
 echo "DONE\n";
 ?>

--- a/tests/swoole_websocket_server/unpack_invalid_frame.phpt
+++ b/tests/swoole_websocket_server/unpack_invalid_frame.phpt
@@ -1,0 +1,23 @@
+--TEST--
+swoole_websocket_server: unpack returns false for an incomplete frame
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\WebSocket\Frame;
+use Swoole\WebSocket\Server;
+
+printf("Frame::unpack returns: %s\n", (string) (new ReflectionMethod(Frame::class, 'unpack'))->getReturnType());
+printf("Server::unpack returns: %s\n", (string) (new ReflectionMethod(Server::class, 'unpack'))->getReturnType());
+
+Assert::false(Frame::unpack("\x81"));
+Assert::same(swoole_last_error(), SWOOLE_ERROR_PROTOCOL_ERROR);
+Assert::false(Server::unpack("\x81"));
+echo "DONE\n";
+?>
+--EXPECT--
+Frame::unpack returns: Swoole\WebSocket\Frame|false
+Server::unpack returns: Swoole\WebSocket\Frame|false
+DONE

--- a/tests/swoole_websocket_server/unpack_preserves_input.phpt
+++ b/tests/swoole_websocket_server/unpack_preserves_input.phpt
@@ -10,19 +10,17 @@ use Swoole\WebSocket\Frame;
 $payload = "masked-payload";
 $flags = SWOOLE_WEBSOCKET_FLAG_FIN | SWOOLE_WEBSOCKET_FLAG_MASK;
 $packed = Frame::pack($payload, WEBSOCKET_OPCODE_TEXT, $flags);
-$original = $packed;
+$originalHex = bin2hex($packed);
 
 $frame = Frame::unpack($packed);
 
 var_dump((ord($packed[1]) & 0x80) === 0x80);
-var_dump($packed === $original);
-var_dump(bin2hex($packed) === bin2hex($original));
+var_dump(bin2hex($packed) === $originalHex);
 var_dump($frame->data === $payload);
 var_dump($frame->opcode === WEBSOCKET_OPCODE_TEXT);
 var_dump($frame->finish === true);
 ?>
 --EXPECT--
-bool(true)
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
## What changed

- unmask a temporary copy before decompressing masked frames
- declare the existing `false` result for invalid frames
- cover compressed frames with and without masking, including frames that cannot be inflated
- compare the existing input-preservation test against a snapshot taken before unpacking, so it can detect a modified input

Masked compressed frames were passed to zlib before their mask was removed, so decompression failed.

The `false` return already existed. Correcting the return type prevents debug PHP builds from aborting when that path is used.