### PR TITLE
Fix truncated ProcessPool stream packets

### DIFF
--- a/core-tests/src/network/stream.cpp
+++ b/core-tests/src/network/stream.cpp
@@ -18,11 +18,41 @@
 */
 
 #include "test_core.h"
+#include "swoole_pipe.h"
 #include "swoole_server.h"
 
 using namespace std;
 using namespace swoole;
 using namespace swoole::network;
+
+TEST(stream, recv_sync_rejects_truncated_packet) {
+    char buffer[2048];
+
+    {
+        UnixSocket sockets(true, SOCK_STREAM);
+        ASSERT_TRUE(sockets.ready());
+
+        uint32_t packet_len = htonl(sizeof(buffer));
+        auto *sender = sockets.get_socket(true);
+        ASSERT_EQ(sender->send_sync(&packet_len, sizeof(packet_len) - 1), static_cast<ssize_t>(sizeof(packet_len) - 1));
+        ASSERT_EQ(sender->shutdown(SHUT_WR), 0);
+
+        EXPECT_EQ(Stream::recv_sync(sockets.get_socket(false), buffer, sizeof(buffer)), SW_ERR);
+    }
+
+    {
+        UnixSocket sockets(true, SOCK_STREAM);
+        ASSERT_TRUE(sockets.ready());
+
+        uint32_t packet_len = htonl(8);
+        auto *sender = sockets.get_socket(true);
+        ASSERT_EQ(sender->send_sync(&packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+        ASSERT_EQ(sender->send_sync(SW_STRL("ab")), 2);
+        ASSERT_EQ(sender->shutdown(SHUT_WR), 0);
+
+        EXPECT_EQ(Stream::recv_sync(sockets.get_socket(false), buffer, sizeof(buffer)), SW_ERR);
+    }
+}
 
 TEST(stream, send) {
     Server serv(Server::MODE_BASE);

--- a/core-tests/src/os/process_pool.cpp
+++ b/core-tests/src/os/process_pool.cpp
@@ -10,6 +10,8 @@
 #include "swoole_signal.h"
 #include <sys/ipc.h>
 #include <sys/msg.h>
+#include <string>
+#include <vector>
 using namespace swoole;
 
 constexpr int magic_number = 99900011;
@@ -558,6 +560,112 @@ TEST(process_pool, listen) {
     sysv_signal(SIGTERM, SIG_DFL);
 
     t1.join();
+}
+
+TEST(process_pool, listen_rejects_truncated_stream_packet) {
+    ProcessPool pool{};
+    auto port = swoole::test::get_random_port();
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen("127.0.0.1", port, 128), SW_OK);
+
+    pool.set_max_packet_size(64);
+    pool.set_protocol(SW_PROTOCOL_STREAM);
+
+    std::vector<std::string> messages;
+    pool.ptr = &messages;
+    pool.onMessage = [](ProcessPool *pool, RecvData *msg) {
+        auto *messages = static_cast<std::vector<std::string> *>(pool->ptr);
+        messages->emplace_back(msg->data, msg->info.len);
+        if (messages->back() == "sentinel") {
+            pool->running = false;
+        }
+    };
+
+    network::SyncClient c1(SW_SOCK_TCP);
+    network::SyncClient c2(SW_SOCK_TCP);
+    network::SyncClient c3(SW_SOCK_TCP);
+    ASSERT_TRUE(c1.connect("127.0.0.1", port));
+    ASSERT_TRUE(c2.connect("127.0.0.1", port));
+    ASSERT_TRUE(c3.connect("127.0.0.1", port));
+
+    uint32_t packet_len = htonl(8);
+    ASSERT_EQ(c1.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c1.send(SW_STRL("message1")), 8);
+    ASSERT_EQ(c2.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c2.send(SW_STRL("xx")), 2);
+    ASSERT_EQ(c2.get_client()->shutdown(SHUT_WR), SW_OK);
+    ASSERT_EQ(c3.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c3.send(SW_STRL("sentinel")), 8);
+
+    auto *worker = pool.get_worker(0);
+    worker->init();
+    pool.running = true;
+    pool.main_loop(&pool, worker);
+    pool.destroy();
+
+    ASSERT_EQ(messages.size(), 2);
+    EXPECT_EQ(messages[0], "message1");
+    EXPECT_EQ(messages[1], "sentinel");
+}
+
+TEST(process_pool, listen_rejects_truncated_task_packet) {
+    ProcessPool pool{};
+    auto port = swoole::test::get_random_port();
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen("127.0.0.1", port, 128), SW_OK);
+    pool.set_protocol(SW_PROTOCOL_TASK);
+
+    std::vector<std::string> messages;
+    pool.ptr = &messages;
+    pool.onTask = [](ProcessPool *pool, Worker *worker, EventData *task) -> int {
+        auto *messages = static_cast<std::vector<std::string> *>(pool->ptr);
+        messages->emplace_back(task->data, task->info.len);
+        if (messages->back() == "sentinel") {
+            pool->running = false;
+        }
+        return SW_OK;
+    };
+
+    EventData event1{};
+    EventData event2{};
+    EventData event3{};
+    event1.info.len = 8;
+    event2.info.len = 8;
+    event3.info.len = 8;
+    memcpy(event1.data, SW_STRL("message1"));
+    memcpy(event2.data, SW_STRL("xx"));
+    memcpy(event3.data, SW_STRL("sentinel"));
+
+    network::SyncClient c1(SW_SOCK_TCP);
+    network::SyncClient c2(SW_SOCK_TCP);
+    network::SyncClient c3(SW_SOCK_TCP);
+    ASSERT_TRUE(c1.connect("127.0.0.1", port));
+    ASSERT_TRUE(c2.connect("127.0.0.1", port));
+    ASSERT_TRUE(c3.connect("127.0.0.1", port));
+
+    uint32_t packet_len = htonl(event1.size());
+    ASSERT_EQ(c1.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c1.send(reinterpret_cast<char *>(&event1), event1.size()), event1.size());
+
+    packet_len = htonl(event2.size());
+    ASSERT_EQ(c2.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c2.send(reinterpret_cast<char *>(&event2), sizeof(event2.info) + 2),
+              static_cast<ssize_t>(sizeof(event2.info) + 2));
+    ASSERT_EQ(c2.get_client()->shutdown(SHUT_WR), SW_OK);
+
+    packet_len = htonl(event3.size());
+    ASSERT_EQ(c3.send((char *) &packet_len, sizeof(packet_len)), static_cast<ssize_t>(sizeof(packet_len)));
+    ASSERT_EQ(c3.send(reinterpret_cast<char *>(&event3), event3.size()), event3.size());
+
+    auto *worker = pool.get_worker(0);
+    worker->init();
+    pool.running = true;
+    pool.main_loop(&pool, worker);
+    pool.destroy();
+
+    ASSERT_EQ(messages.size(), 2);
+    EXPECT_EQ(messages[0], "message1");
+    EXPECT_EQ(messages[1], "sentinel");
 }
 
 const char *test_sock = "/tmp/swoole_process_pool.sock";

--- a/src/network/stream.cc
+++ b/src/network/stream.cc
@@ -136,14 +136,15 @@ int Stream::send(const char *data, size_t length) {
 ssize_t Stream::recv_sync(Socket *sock, void *_buf, size_t _len) {
     int tmp = 0;
     ssize_t ret = sock->recv_sync(&tmp, sizeof(tmp), MSG_WAITALL);
-    if (ret <= 0) {
+    if (ret != static_cast<ssize_t>(sizeof(tmp))) {
         return SW_ERR;
     }
     const int length = static_cast<int>(ntohl(tmp));
     if (length <= 0 || length > static_cast<int>(_len)) {
         return SW_ERR;
     }
-    return sock->recv_sync(_buf, length, MSG_WAITALL);
+    ret = sock->recv_sync(_buf, length, MSG_WAITALL);
+    return ret == static_cast<ssize_t>(length) ? ret : SW_ERR;
 }
 
 }  // namespace network

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -706,7 +706,7 @@ int ProcessPool::run_with_stream_protocol(ProcessPool *pool, Worker *worker) {
                 }
             }
             uint32_t packet_len = 0;
-            if (conn->recv_sync(&packet_len, sizeof(packet_len), MSG_WAITALL) <= 0) {
+            if (conn->recv_sync(&packet_len, sizeof(packet_len), MSG_WAITALL) != (ssize_t) sizeof(packet_len)) {
                 goto _close;
             }
             n = ntohl(packet_len);
@@ -719,7 +719,7 @@ int ProcessPool::run_with_stream_protocol(ProcessPool *pool, Worker *worker) {
             } else if (n > pool->max_packet_size_) {
                 goto _close;
             }
-            if (conn->recv_sync(pool->packet_buffer, n, MSG_WAITALL) <= 0) {
+            if (conn->recv_sync(pool->packet_buffer, n, MSG_WAITALL) != n) {
             _close:
                 conn->free();
                 goto _end;


### PR DESCRIPTION
ProcessPool stream handling accepted short reads if the peer closed after sending only part of a packet. That could pass stale bytes from the reused packet buffer to the message callback.

This requires complete reads for the length prefix and packet body. It also adds focused coverage for the shared Stream helper and the ProcessPool TCP listener paths.

The new tests fail on the unchanged 6.1 branch and pass with this fix.