### PR TITLE
Fix ProcessPool TCP listener rebinding

### DIFF
--- a/core-tests/src/network/socket.cpp
+++ b/core-tests/src/network/socket.cpp
@@ -666,6 +666,34 @@ TEST(socket, make_server_socket) {
     sock->free();
 }
 
+TEST(socket, make_server_socket_rebind_after_time_wait) {
+    auto server = make_server_socket(SW_SOCK_TCP, TEST_HOST);
+    ASSERT_NE(server, nullptr);
+    auto port = server->get_port();
+    ASSERT_GT(port, 0);
+
+    network::Address address;
+    ASSERT_TRUE(address.assign(SW_SOCK_TCP, TEST_HOST, port));
+    auto client = make_socket(SW_SOCK_TCP, SW_FD_STREAM, 0);
+    ASSERT_NE(client, nullptr);
+    ASSERT_EQ(client->connect_sync(address), SW_OK);
+
+    auto connection = server->accept();
+    ASSERT_NE(connection, nullptr);
+    // The server endpoint must close first so TIME_WAIT lands on the listener port. If the client closed first, it
+    // would land on the client's ephemeral port and this test would pass without the fix.
+    connection->free();
+
+    char buf;
+    ASSERT_EQ(client->recv_sync(&buf, sizeof(buf), 0), 0);
+    client->free();
+    server->free();
+
+    server = make_server_socket(SW_SOCK_TCP, TEST_HOST, port);
+    ASSERT_NE(server, nullptr);
+    server->free();
+}
+
 TEST(socket, ssl_get_error_reason) {
     swoole_ssl_init();
     {

--- a/src/network/socket.cc
+++ b/src/network/socket.cc
@@ -1860,6 +1860,11 @@ Socket *make_server_socket(SocketType type, const char *address, int port, int b
         swoole_sys_warning("socket() failed");
         return nullptr;
     }
+    // Only TCP sockets need to rebind addresses held by TIME_WAIT. Enabling reuse for datagram sockets can allow
+    // duplicate binds.
+    if (sock->is_tcp() && sock->set_reuse_addr() < 0) {
+        swoole_sys_warning("setsockopt(%d, SO_REUSEADDR) failed", sock->get_fd());
+    }
     if (sock->bind(address, port) < 0) {
         swoole_sys_warning("bind(%d, %s:%d, %d) failed", sock->get_fd(), address, port, backlog);
         goto __cleanup;


### PR DESCRIPTION
ProcessPool TCP listeners can fail to restart on the same port while connections from the previous listener remain in `TIME_WAIT`.

This enables `SO_REUSEADDR` before binding TCP server sockets. Unix and datagram sockets are unchanged.

The regression closes the server side first and immediately binds a new listener to the same port.