### PR TITLE
Fix persistent client pooling decisions

### DIFF
--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -1096,9 +1096,10 @@ static PHP_METHOD(swoole_client, close) {
         php_swoole_error(E_WARNING, "client socket is closed");
         RETURN_FALSE;
     }
-    // Connection error, or short tcp connection.
-    // No keep connection
-    if (force || !cli->keep || cli->socket->catch_error(swoole_get_last_error()) == SW_CLOSE) {
+    // Connection error, short tcp connection, or a socket that was shut down.
+    // A half-closed socket cannot be reused, so it must not enter the connection pool.
+    if (force || !cli->keep || cli->shutdown_read || cli->shutdown_write ||
+        cli->socket->catch_error(swoole_get_last_error()) == SW_CLOSE) {
         ret = cli->close();
         php_swoole_client_free(ZEND_THIS, cli);
     } else {

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -1096,10 +1096,9 @@ static PHP_METHOD(swoole_client, close) {
         php_swoole_error(E_WARNING, "client socket is closed");
         RETURN_FALSE;
     }
-    // Connection error, short tcp connection, or a socket that was shut down.
     // A half-closed socket cannot be reused, so it must not enter the connection pool.
-    if (force || !cli->keep || cli->shutdown_read || cli->shutdown_write ||
-        cli->socket->catch_error(swoole_get_last_error()) == SW_CLOSE) {
+    // Dead sockets are rejected when a pooled client is retrieved.
+    if (force || !cli->keep || cli->shutdown_read || cli->shutdown_write) {
         ret = cli->close();
         php_swoole_client_free(ZEND_THIS, cli);
     } else {

--- a/tests/swoole_client_sync/keep3.phpt
+++ b/tests/swoole_client_sync/keep3.phpt
@@ -19,6 +19,7 @@ $pm->parentFunc = function () use ($pm) {
     $client2 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
     $r = $client2->connect(TCP_SERVER_HOST, $pm->getFreePort(), 0.5);
     Assert::true($r);
+    Assert::true($client2->reuse);
     $client2->send("hello");
     echo $client2->recv();
     $client2->close();

--- a/tests/swoole_client_sync/keep3.phpt
+++ b/tests/swoole_client_sync/keep3.phpt
@@ -7,6 +7,7 @@ swoole_client_sync: long connection[3]
 require __DIR__ . '/../include/bootstrap.php';
 
 $pm = new ProcessManager;
+$pm->initFreePorts(2);
 
 $pm->parentFunc = function () use ($pm) {
     $client1 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
@@ -14,6 +15,11 @@ $pm->parentFunc = function () use ($pm) {
     Assert::true($r);
     $client1->send("hello");
     echo $client1->recv();
+
+    $failedClient = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_SYNC);
+    Assert::false(@$failedClient->connect(TCP_SERVER_HOST, $pm->getFreePort(1), 0.5));
+    Assert::same(swoole_last_error(), SOCKET_ECONNREFUSED);
+
     $client1->close();
 
     $client2 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);

--- a/tests/swoole_client_sync/keep_shutdown.phpt
+++ b/tests/swoole_client_sync/keep_shutdown.phpt
@@ -1,0 +1,38 @@
+--TEST--
+swoole_client_sync: a persistent connection that was shut down is not reused
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+// Nothing accepts this listener, so the peer cannot close the connection and send a FIN.
+// The client socket stays connected and only its own shutdown state can make it unfit for reuse.
+$server = stream_socket_server('tcp://' . TCP_SERVER_HOST . ':0', $errno, $errstr);
+Assert::assert($server !== false, "$errstr ($errno)");
+$port = (int) explode(':', stream_socket_get_name($server, false))[1];
+
+// An ordinary persistent connection is still pooled and handed back.
+$client1 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
+Assert::true($client1->connect(TCP_SERVER_HOST, $port, 0.5));
+Assert::true($client1->close());
+
+$client2 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
+Assert::true($client2->connect(TCP_SERVER_HOST, $port, 0.5));
+Assert::true($client2->reuse);
+$client2->close(true);
+
+// A connection that was shut down is not.
+$client3 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
+Assert::true($client3->connect(TCP_SERVER_HOST, $port, 0.5));
+Assert::true($client3->shutdown(Swoole\Client::SHUT_WR));
+Assert::true($client3->close());
+
+$client4 = new Swoole\Client(SWOOLE_SOCK_TCP | SWOOLE_KEEP | SWOOLE_SYNC);
+Assert::true($client4->connect(TCP_SERVER_HOST, $port, 0.5));
+Assert::false($client4->reuse);
+
+$client4->close(true);
+fclose($server);
+?>
+--EXPECT--


### PR DESCRIPTION
Persistent `Swoole\Client` connections could be pooled after shutdown. A write-shutdown socket can pass the read-side liveness check even though it can no longer send, while a read-shutdown socket can remain pooled holding its descriptor.

A healthy persistent connection could also be discarded when an unrelated operation left an error in the thread-global last-error state. That value does not describe the client being closed. A client whose own connection attempt fails is freed before reaching the pool. Dead pooled sockets are already rejected by the existing liveness check when retrieved.

This closes shutdown clients instead of pooling them and removes the unrelated global error check.

The regressions cover ordinary reuse, read and write shutdown, an unrelated connection error before close, and rejection of dead pooled sockets.