### PR TITLE
[WIP][6.1]Fix atomic without futex

### DIFF
--- a/ext-src/swoole_atomic.cc
+++ b/ext-src/swoole_atomic.cc
@@ -29,6 +29,9 @@ static zend_object_handlers swoole_atomic_long_handlers;
 
 struct AtomicObject {
     sw_atomic_t *ptr;
+#ifndef HAVE_FUTEX
+    sw_atomic_t *wakeup_count;
+#endif
     zend_object std;
 };
 
@@ -40,8 +43,17 @@ static sw_atomic_t *atomic_get_ptr(const zval *zobject) {
     return atomic_fetch_object(Z_OBJ_P(zobject))->ptr;
 }
 
+#ifndef HAVE_FUTEX
+static sw_atomic_t *atomic_get_wakeup_count(const zval *zobject) {
+    return atomic_fetch_object(Z_OBJ_P(zobject))->wakeup_count;
+}
+#endif
+
 static void atomic_free_object(zend_object *object) {
     sw_mem_pool()->free((void *) atomic_fetch_object(object)->ptr);
+#ifndef HAVE_FUTEX
+    sw_mem_pool()->free((void *) atomic_fetch_object(object)->wakeup_count);
+#endif
     zend_object_std_dtor(object);
 }
 
@@ -58,6 +70,13 @@ static zend_object *atomic_create_object(zend_class_entry *ce) {
     if (atomic->ptr == nullptr) {
         zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
     }
+
+#ifndef HAVE_FUTEX
+    atomic->wakeup_count = (sw_atomic_t *) sw_mem_pool()->alloc(sizeof(sw_atomic_t));
+    if (atomic->wakeup_count == nullptr) {
+        zend_throw_exception(swoole_exception_ce, "global memory allocation failure", SW_ERROR_MALLOC_FAIL);
+    }
+#endif
 
     return &atomic->std;
 }
@@ -160,7 +179,6 @@ void php_swoole_atomic_minit(int module_number) {
 }
 
 PHP_METHOD(swoole_atomic, __construct) {
-    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     zend_long value = 0;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 1)
@@ -168,7 +186,13 @@ PHP_METHOD(swoole_atomic, __construct) {
     Z_PARAM_LONG(value)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     *atomic = (sw_atomic_t) value;
+
+#ifndef HAVE_FUTEX
+    sw_atomic_t *wakeup_count = atomic_get_wakeup_count(ZEND_THIS);
+    *wakeup_count = (sw_atomic_t) 0;
+#endif
 }
 
 PHP_METHOD(swoole_atomic, add) {
@@ -224,7 +248,6 @@ PHP_METHOD(swoole_atomic, cmpset) {
 }
 
 PHP_METHOD(swoole_atomic, wait) {
-    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     double timeout = 1.0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -232,11 +255,20 @@ PHP_METHOD(swoole_atomic, wait) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (timeout < 0) {
+        timeout = 1.0;
+    }
+
+    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
+#ifdef HAVE_FUTEX
     SW_CHECK_RETURN(sw_atomic_futex_wait(atomic, timeout));
+#else
+    sw_atomic_t *wakeup_count = atomic_get_wakeup_count(ZEND_THIS);
+    SW_CHECK_RETURN(sw_atomic_futex_wait(atomic, timeout, wakeup_count));
+#endif
 }
 
 PHP_METHOD(swoole_atomic, wakeup) {
-    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     zend_long n = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -244,7 +276,17 @@ PHP_METHOD(swoole_atomic, wakeup) {
     Z_PARAM_LONG(n)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (n < 1) {
+        n = 1;
+    }
+
+    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
+#ifdef HAVE_FUTEX
     SW_CHECK_RETURN(sw_atomic_futex_wakeup(atomic, (int) n));
+#else
+    sw_atomic_t *wakeup_count = atomic_get_wakeup_count(ZEND_THIS);
+    SW_CHECK_RETURN(sw_atomic_futex_wakeup(atomic, (int) n, wakeup_count));
+#endif
 }
 
 PHP_METHOD(swoole_atomic_long, __construct) {

--- a/ext-src/swoole_thread_atomic.cc
+++ b/ext-src/swoole_thread_atomic.cc
@@ -31,9 +31,15 @@ static zend_object_handlers swoole_thread_atomic_long_handlers;
 
 struct AtomicResource : ThreadResource {
     sw_atomic_t value;
+#ifndef HAVE_FUTEX
+    sw_atomic_t wakeup_count;
+#endif
 
     explicit AtomicResource(zend_long _value) {
         value = _value;
+#ifndef HAVE_FUTEX
+        wakeup_count = 0;
+#endif
     }
 
     ~AtomicResource() override = default;
@@ -51,6 +57,12 @@ static sw_inline AtomicObject *atomic_fetch_object(zend_object *obj) {
 static sw_atomic_t *atomic_get_ptr(const zval *zobject) {
     return &atomic_fetch_object(Z_OBJ_P(zobject))->atomic->value;
 }
+
+#ifndef HAVE_FUTEX
+static sw_atomic_t *atomic_get_wakeup_count(const zval *zobject) {
+    return &atomic_fetch_object(Z_OBJ_P(zobject))->atomic->wakeup_count;
+}
+#endif
 
 static void atomic_free_object(zend_object *object) {
     AtomicObject *o = atomic_fetch_object(object);
@@ -262,7 +274,6 @@ PHP_METHOD(swoole_thread_atomic, cmpset) {
 }
 
 PHP_METHOD(swoole_thread_atomic, wait) {
-    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     double timeout = 1.0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -270,11 +281,20 @@ PHP_METHOD(swoole_thread_atomic, wait) {
     Z_PARAM_DOUBLE(timeout)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (timeout < 0) {
+        timeout = 1.0;
+    }
+
+    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
+#ifdef HAVE_FUTEX
     SW_CHECK_RETURN(sw_atomic_futex_wait(atomic, timeout));
+#else
+    sw_atomic_t *wakeup_count = atomic_get_wakeup_count(ZEND_THIS);
+    SW_CHECK_RETURN(sw_atomic_futex_wait(atomic, timeout, wakeup_count));
+#endif
 }
 
 PHP_METHOD(swoole_thread_atomic, wakeup) {
-    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
     zend_long n = 1;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -282,7 +302,17 @@ PHP_METHOD(swoole_thread_atomic, wakeup) {
     Z_PARAM_LONG(n)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (n < 1) {
+        n = 1;
+    }
+
+    sw_atomic_t *atomic = atomic_get_ptr(ZEND_THIS);
+#ifdef HAVE_FUTEX
     SW_CHECK_RETURN(sw_atomic_futex_wakeup(atomic, (int) n));
+#else
+    sw_atomic_t *wakeup_count = atomic_get_wakeup_count(ZEND_THIS);
+    SW_CHECK_RETURN(sw_atomic_futex_wakeup(atomic, (int) n, wakeup_count));
+#endif
 }
 
 PHP_METHOD(swoole_thread_atomic_long, __construct) {

--- a/include/swoole_atomic.h
+++ b/include/swoole_atomic.h
@@ -44,5 +44,10 @@ typedef sw_atomic_uint32_t sw_atomic_t;
 
 void sw_spinlock(sw_atomic_t *lock);
 #define sw_spinlock_release(lock) __sync_lock_release(lock)
+#ifdef HAVE_FUTEX
 int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout);
 int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n);
+#else
+int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout, sw_atomic_t *wakeup_count);
+int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n, sw_atomic_t *wakeup_count);
+#endif

--- a/src/core/misc.cc
+++ b/src/core/misc.cc
@@ -71,30 +71,68 @@ int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n) {
     }
 }
 #else
-int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout) {
-    if (sw_atomic_cmp_set(atomic, (sw_atomic_t) 1, (sw_atomic_t) 0)) {
-        return 0;
-    }
+int sw_atomic_futex_wait(sw_atomic_t *atomic, double timeout, sw_atomic_t *wakeup_count) {
     timeout = timeout <= 0 ? INT_MAX : timeout;
-    int32_t i = (int32_t) sw_atomic_sub_fetch(atomic, 1);
+    int32_t value = 0;
+
     while (timeout > 0) {
-        if ((int32_t) *atomic > i) {
+        /**
+         * Why the process holding the resource does not decrement wakeup_count:
+         * Due to the use of a while loop polling mechanism, whenever the lock is released,
+         * there will always be exactly one process that successfully acquires the resource via CAS.
+         * If this successful process were to also participate in decrementing wakeup_count,
+         * it would introduce unnecessary contention with other failed processes operating on the same atomic variable,
+         * potentially resulting in CAS failures and an inconsistent count.
+         *
+         * To avoid this issue, only the processes that fail to acquire the resource are responsible for
+         * decrementing wakeup_count. This design ensures that the total number of woken processes is correctly
+         * and accurately accounted for in every wakeup batch.
+         */
+        if (sw_atomic_cmp_set(atomic, (sw_atomic_t) 1, (sw_atomic_t) 0)) {
             return 0;
-        } else {
+        }
+
+        value = *wakeup_count;
+        if (value == 0) {
             usleep(1000);
             timeout -= 0.001;
+            continue;
+        } else {
+            if (sw_atomic_cmp_set(atomic, (sw_atomic_t) 1, (sw_atomic_t) 0)) {
+                return 0;
+            }
+        }
+
+        while (value) {
+            if (sw_atomic_cmp_set(wakeup_count, (sw_atomic_t) value, (sw_atomic_t)(value - 1))) {
+                return -1;
+            }
+
+            value = *wakeup_count;
         }
     }
-    sw_atomic_fetch_add(atomic, 1);
+
+    swoole_set_last_error(ETIMEDOUT);
     return -1;
 }
 
-int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n) {
+int sw_atomic_futex_wakeup(sw_atomic_t *atomic, int n, sw_atomic_t *wakeup_count) {
     if (1 == (int32_t) *atomic) {
         return 0;
     }
-    sw_atomic_fetch_add(atomic, n);
-    return 0;
+
+    /**
+     * The order here is important: the resource must be released first so that waiting processes can acquire it,
+     * before waking up n-1 processes.
+     */
+    int result = sw_atomic_cmp_set(atomic, (sw_atomic_t) 0, (sw_atomic_t) 1);
+
+    /**
+     * Use wakeup_count to wake up the other processes or threads.
+     * n - 1 is explained in sw_atomic_futex_wait.
+     */
+    *wakeup_count = n - 1;
+    return n;
 }
 #endif
 

--- a/tests/swoole_atomic/timeout.phpt
+++ b/tests/swoole_atomic/timeout.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Swoole\Atomic: Processes with different timeouts
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Process;
+
+const N = 10;
+$atomic = new Atomic(1);
+
+for ($i = 0; $i < N; $i++) {
+    $process = new Process(function() use ($atomic, $i) {
+        $timeout = ($i == 5 || $i == 6) ? 0.8 : 0;
+        $result = $atomic->wait($timeout);
+        if ($result) {
+            sleep(1);
+            echo "process $i lock success" . PHP_EOL;
+            $atomic->wakeup(9);
+        } else {
+            if ($i == 5 || $i == 6) {
+                echo "process $i timeout" . PHP_EOL;
+            } else {
+                echo "process $i lock failed" . PHP_EOL;
+            }
+        }
+    });
+
+    $process->start();
+}
+
+for ($i = 0; $i < N; $i++) {
+    Swoole\Process::wait();
+}
+
+?>
+--EXPECTF--
+process %d timeout
+process %d timeout
+process %d lock success
+process %d lock failed
+process %d lock failed
+process %d lock failed
+process %d lock failed
+process %d lock failed
+process %d lock failed
+process %d lock success

--- a/tests/swoole_thread/atomic_timeout.phpt
+++ b/tests/swoole_thread/atomic_timeout.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Swoole\Thread\Atomic: Threads with different timeouts
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_nts();
+?>
+
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Thread;
+use Swoole\Thread\Atomic;
+
+const N = 10;
+
+$args = Thread::getArguments();
+if (empty($args)) {
+    $threads = [];
+    $atomic = new Atomic(1);
+
+    for ($i = 0; $i < N; $i++) {
+        $threads[] = new Thread(__FILE__, $atomic, $i);
+    }
+
+    foreach ($threads as $thread) {
+        $thread->join();
+    }
+} else {
+    $atomic = $args[0];
+    $i = $args[1];
+
+    $timeout = ($i == 5 || $i == 6) ? 0.8 : 0;
+    $result = $atomic->wait($timeout);
+    if ($result) {
+        sleep(1);
+        echo "thread $i lock success" . PHP_EOL;
+        $atomic->wakeup(9);
+    } else {
+        if ($i == 5 || $i == 6) {
+            echo "thread $i timeout" . PHP_EOL;
+        } else {
+            echo "thread $i lock failed" . PHP_EOL;
+        }
+    }
+}
+
+?>
+--EXPECTF--
+thread %d timeout
+thread %d timeout
+thread %d lock success
+thread %d lock failed
+thread %d lock failed
+thread %d lock failed
+thread %d lock failed
+thread %d lock failed
+thread %d lock failed
+thread %d lock success


### PR DESCRIPTION
In environments without futex support, Swoole\Atomic::wait() and Swoole\Atomic::wakeup() rely on atomic decrement operations on sw_atomic_t to implement the waiting mechanism. This approach introduces a problem: when a waiting process times out and exits prematurely, the sw_atomic_t counter becomes inaccurate. This may cause other processes to acquire the resource before it has actually been released, thereby breaking the correctness of the mutual exclusion guarantee.