### PR TITLE
Fix coroutine socket option validation

### DIFF
--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -2023,7 +2023,7 @@ static PHP_METHOD(swoole_socket_coro, setOption) {
         if (Z_TYPE_P(optval) != IS_ARRAY) {
             if (UNEXPECTED(Z_TYPE_P(optval) != IS_OBJECT)) {
                 zend_argument_type_error(optval_arg_index,
-                                         "must be of type array when argument $option is SO_LINGER, %s given",
+                                         "must be of type array|object when argument $opt_name is SO_LINGER, %s given",
                                          zend_zval_value_name(optval));
                 RETURN_THROWS();
             } else {
@@ -2052,7 +2052,7 @@ static PHP_METHOD(swoole_socket_coro, setOption) {
         }
 
         if (val_linger < 0 || val_linger > USHRT_MAX) {
-            zend_argument_value_error(optval_arg_index, "\"%s\" must be between 0 and %d", l_linger, USHRT_MAX);
+            zend_argument_value_error(optval_arg_index, "\"%s\" must be between 0 and %u", l_linger_key, USHRT_MAX);
             RETURN_THROWS();
         }
 
@@ -2073,7 +2073,7 @@ static PHP_METHOD(swoole_socket_coro, setOption) {
         if (Z_TYPE_P(optval) != IS_ARRAY) {
             if (UNEXPECTED(Z_TYPE_P(optval) != IS_OBJECT)) {
                 zend_argument_type_error(optval_arg_index,
-                                         "must be of type array when argument $option is %s, %s given",
+                                         "must be of type array|object when argument $opt_name is %s, %s given",
                                          optname == SO_RCVTIMEO ? "SO_RCVTIMEO" : "SO_SNDTIMEO",
                                          zend_zval_value_name(optval));
                 RETURN_THROWS();
@@ -2083,8 +2083,6 @@ static PHP_METHOD(swoole_socket_coro, setOption) {
         } else {
             opt_ht = Z_ARRVAL_P(optval);
         }
-
-        opt_ht = Z_ARRVAL_P(optval);
 
         if ((sec = zend_hash_str_find(opt_ht, sec_key, sizeof(sec_key) - 1)) == nullptr) {
             php_error_docref(nullptr, E_WARNING, "no key \"%s\" passed in optval", sec_key);

--- a/tests/swoole_socket_coro/setopt/linger.phpt
+++ b/tests/swoole_socket_coro/setopt/linger.phpt
@@ -1,0 +1,42 @@
+--TEST--
+swoole_socket_coro/setopt: setOption SO_LINGER
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+$socket = new Co\Socket(AF_INET, SOCK_STREAM, SOL_TCP);
+
+Assert::true($socket->setOption(SOL_SOCKET, SO_LINGER, ['l_onoff' => 1, 'l_linger' => 5]));
+Assert::true($socket->setOption(SOL_SOCKET, SO_LINGER, (object) ['l_onoff' => 1, 'l_linger' => 5]));
+
+try {
+    $socket->setOption(SOL_SOCKET, SO_LINGER, 1);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $socket->setOption(SOL_SOCKET, SO_LINGER, ['l_onoff' => 65536, 'l_linger' => 0]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $socket->setOption(SOL_SOCKET, SO_LINGER, ['l_onoff' => 1, 'l_linger' => 65536]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $socket->setOption(SOL_SOCKET, SO_LINGER, ['l_onoff' => 1, 'l_linger' => -1]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) must be of type array|object when argument $opt_name is SO_LINGER, int given
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) "l_onoff" must be between 0 and 65535
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) "l_linger" must be between 0 and 65535
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) "l_linger" must be between 0 and 65535

--- a/tests/swoole_socket_coro/setopt/recvtimeo.phpt
+++ b/tests/swoole_socket_coro/setopt/recvtimeo.phpt
@@ -1,8 +1,8 @@
 --TEST--
-swoole_socket_coro/setopt: setOption SO_RCVTIMEO
+swoole_socket_coro/setopt: setOption SO_RCVTIMEO / SO_SNDTIMEO
 --DESCRIPTION--
--wrong params
--set/get params comparison
+-invalid params
+-array/object params
 --SKIPIF--
 <?php require __DIR__ . '/../../include/skipif.inc'; ?>
 --FILE--
@@ -11,13 +11,29 @@ require __DIR__ . '/../../include/bootstrap.php';
 
 $socket = new Co\Socket(AF_INET, SOCK_STREAM, SOL_TCP);
 
-//wrong params
+try {
+    $socket->setOption(SOL_SOCKET, SO_RCVTIMEO, 1);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $socket->setOption(SOL_SOCKET, SO_SNDTIMEO, 1);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 $retval_1 = $socket->setOption(SOL_SOCKET, SO_RCVTIMEO, array());
-Assert::assert($retval_1 === false);
+Assert::false($retval_1);
 $options = array("sec" => 1, "usec" => 0);
 $retval_2 = $socket->setOption(SOL_SOCKET, SO_RCVTIMEO, $options);
-Assert::assert($retval_2 === true);
+Assert::true($retval_2);
+Assert::true($socket->setOption(SOL_SOCKET, SO_RCVTIMEO, (object) $options));
+Assert::true($socket->setOption(SOL_SOCKET, SO_SNDTIMEO, (object) $options));
 
 ?>
 --EXPECTF--
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) must be of type array|object when argument $opt_name is SO_RCVTIMEO, int given
+Swoole\Coroutine\Socket::setOption(): Argument #3 ($opt_value) must be of type array|object when argument $opt_name is SO_SNDTIMEO, int given
+
 Warning: Swoole\Coroutine\Socket::setOption(): no key "sec" passed in optval in %s on line %d


### PR DESCRIPTION
`Swoole\Coroutine\Socket::setOption()` uses the linger option value as text when reporting an invalid `l_linger`. Object values for receive and send timeouts are also treated as arrays, which can crash the process.

This reports the correct field and accepted input types, reads object timeout values correctly, and adds focused regression tests. The linger fix matches [php-src's correction to the same code](https://github.com/php/php-src/commit/3882f55a6).

Master has the same bugs. I can send a companion PR if useful.
