### PR TITLE
Fix large multipart upload preprocessing

### DIFF
--- a/include/swoole_http.h
+++ b/include/swoole_http.h
@@ -18,6 +18,7 @@
 #include "swoole_protocol.h"
 
 #include <unordered_map>
+#include <vector>
 
 enum swHttpVersion {
     SW_HTTP_VERSION_10 = 1,
@@ -151,6 +152,7 @@ struct Request {
 
     FormData *form_data_;
     String *buffer_;
+    std::vector<std::string> upload_tmpfile_paths_;
 
     Request() {
         clean();
@@ -160,6 +162,7 @@ struct Request {
     ~Request();
     void clean() {
         memset(&method, 0, offsetof(Request, form_data_));
+        upload_tmpfile_paths_.clear();
     }
     int get_protocol();
     int get_header_length();

--- a/package.xml
+++ b/package.xml
@@ -1710,6 +1710,7 @@
             <file role="test" name="tests/swoole_http_server/upload_file_array_parsed.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_file_empty.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_max_filesize.phpt" />
+            <file role="test" name="tests/swoole_http_server/upload_reserved_header_preprocessor.phpt" />
             <file role="test" name="tests/swoole_http_server/worker_max_concurrency.phpt" />
             <file role="test" name="tests/swoole_http_server/zstd.phpt" />
             <file role="test" name="tests/swoole_http_server_coro/bad_request.phpt" />

--- a/package.xml
+++ b/package.xml
@@ -1709,9 +1709,7 @@
             <file role="test" name="tests/swoole_http_server/upload_file_array_default.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_file_array_parsed.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_file_empty.phpt" />
-            <file role="test" name="tests/swoole_http_server/upload_file_empty_preprocessed.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_max_filesize.phpt" />
-            <file role="test" name="tests/swoole_http_server/upload_reserved_header_preprocessor.phpt" />
             <file role="test" name="tests/swoole_http_server/worker_max_concurrency.phpt" />
             <file role="test" name="tests/swoole_http_server/zstd.phpt" />
             <file role="test" name="tests/swoole_http_server_coro/bad_request.phpt" />

--- a/package.xml
+++ b/package.xml
@@ -1709,6 +1709,7 @@
             <file role="test" name="tests/swoole_http_server/upload_file_array_default.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_file_array_parsed.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_file_empty.phpt" />
+            <file role="test" name="tests/swoole_http_server/upload_file_empty_preprocessed.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_max_filesize.phpt" />
             <file role="test" name="tests/swoole_http_server/upload_reserved_header_preprocessor.phpt" />
             <file role="test" name="tests/swoole_http_server/worker_max_concurrency.phpt" />

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -164,6 +164,14 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
     auto *request = static_cast<Request *>(p->data);
     auto *form_data = request->form_data_;
 
+    if (SW_STRCASEEQ(form_data->current_header_name, form_data->current_header_name_len, SW_HTTP_UPLOAD_FILE)) {
+        swoole_error_log(SW_LOG_WARNING,
+                         SW_ERROR_SERVER_INVALID_REQUEST,
+                         "Bad Request: the reserved header '%s' may not be sent by clients",
+                         SW_HTTP_UPLOAD_FILE);
+        return SW_ERR;
+    }
+
     form_data->multipart_buffer_->append(form_data->current_header_name, form_data->current_header_name_len);
     form_data->multipart_buffer_->append(SW_STRL(": "));
     form_data->multipart_buffer_->append(at, length);

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -182,6 +182,9 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
         ParseCookieCallback cb = [request, form_data, p, &failed](
                                      char *key, size_t key_len, char *value, size_t value_len) {
             if (SW_STRCASEEQ(key, key_len, "filename")) {
+                if (SW_STREQ(value, value_len, "\"\"")) {
+                    return false;
+                }
                 memcpy(form_data->upload_tmpfile->str,
                        form_data->upload_tmpfile_fmt_.c_str(),
                        form_data->upload_tmpfile_fmt_.length());
@@ -196,9 +199,6 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
                 FILE *fp = fdopen(tmpfile, "wb+");
                 if (fp == nullptr) {
                     swoole_sys_warning("fopen(%s) failed", form_data->upload_tmpfile->str);
-                    close(tmpfile);
-                    unlink(form_data->upload_tmpfile->str);
-                    failed = true;
                     return false;
                 }
                 p->fp = fp;

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -169,7 +169,7 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
                          SW_ERROR_SERVER_INVALID_REQUEST,
                          "Bad Request: the reserved header '%s' may not be sent by clients",
                          SW_HTTP_UPLOAD_FILE);
-        return SW_ERR;
+        return MPPE_ERROR;
     }
 
     form_data->multipart_buffer_->append(form_data->current_header_name, form_data->current_header_name_len);
@@ -178,7 +178,9 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
     form_data->multipart_buffer_->append(SW_STRL("\r\n"));
 
     if (SW_STRCASEEQ(form_data->current_header_name, form_data->current_header_name_len, "content-disposition")) {
-        ParseCookieCallback cb = [request, form_data, p](char *key, size_t key_len, char *value, size_t value_len) {
+        bool failed = false;
+        ParseCookieCallback cb = [request, form_data, p, &failed](
+                                     char *key, size_t key_len, char *value, size_t value_len) {
             if (SW_STRCASEEQ(key, key_len, "filename")) {
                 memcpy(form_data->upload_tmpfile->str,
                        form_data->upload_tmpfile_fmt_.c_str(),
@@ -187,22 +189,31 @@ static int multipart_on_header_value(multipart_parser *p, const char *at, size_t
                 form_data->upload_filesize = 0;
                 int tmpfile = swoole_tmpfile(form_data->upload_tmpfile->str);
                 if (tmpfile < 0) {
-                    request->excepted = true;
+                    failed = true;
                     return false;
                 }
 
                 FILE *fp = fdopen(tmpfile, "wb+");
                 if (fp == nullptr) {
                     swoole_sys_warning("fopen(%s) failed", form_data->upload_tmpfile->str);
+                    close(tmpfile);
+                    unlink(form_data->upload_tmpfile->str);
+                    failed = true;
                     return false;
                 }
                 p->fp = fp;
+                request->upload_tmpfile_paths_.emplace_back(form_data->upload_tmpfile->str);
 
                 return false;
             }
             return true;
         };
         parse_cookie(at, length, cb);
+        if (failed) {
+            request->excepted = 1;
+            request->unavailable = 1;
+            return MPPE_PAUSED;
+        }
     }
 
     return 0;
@@ -217,7 +228,7 @@ static int multipart_on_data(multipart_parser *p, const char *at, size_t length)
         if (form_data->multipart_buffer_->length + length > request->max_length_) {
             request->excepted = 1;
             request->unavailable = 1;
-            return 1;
+            return MPPE_PAUSED;
         }
         form_data->multipart_buffer_->append(at, length);
         return 0;
@@ -227,7 +238,7 @@ static int multipart_on_data(multipart_parser *p, const char *at, size_t length)
     if (form_data->upload_filesize > form_data->upload_max_filesize) {
         request->excepted = 1;
         request->too_large = 1;
-        return 1;
+        return MPPE_PAUSED;
     }
 
     ssize_t n = fwrite(at, sizeof(char), length, p->fp);
@@ -237,7 +248,7 @@ static int multipart_on_data(multipart_parser *p, const char *at, size_t length)
         request->excepted = 1;
         request->unavailable = 1;
         swoole_sys_warning("failed to write upload file");
-        return 1;
+        return MPPE_PAUSED;
     }
 
     return 0;
@@ -822,7 +833,6 @@ void Request::destroy_multipart_parser() {
     form_data_->multipart_buffer_ = nullptr;
     if (form_data_->multipart_parser_->fp) {
         fclose(form_data_->multipart_parser_->fp);
-        unlink(form_data_->upload_tmpfile->str);
     }
     multipart_parser_free(form_data_->multipart_parser_);
     form_data_->multipart_parser_ = nullptr;
@@ -860,6 +870,9 @@ bool Request::parse_multipart_data(String *buffer) {
 Request::~Request() {
     if (form_data_) {
         destroy_multipart_parser();
+    }
+    for (const auto &tmpfile : upload_tmpfile_paths_) {
+        unlink(tmpfile.c_str());
     }
 }
 

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -718,10 +718,14 @@ _parse:
     dispatch_data.data = buffer->str;
     dispatch_data.info.len = buffer->length;
 
+    // dispatch_request() may run the worker inline in BASE mode and destroy request.
+    auto upload_tmpfile_paths = std::move(request->upload_tmpfile_paths_);
     if (http_server::dispatch_request(serv, protocol, _socket, &dispatch_data) < 0) {
+        for (const auto &tmpfile : upload_tmpfile_paths) {
+            unlink(tmpfile.c_str());
+        }
         goto _close_fd;
     }
-    request->upload_tmpfile_paths_.clear();
 
     if (conn->active && !_socket->removed) {
         port->destroy_http_request(conn);

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -566,7 +566,12 @@ _parse:
         if (request->form_data_) {
             if (serv->upload_max_filesize > 0 &&
                 request->header_length_ + request->content_length_ > request->max_length_) {
-                request->init_multipart_parser(serv);
+                if (!request->init_multipart_parser(serv)) {
+                    // destroy_multipart_parser() requires a fully initialized FormData.
+                    delete request->form_data_;
+                    request->form_data_ = nullptr;
+                    goto _bad_request;
+                }
 
                 buffer = request->buffer_;
             } else {
@@ -716,6 +721,7 @@ _parse:
     if (http_server::dispatch_request(serv, protocol, _socket, &dispatch_data) < 0) {
         goto _close_fd;
     }
+    request->upload_tmpfile_paths_.clear();
 
     if (conn->active && !_socket->removed) {
         port->destroy_http_request(conn);

--- a/tests/swoole_http_server/upload_file_empty_preprocessed.phpt
+++ b/tests/swoole_http_server/upload_file_empty_preprocessed.phpt
@@ -1,0 +1,72 @@
+--TEST--
+swoole_http_server: preserve empty uploads during preprocessing
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    $boundary = '------------------------d3f990cdce762596';
+    $content = str_repeat('A', 80 * 1024);
+    $body = implode("\r\n", [
+        "--$boundary",
+        'Content-Disposition: form-data; name="large"; filename="large.txt"',
+        'Content-Type: text/plain',
+        '',
+        $content,
+        "--$boundary",
+        'Content-Disposition: form-data; name="empty"; filename=""',
+        'Content-Type: application/octet-stream',
+        '',
+        '',
+        "--$boundary--",
+        '',
+    ]);
+    $request = implode("\r\n", [
+        'POST / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Connection: close',
+        "Content-Type: multipart/form-data; boundary=$boundary",
+        'Content-Length: ' . strlen($body),
+        '',
+        $body,
+    ]);
+
+    $socket = stream_socket_client("tcp://127.0.0.1:{$pm->getFreePort()}");
+    fwrite($socket, $request);
+    $response = stream_get_contents($socket);
+    fclose($socket);
+    [, $responseBody] = explode("\r\n\r\n", $response, 2);
+    $files = json_decode($responseBody, true);
+
+    Assert::same($files['large']['error'], UPLOAD_ERR_OK);
+    Assert::same($files['large']['size'], strlen($content));
+    Assert::same($files['empty']['error'], UPLOAD_ERR_NO_FILE);
+    Assert::same($files['empty']['tmp_name'], '');
+
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $server->set([
+        'log_file' => '/dev/null',
+        'package_max_length' => 64 * 1024,
+        'upload_max_filesize' => 1024 * 1024,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $response->end(json_encode($request->files));
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--

--- a/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
+++ b/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
@@ -1,0 +1,118 @@
+--TEST--
+swoole_http_server: reject upload reserved header during preprocessing
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+function build_request(string $boundary, string $body): string
+{
+    return implode("\r\n", [
+        'POST / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Connection: close',
+        'Content-Type: multipart/form-data; boundary=' . $boundary,
+        'Content-Length: ' . strlen($body),
+        '',
+        $body,
+    ]);
+}
+
+function send_request(ProcessManager $pm, string $request): string
+{
+    $socket = stream_socket_client("tcp://127.0.0.1:{$pm->getFreePort()}");
+    @fwrite($socket, $request);
+    $response = stream_get_contents($socket);
+    fclose($socket);
+
+    return $response;
+}
+
+$probes = [
+    tempnam(sys_get_temp_dir(), 'swoole-upload-probe-'),
+    tempnam(sys_get_temp_dir(), 'swoole-upload-probe-'),
+];
+$handlerMarker = tempnam(sys_get_temp_dir(), 'swoole-upload-handler-');
+$uploadDir = sys_get_temp_dir() . '/swoole-upload-' . getmypid();
+file_put_contents($probes[0], 'probe');
+file_put_contents($probes[1], 'probe');
+unlink($handlerMarker);
+mkdir_if_not_exists($uploadDir);
+
+$boundary = '------------------------d3f990cdce762596';
+$earlyBody = implode("\r\n", [
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="file"; filename="test.txt"',
+    'Swoole-Upload-File: ' . $probes[0],
+    'Content-Type: text/plain',
+    '',
+    str_repeat('A', 80 * 1024),
+    '--' . $boundary . '--',
+    '',
+]);
+$lateBody = implode("\r\n", [
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="file"; filename="test.txt"',
+    'Content-Type: text/plain',
+    '',
+    str_repeat('B', 80 * 1024),
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="field"',
+    'Swoole-Upload-File: ' . $probes[1],
+    '',
+    'value',
+    '--' . $boundary . '--',
+    '',
+]);
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm, $boundary, $earlyBody, $lateBody, $probes, $handlerMarker, $uploadDir) {
+    $response = send_request($pm, build_request($boundary, $earlyBody));
+    Assert::contains($response, '400 Bad Request');
+
+    $response = send_request($pm, build_request($boundary, $lateBody));
+    Assert::contains($response, '400 Bad Request');
+    Assert::false(file_exists($handlerMarker));
+    Assert::true(file_exists($probes[0]));
+    Assert::true(file_exists($probes[1]));
+
+    foreach (glob($uploadDir . '/swoole.upfile.*') as $file) {
+        unlink($file);
+    }
+    rmdir($uploadDir);
+    unlink($probes[0]);
+    unlink($probes[1]);
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm, $probes, $handlerMarker, $uploadDir) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $http->set([
+        'log_file' => '/dev/null',
+        'worker_num' => 1,
+        'package_max_length' => 64 * 1024,
+        'upload_max_filesize' => 1024 * 1024,
+        'upload_tmp_dir' => $uploadDir,
+    ]);
+    $http->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('Request', function (Request $request, Response $response) use ($probes, $handlerMarker) {
+        foreach ($probes as $probe) {
+            if (is_uploaded_file($probe)) {
+                file_put_contents($handlerMarker, 'uploaded');
+                break;
+            }
+        }
+        $response->end('UNEXPECTED');
+    });
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--

--- a/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
+++ b/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
@@ -175,6 +175,12 @@ $pm->parentFunc = function () use (
     ), 1);
     Assert::greaterThan((int) $match[1], strlen($tooLargeBody));
 
+    $response = send_request($pm, build_request($boundary, $fileBody));
+    Assert::contains($response, md5(str_repeat('D', 80 * 1024)));
+    $response = send_request($pm, $getRequest);
+    Assert::contains($response, 'UNEXPECTED');
+    Assert::same(glob($uploadDir . '/swoole.upfile.*'), []);
+
     Assert::true(rmdir($uploadDir));
     $response = send_request($pm, build_request($boundary, $fileBody));
     Assert::contains($response, '503 Service Unavailable');
@@ -202,6 +208,11 @@ $pm->childFunc = function () use ($pm, $probes, $handlerMarker, $uploadDir, $log
         $pm->wakeup();
     });
     $http->on('Request', function (Request $request, Response $response) use ($probes, $handlerMarker) {
+        $file = $request->files['file'] ?? null;
+        if (is_array($file)) {
+            $response->end(md5_file($file['tmp_name']));
+            return;
+        }
         foreach ($probes as $probe) {
             if (is_uploaded_file($probe)) {
                 file_put_contents($handlerMarker, 'uploaded');

--- a/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
+++ b/tests/swoole_http_server/upload_reserved_header_preprocessor.phpt
@@ -32,15 +32,32 @@ function send_request(ProcessManager $pm, string $request): string
     return $response;
 }
 
+// Send the HTTP headers first so the multipart header block can be read without fragmentation.
+function send_split_request(ProcessManager $pm, string $boundary, string $body): string
+{
+    $request = build_request($boundary, $body);
+    $headerLength = strpos($request, "\r\n\r\n") + 4;
+    $socket = stream_socket_client("tcp://127.0.0.1:{$pm->getFreePort()}");
+    fwrite($socket, substr($request, 0, $headerLength));
+    usleep(10000);
+    fwrite($socket, substr($request, $headerLength));
+    $response = stream_get_contents($socket);
+    fclose($socket);
+
+    return $response;
+}
+
 $probes = [
     tempnam(sys_get_temp_dir(), 'swoole-upload-probe-'),
     tempnam(sys_get_temp_dir(), 'swoole-upload-probe-'),
 ];
 $handlerMarker = tempnam(sys_get_temp_dir(), 'swoole-upload-handler-');
+$logFile = tempnam(sys_get_temp_dir(), 'swoole-upload-log-');
 $uploadDir = sys_get_temp_dir() . '/swoole-upload-' . getmypid();
 file_put_contents($probes[0], 'probe');
 file_put_contents($probes[1], 'probe');
 unlink($handlerMarker);
+unlink($logFile);
 mkdir_if_not_exists($uploadDir);
 
 $boundary = '------------------------d3f990cdce762596';
@@ -68,30 +85,114 @@ $lateBody = implode("\r\n", [
     '--' . $boundary . '--',
     '',
 ]);
+$beforeFileBody = implode("\r\n", [
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="field"',
+    'Swoole-Upload-File: ' . $probes[0],
+    '',
+    'value',
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="file"; filename="test.txt"',
+    'Content-Type: text/plain',
+    '',
+    str_repeat('C', 80 * 1024),
+    '--' . $boundary . '--',
+    '',
+]);
+$fileBody = implode("\r\n", [
+    '--' . $boundary,
+    'Content-Disposition: form-data; name="file"; filename="test.txt"',
+    'Content-Type: text/plain',
+    '',
+    str_repeat('D', 80 * 1024),
+    '--' . $boundary . '--',
+    '',
+]);
+$tooLargeBody = '';
+// Keep the client body below the package limit; generated file markers make the rebuilt body exceed it.
+for ($i = 0; $i < 455; $i++) {
+    $tooLargeBody .= implode("\r\n", [
+        '--' . $boundary,
+        'Content-Disposition: form-data; name="file' . $i . '"; filename="test.txt"',
+        'Content-Type: text/plain',
+        '',
+        'x',
+    ]) . "\r\n";
+}
+$tooLargeBody .= '--' . $boundary . "--\r\n";
+$malformedRequest = implode("\r\n", [
+    'POST / HTTP/1.1',
+    'Host: 127.0.0.1',
+    'Connection: close',
+    'Content-Type: multipart/form-data',
+    'Content-Length: ' . (80 * 1024),
+    '',
+    str_repeat('x', 80 * 1024),
+]);
+$getRequest = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
 
 $pm = new ProcessManager;
-$pm->parentFunc = function () use ($pm, $boundary, $earlyBody, $lateBody, $probes, $handlerMarker, $uploadDir) {
+$pm->parentFunc = function () use (
+    $pm,
+    $boundary,
+    $earlyBody,
+    $lateBody,
+    $beforeFileBody,
+    $fileBody,
+    $tooLargeBody,
+    $malformedRequest,
+    $getRequest,
+    $probes,
+    $handlerMarker,
+    $uploadDir,
+    $logFile
+) {
+    $response = send_request($pm, $malformedRequest);
+    Assert::contains($response, '400 Bad Request');
+    $response = send_request($pm, $getRequest);
+    Assert::contains($response, 'UNEXPECTED');
+
     $response = send_request($pm, build_request($boundary, $earlyBody));
     Assert::contains($response, '400 Bad Request');
+    Assert::same(glob($uploadDir . '/swoole.upfile.*'), []);
 
     $response = send_request($pm, build_request($boundary, $lateBody));
     Assert::contains($response, '400 Bad Request');
+    Assert::same(glob($uploadDir . '/swoole.upfile.*'), []);
+
+    $response = send_request($pm, build_request($boundary, $beforeFileBody));
+    Assert::contains($response, '400 Bad Request');
+    Assert::same(glob($uploadDir . '/swoole.upfile.*'), []);
+
+    $response = send_split_request($pm, $boundary, $tooLargeBody);
+    Assert::contains($response, '413 Request Entity Too Large');
+    Assert::same(glob($uploadDir . '/swoole.upfile.*'), []);
+    $log = file_get_contents($logFile);
+    Assert::same(preg_match(
+        '/Request Entity Too Large: header-length \(\d+\) \+ content-length \((\d+)\)/',
+        $log,
+        $match
+    ), 1);
+    Assert::greaterThan((int) $match[1], strlen($tooLargeBody));
+
+    Assert::true(rmdir($uploadDir));
+    $response = send_request($pm, build_request($boundary, $fileBody));
+    Assert::contains($response, '503 Service Unavailable');
+
     Assert::false(file_exists($handlerMarker));
     Assert::true(file_exists($probes[0]));
     Assert::true(file_exists($probes[1]));
+    Assert::contains($log, "reserved header 'Swoole-Upload-File'");
 
-    foreach (glob($uploadDir . '/swoole.upfile.*') as $file) {
-        unlink($file);
-    }
-    rmdir($uploadDir);
     unlink($probes[0]);
     unlink($probes[1]);
+    unlink($logFile);
     $pm->kill();
 };
-$pm->childFunc = function () use ($pm, $probes, $handlerMarker, $uploadDir) {
+$pm->childFunc = function () use ($pm, $probes, $handlerMarker, $uploadDir, $logFile) {
     $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
     $http->set([
-        'log_file' => '/dev/null',
+        'log_file' => $logFile,
         'worker_num' => 1,
         'package_max_length' => 64 * 1024,
         'upload_max_filesize' => 1024 * 1024,


### PR DESCRIPTION
The large-upload preprocessor writes file parts to temporary files before dispatch. A client-supplied `Swoole-Upload-File` header was accepted, and failures before dispatch could leave generated files behind or continue with incomplete upload state.

Reject client-supplied marker headers. Keep temporary files owned by the reactor until dispatch, hand their ownership to the worker before the dispatch call, and remove them when a request is rejected. Reject malformed boundaries, and report temporary-file creation failures as unavailable. Keep an empty file input as `UPLOAD_ERR_NO_FILE` when another file triggers preprocessing.

Tests cover marker ordering, malformed boundaries, rebuilt-body limits, temporary-file failures, empty file inputs, successful dispatch, worker survival, and cleanup.
