### PR TITLE
Fix client: preserve SOCKS5 response boundaries

### DIFF
--- a/core-tests/src/protocol/base.cpp
+++ b/core-tests/src/protocol/base.cpp
@@ -262,6 +262,166 @@ TEST(protocol, socks5_dns_tunnel_target_host_length) {
     delete proxy;
 }
 
+TEST(protocol, socks5_fragmented_no_auth_response) {
+    auto proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(proxy, nullptr);
+    proxy->target_host = "socks5-target.test";
+    proxy->target_port = 80;
+
+    ASSERT_EQ(proxy->pack_negotiate_request(), 3);
+    ASSERT_MEMEQ(proxy->buf, "\x05\x01\x00", 3);
+    proxy->state = SW_SOCKS5_STATE_HANDSHAKE;
+
+    std::vector<std::string> requests;
+    auto send_fn = [&requests](const char *buf, size_t len) {
+        requests.emplace_back(buf, len);
+        return static_cast<ssize_t>(len);
+    };
+
+    ASSERT_TRUE(proxy->handshake("\x05", 1, send_fn));
+    ASSERT_EQ(proxy->get_recv_length(), 1);
+    ASSERT_EQ(proxy->pack_negotiate_request(), 3);
+    ASSERT_EQ(proxy->get_recv_length(), 2);
+    ASSERT_TRUE(proxy->handshake("\x05", 1, send_fn));
+    ASSERT_EQ(proxy->get_recv_length(), 1);
+    ASSERT_TRUE(proxy->handshake("\x00", 1, send_fn));
+    ASSERT_EQ(proxy->state, SW_SOCKS5_STATE_CONNECT);
+    ASSERT_EQ(proxy->get_recv_length(), 4);
+    ASSERT_EQ(requests.size(), 1);
+    ASSERT_EQ(requests[0].length(), 25);
+    ASSERT_MEMEQ(requests[0].data(), "\x05\x01\x00\x03", 4);
+    ASSERT_EQ(static_cast<uchar>(requests[0][4]), 18);
+    ASSERT_MEMEQ(requests[0].data() + 5, "socks5-target.test", 18);
+
+    const std::string response("\x05\x00\x00\x01\x7f\x00\x00\x01\x1f\x90", 10);
+    const size_t remaining[] = {3, 2, 1, 6, 5, 4, 3, 2, 1, 0};
+    for (size_t i = 0; i < response.length(); i++) {
+        ASSERT_TRUE(proxy->handshake(response.data() + i, 1, send_fn));
+        ASSERT_EQ(proxy->get_recv_length(), remaining[i]);
+    }
+    ASSERT_EQ(proxy->state, SW_SOCKS5_STATE_READY);
+}
+
+TEST(protocol, socks5_fragmented_auth_and_domain_response) {
+    auto proxy =
+        std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "username", "password"));
+    ASSERT_NE(proxy, nullptr);
+    proxy->target_host = "socks5-target.test";
+    proxy->target_port = 80;
+
+    ASSERT_EQ(proxy->pack_negotiate_request(), 3);
+    ASSERT_MEMEQ(proxy->buf, "\x05\x01\x02", 3);
+    proxy->state = SW_SOCKS5_STATE_HANDSHAKE;
+
+    std::vector<std::string> requests;
+    auto send_fn = [&requests](const char *buf, size_t len) {
+        requests.emplace_back(buf, len);
+        return static_cast<ssize_t>(len);
+    };
+
+    ASSERT_TRUE(proxy->handshake("\x05", 1, send_fn));
+    ASSERT_EQ(proxy->get_recv_length(), 1);
+    ASSERT_TRUE(proxy->handshake("\x02", 1, send_fn));
+    ASSERT_EQ(proxy->state, SW_SOCKS5_STATE_AUTH);
+    ASSERT_EQ(proxy->get_recv_length(), 2);
+    ASSERT_EQ(requests.size(), 1);
+    ASSERT_EQ(requests[0].length(), 19);
+    ASSERT_MEMEQ(requests[0].data(), "\x01\x08username\x08password", 19);
+
+    ASSERT_TRUE(proxy->handshake("\x01", 1, send_fn));
+    ASSERT_EQ(proxy->get_recv_length(), 1);
+    ASSERT_TRUE(proxy->handshake("\x00", 1, send_fn));
+    ASSERT_EQ(proxy->state, SW_SOCKS5_STATE_CONNECT);
+    ASSERT_EQ(proxy->get_recv_length(), 4);
+    ASSERT_EQ(requests.size(), 2);
+
+    const std::string response("\x05\x00\x00\x03\x03"
+                               "abc\x1f\x90",
+                               10);
+    const size_t remaining[] = {3, 2, 1, 1, 5, 4, 3, 2, 1, 0};
+    for (size_t i = 0; i < response.length(); i++) {
+        ASSERT_TRUE(proxy->handshake(response.data() + i, 1, send_fn));
+        ASSERT_EQ(proxy->get_recv_length(), remaining[i]);
+    }
+    ASSERT_EQ(proxy->state, SW_SOCKS5_STATE_READY);
+}
+
+TEST(protocol, socks5_fragmented_ipv6_response) {
+    auto send_fn = [](const char *, size_t len) { return static_cast<ssize_t>(len); };
+
+    auto ipv6_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP6, "::1", 1080, "", ""));
+    ASSERT_NE(ipv6_proxy, nullptr);
+    ipv6_proxy->state = SW_SOCKS5_STATE_CONNECT;
+    const std::string ipv6_response(
+        "\x05\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x1f\x90", 22);
+    for (size_t i = 0; i < ipv6_response.length(); i++) {
+        ASSERT_TRUE(ipv6_proxy->handshake(ipv6_response.data() + i, 1, send_fn));
+        ASSERT_EQ(ipv6_proxy->get_recv_length(), i < 3 ? 3 - i : 21 - i);
+    }
+    ASSERT_EQ(ipv6_proxy->state, SW_SOCKS5_STATE_READY);
+}
+
+TEST(protocol, socks5_long_domain_response) {
+    auto send_fn = [](const char *, size_t len) { return static_cast<ssize_t>(len); };
+    auto domain_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(domain_proxy, nullptr);
+    domain_proxy->state = SW_SOCKS5_STATE_CONNECT;
+    const std::string domain_header("\x05\x00\x00\x03\xff", 5);
+    ASSERT_TRUE(domain_proxy->handshake(domain_header.data(), 4, send_fn));
+    ASSERT_EQ(domain_proxy->get_recv_length(), 1);
+    ASSERT_TRUE(domain_proxy->handshake(domain_header.data() + 4, 1, send_fn));
+    ASSERT_EQ(domain_proxy->get_recv_length(), 257);
+    std::string domain(255, 'a');
+    domain.append("\x1f\x90", 2);
+    ASSERT_TRUE(domain_proxy->handshake(domain.data(), domain.length(), send_fn));
+    ASSERT_EQ(domain_proxy->state, SW_SOCKS5_STATE_READY);
+}
+
+TEST(protocol, socks5_response_errors) {
+    auto send_fn = [](const char *, size_t len) { return static_cast<ssize_t>(len); };
+
+    auto version_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(version_proxy, nullptr);
+    version_proxy->state = SW_SOCKS5_STATE_CONNECT;
+    ASSERT_FALSE(version_proxy->handshake("\x04\x00\x00\x01", 4, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_UNSUPPORT_VERSION);
+
+    auto server_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(server_proxy, nullptr);
+    server_proxy->state = SW_SOCKS5_STATE_CONNECT;
+    ASSERT_FALSE(server_proxy->handshake("\x05\x05\x00\xff", 4, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_SERVER_ERROR);
+
+    auto address_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(address_proxy, nullptr);
+    address_proxy->state = SW_SOCKS5_STATE_CONNECT;
+    ASSERT_FALSE(address_proxy->handshake("\x05\x00\x00\xff", 4, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
+
+    auto method_proxy = std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", ""));
+    ASSERT_NE(method_proxy, nullptr);
+    ASSERT_EQ(method_proxy->pack_negotiate_request(), 3);
+    method_proxy->state = SW_SOCKS5_STATE_HANDSHAKE;
+    ASSERT_FALSE(method_proxy->handshake("\x05\x02", 2, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_UNSUPPORT_METHOD);
+
+    auto auth_version_proxy =
+        std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "username", "password"));
+    ASSERT_NE(auth_version_proxy, nullptr);
+    ASSERT_EQ(auth_version_proxy->pack_negotiate_request(), 3);
+    auth_version_proxy->state = SW_SOCKS5_STATE_AUTH;
+    ASSERT_FALSE(auth_version_proxy->handshake("\x02\x00", 2, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_UNSUPPORT_VERSION);
+
+    auto auth_proxy =
+        std::unique_ptr<Socks5Proxy>(Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "username", "password"));
+    ASSERT_NE(auth_proxy, nullptr);
+    ASSERT_EQ(auth_proxy->pack_negotiate_request(), 3);
+    auth_proxy->state = SW_SOCKS5_STATE_AUTH;
+    ASSERT_FALSE(auth_proxy->handshake("\x01\x01", 2, send_fn));
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_AUTH_FAILED);
+}
+
 TEST(protocol, swap_byte_order) {
     {
         EXPECT_EQ(swoole_swap_endian16(0x1234), 0x3412);

--- a/include/swoole_proxy.h
+++ b/include/swoole_proxy.h
@@ -84,10 +84,14 @@ struct Socks5Proxy {
     int target_port;
     int socket_type;
     char buf[512];
+    std::string response;
 
     ssize_t pack_negotiate_request();
     ssize_t pack_auth_request();
     ssize_t pack_connect_request();
+    // Returns the bytes needed to complete the current response stage. Callers must not read more because any
+    // following bytes belong to the target connection.
+    size_t get_recv_length() const;
     bool handshake(const char *rbuf, size_t rlen, const std::function<ssize_t(const char *buf, size_t len)> &send_fn);
 
     static const char *strerror(int code);

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -226,7 +226,7 @@ bool Socket::socks5_handshake() {
     char recv_buf[512];
     ctx->state = SW_SOCKS5_STATE_HANDSHAKE;
     while (true) {
-        const ssize_t n = recv(recv_buf, sizeof(recv_buf));
+        const ssize_t n = recv(recv_buf, ctx->get_recv_length());
         if (n > 0 && ctx->handshake(recv_buf, n, send_fn)) {
             if (ctx->state == SW_SOCKS5_STATE_READY) {
                 return true;

--- a/src/network/client.cc
+++ b/src/network/client.cc
@@ -444,7 +444,7 @@ static int Client_tcp_connect_sync(Client *cli, const char *host, int port, doub
             }
             ctx->state = SW_SOCKS5_STATE_HANDSHAKE;
             while (true) {
-                const ssize_t n = cli->recv(recv_buf->str, recv_buf->size, 0);
+                const ssize_t n = cli->recv(recv_buf->str, ctx->get_recv_length(), 0);
                 if (n > 0 && cli->socks5_handshake(recv_buf->str, n)) {
                     if (cli->socks5_proxy->state == SW_SOCKS5_STATE_READY) {
                         break;
@@ -752,12 +752,11 @@ static int Client_onStreamRead(Reactor *reactor, Event *event) {
     }
 
     if (cli->socks5_proxy && cli->socks5_proxy->state != SW_SOCKS5_STATE_READY) {
-        n = event->socket->recv(buf, buf_size, 0);
+        n = event->socket->recv(buf, cli->socks5_proxy->get_recv_length(), 0);
         if (n <= 0) {
             swoole_set_last_error(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
             goto _connect_fail;
         }
-        cli->buffer->length += n;
         if (!cli->socks5_handshake(buf, n)) {
             swoole_set_last_error(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
             goto _connect_fail;
@@ -765,7 +764,6 @@ static int Client_onStreamRead(Reactor *reactor, Event *event) {
         if (cli->socks5_proxy->state != SW_SOCKS5_STATE_READY) {
             return SW_OK;
         }
-        cli->buffer->clear();
         if (!do_ssl_handshake) {
             execute_onConnect(cli);
             return SW_OK;

--- a/src/protocol/socks5.cc
+++ b/src/protocol/socks5.cc
@@ -64,6 +64,7 @@ Socks5Proxy *Socks5Proxy::create(
 }
 
 ssize_t Socks5Proxy::pack_negotiate_request() {
+    response.clear();
     char *p = buf;
     p[0] = SW_SOCKS5_VERSION_CODE;  // Version
     p[1] = 0x01;
@@ -92,19 +93,55 @@ ssize_t Socks5Proxy::pack_auth_request() {
     return p - buf;
 }
 
+size_t Socks5Proxy::get_recv_length() const {
+    size_t expected_length;
+
+    if (state == SW_SOCKS5_STATE_HANDSHAKE || state == SW_SOCKS5_STATE_AUTH) {
+        expected_length = 2;
+    } else if (state == SW_SOCKS5_STATE_CONNECT) {
+        if (response.length() < 4) {
+            expected_length = 4;
+        } else {
+            switch (static_cast<uchar>(response[3])) {
+            case 0x01:
+                expected_length = 10;
+                break;
+            case 0x03:
+                if (response.length() < 5) {
+                    return 1;
+                }
+                expected_length = 7 + static_cast<uchar>(response[4]);
+                break;
+            case 0x04:
+                expected_length = 22;
+                break;
+            default:
+                return 0;
+            }
+        }
+    } else {
+        return 0;
+    }
+
+    return expected_length > response.length() ? expected_length - response.length() : 0;
+}
+
 bool Socks5Proxy::handshake(const char *rbuf,
                             size_t rlen,
                             const std::function<ssize_t(const char *buf, size_t len)> &send_fn) {
-    if (rlen < 2) {
-        swoole_error_log(
-            SW_LOG_NOTICE, SW_ERROR_SOCKS5_HANDSHAKE_FAILED, "SOCKS5 handshake failed, data length is too short");
-        return false;
-    }
-
-    const uchar resp_version = rbuf[0];
-    const uchar resp_result = rbuf[1];
+    response.append(rbuf, rlen);
+    auto send_connect_request = [this, &send_fn]() {
+        state = SW_SOCKS5_STATE_CONNECT;
+        const auto len = pack_connect_request();
+        return len >= 0 && send_fn(buf, len) == len;
+    };
 
     if (state == SW_SOCKS5_STATE_HANDSHAKE) {
+        if (response.length() < 2) {
+            return true;
+        }
+        const uchar resp_version = static_cast<uchar>(response[0]);
+        const uchar resp_result = static_cast<uchar>(response[1]);
         if (resp_version != SW_SOCKS5_VERSION_CODE) {
             swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return false;
@@ -114,23 +151,20 @@ bool Socks5Proxy::handshake(const char *rbuf,
                 SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_METHOD, "SOCKS authentication method is not supported");
             return false;
         }
+        response.clear();
         // authenticate request
         if (method == SW_SOCKS5_METHOD_AUTH) {
             const auto len = pack_auth_request();
             state = SW_SOCKS5_STATE_AUTH;
             return send_fn(buf, len) == len;
         }
-        // send connect request
-        else {
-        _send_connect_request:
-            state = SW_SOCKS5_STATE_CONNECT;
-            const auto len = pack_connect_request();
-            if (len < 0) {
-                return false;
-            }
-            return send_fn(buf, len) == len;
-        }
+        return send_connect_request();
     } else if (state == SW_SOCKS5_STATE_AUTH) {
+        if (response.length() < 2) {
+            return true;
+        }
+        const uchar resp_version = static_cast<uchar>(response[0]);
+        const uchar resp_result = static_cast<uchar>(response[1]);
         if (resp_version != 0x01) {
             swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return false;
@@ -140,28 +174,36 @@ bool Socks5Proxy::handshake(const char *rbuf,
                 SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS username/password authentication failed");
             return false;
         }
-        goto _send_connect_request;
+        response.clear();
+        return send_connect_request();
     } else if (state == SW_SOCKS5_STATE_CONNECT) {
+        if (response.length() < 4) {
+            return true;
+        }
+        const uchar resp_version = static_cast<uchar>(response[0]);
+        const uchar resp_result = static_cast<uchar>(response[1]);
         if (resp_version != SW_SOCKS5_VERSION_CODE) {
             swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_UNSUPPORT_VERSION, "SOCKS version is not supported");
             return false;
         }
-#if 0
-        uchar reg = recv_data[2];
-        uchar type = recv_data[3];
-        uint32_t ip = *(uint32_t *) (recv_data + 4);
-        uint16_t port = *(uint16_t *) (recv_data + 8);
-#endif
-        if (resp_result == 0) {
-            state = SW_SOCKS5_STATE_READY;
-            return true;
-        } else {
+        if (resp_result != 0) {
             swoole_error_log(SW_LOG_NOTICE,
                              SW_ERROR_SOCKS5_SERVER_ERROR,
                              "Socks5 server error, reason :%s",
                              Socks5Proxy::strerror(resp_result));
             return false;
         }
+        const uchar address_type = static_cast<uchar>(response[3]);
+        if (address_type != 0x01 && address_type != 0x03 && address_type != 0x04) {
+            swoole_error_log(SW_LOG_NOTICE, SW_ERROR_SOCKS5_HANDSHAKE_FAILED, "SOCKS5 address type is not supported");
+            return false;
+        }
+        if (get_recv_length() > 0) {
+            return true;
+        }
+        response.clear();
+        state = SW_SOCKS5_STATE_READY;
+        return true;
     }
     return true;
 }

--- a/tests/include/api/swoole_client/socks5_fake_proxy.php
+++ b/tests/include/api/swoole_client/socks5_fake_proxy.php
@@ -1,0 +1,61 @@
+<?php
+
+function socks5_read_exact($socket, int $length, string $description): string
+{
+    $data = '';
+    while (strlen($data) < $length) {
+        $chunk = fread($socket, $length - strlen($data));
+        if ($chunk === false || $chunk === '') {
+            $state = stream_get_meta_data($socket);
+            $reason = $state['timed_out'] ? 'timed out' : 'connection closed';
+            throw new RuntimeException("{$reason} while waiting for {$description}");
+        }
+        $data .= $chunk;
+    }
+    return $data;
+}
+
+function socks5_write($socket, string $data): void
+{
+    Assert::same(fwrite($socket, $data), strlen($data));
+}
+
+function socks5_run_proxy(ProcessManager $pm, int $port, bool $fragment = true): void
+{
+    $server = stream_socket_server('tcp://' . TCP_SERVER_HOST . ":{$port}", $errno, $errstr);
+    Assert::notSame($server, false, "{$errstr} ({$errno})");
+    $pm->wakeup();
+
+    $socket = stream_socket_accept($server, 5);
+    Assert::notSame($socket, false);
+    Assert::true(stream_set_timeout($socket, 2));
+    Assert::same(socks5_read_exact($socket, 3, 'negotiation request'), "\x05\x01\x00");
+
+    if ($fragment) {
+        socks5_write($socket, "\x05");
+        usleep(20000);
+        socks5_write($socket, "\x00");
+    } else {
+        socks5_write($socket, "\x05\x00");
+    }
+
+    Assert::same(socks5_read_exact($socket, 4, 'CONNECT request header'), "\x05\x01\x00\x03");
+    $hostLength = ord(socks5_read_exact($socket, 1, 'CONNECT target length'));
+    Assert::same($hostLength, 18);
+    Assert::same(socks5_read_exact($socket, $hostLength, 'CONNECT target'), 'socks5-target.test');
+    Assert::same(unpack('n', socks5_read_exact($socket, 2, 'CONNECT target port'))[1], 80);
+
+    $response = "\x05\x00\x00\x01\x7f\x00\x00\x01\x1f\x90";
+    if ($fragment) {
+        for ($i = 0; $i < strlen($response) - 1; $i++) {
+            socks5_write($socket, $response[$i]);
+            usleep(20000);
+        }
+        socks5_write($socket, $response[strlen($response) - 1] . "SOCKS5 READY\n");
+    } else {
+        socks5_write($socket, $response . "SOCKS5 READY\n");
+    }
+
+    fclose($socket);
+    fclose($server);
+}

--- a/tests/swoole_client_async/socks5_fragmented_response.phpt
+++ b/tests/swoole_client_async/socks5_fragmented_response.phpt
@@ -1,0 +1,43 @@
+--TEST--
+swoole_client_async: fragmented SOCKS5 response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+require TESTS_API_PATH . '/swoole_client/socks5_fake_proxy.php';
+
+$pm = new ProcessManager();
+$port = get_one_free_port();
+$pm->parentFunc = function ($pid) use ($port) {
+    $client = new Swoole\Async\Client(SWOOLE_SOCK_TCP);
+    $client->set([
+        'socks5_host' => TCP_SERVER_HOST,
+        'socks5_port' => $port,
+    ]);
+    $client->on('connect', function (Swoole\Async\Client $client) {
+        Assert::true($client->isConnected());
+    });
+    $client->on('receive', function (Swoole\Async\Client $client, string $data) {
+        Assert::same($data, "SOCKS5 READY\n");
+        $client->close();
+    });
+    $client->on('error', function () {
+        echo "ERROR\n";
+        Swoole\Event::exit();
+    });
+    $client->on('close', function () {
+        echo "DONE\n";
+        Swoole\Event::exit();
+    });
+    Assert::true($client->connect('socks5-target.test', 80, 2));
+    Swoole\Event::wait();
+};
+$pm->childFunc = function () use ($pm, $port) {
+    socks5_run_proxy($pm, $port);
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_coro/socks5_fragmented_response.phpt
+++ b/tests/swoole_client_coro/socks5_fragmented_response.phpt
@@ -1,0 +1,32 @@
+--TEST--
+swoole_client_coro: fragmented SOCKS5 response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+require TESTS_API_PATH . '/swoole_client/socks5_fake_proxy.php';
+
+$pm = new ProcessManager();
+$port = get_one_free_port();
+$pm->parentFunc = function ($pid) use ($port) {
+    Co\run(function () use ($port) {
+        $client = new Swoole\Coroutine\Client(SWOOLE_SOCK_TCP);
+        Assert::true($client->set([
+            'socks5_host' => TCP_SERVER_HOST,
+            'socks5_port' => $port,
+        ]));
+        Assert::true($client->connect('socks5-target.test', 80, 2));
+        Assert::same($client->recv(), "SOCKS5 READY\n");
+        $client->close();
+        echo "DONE\n";
+    });
+};
+$pm->childFunc = function () use ($pm, $port) {
+    socks5_run_proxy($pm, $port);
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_sync/socks5_coalesced_response.phpt
+++ b/tests/swoole_client_sync/socks5_coalesced_response.phpt
@@ -1,0 +1,30 @@
+--TEST--
+swoole_client_sync: SOCKS5 response with target data
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+require TESTS_API_PATH . '/swoole_client/socks5_fake_proxy.php';
+
+$pm = new ProcessManager();
+$port = get_one_free_port();
+$pm->parentFunc = function ($pid) use ($port) {
+    $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+    $client->set([
+        'socks5_host' => TCP_SERVER_HOST,
+        'socks5_port' => $port,
+    ]);
+    Assert::true($client->connect('socks5-target.test', 80, 2));
+    Assert::same($client->recv(), "SOCKS5 READY\n");
+    $client->close();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm, $port) {
+    socks5_run_proxy($pm, $port, false);
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_sync/socks5_fragmented_response.phpt
+++ b/tests/swoole_client_sync/socks5_fragmented_response.phpt
@@ -1,0 +1,30 @@
+--TEST--
+swoole_client_sync: fragmented SOCKS5 response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+require TESTS_API_PATH . '/swoole_client/socks5_fake_proxy.php';
+
+$pm = new ProcessManager();
+$port = get_one_free_port();
+$pm->parentFunc = function ($pid) use ($port) {
+    $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+    $client->set([
+        'socks5_host' => TCP_SERVER_HOST,
+        'socks5_port' => $port,
+    ]);
+    Assert::true($client->connect('socks5-target.test', 80, 2));
+    Assert::same($client->recv(), "SOCKS5 READY\n");
+    $client->close();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm, $port) {
+    socks5_run_proxy($pm, $port);
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
SOCKS5 clients can consume target data when it arrives with the final proxy reply. They also reject valid proxy replies split across socket reads.

This keeps incomplete proxy replies in the SOCKS5 parser and limits each client read to the bytes needed for the current stage. Target data remains in the socket for the client, and fragmented replies work across synchronous, asynchronous, and coroutine clients.

The exact-read handoff relies on Swoole's supported reactors being level-triggered, so unread target data schedules another read event.

Includes self-contained coverage for fragmented replies, authentication, all CONNECT reply address forms, and target data sent with the proxy reply.