### PR TITLE
Fix Server Port set return handling

### DIFF
--- a/ext-src/stubs/php_swoole_server_port.stub.php
+++ b/ext-src/stubs/php_swoole_server_port.stub.php
@@ -3,7 +3,7 @@ namespace Swoole\Server {
     class Port {
         private function __construct() {}
         public function __destruct() {}
-        public function set(array $settings): void {}
+        public function set(array $settings): bool {}
         public function on(string $event_name, callable $callback): bool {}
         public function getCallback(string $event_name): \Closure|null {}
         #ifdef SWOOLE_SOCKETS_SUPPORT

--- a/ext-src/stubs/php_swoole_server_port_arginfo.h
+++ b/ext-src/stubs/php_swoole_server_port_arginfo.h
@@ -1,12 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d135ba05df9cfb18ecdb5764ea5434c25efc631 */
+ * Stub hash: 82fe38b62ed1e956b746ad026e27d155a301ea39 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Server_Port___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Server_Port___destruct arginfo_class_Swoole_Server_Port___construct
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Server_Port_set, 0, 1, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Server_Port_set, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, settings, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -943,7 +943,6 @@ void ServerObject::on_before_start() {
             sw_zend_read_property_ex(swoole_server_port_ce, zport, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
         // use swoole_server->setting
         if (zport_setting == nullptr || ZVAL_IS_NULL(zport_setting)) {
-            Z_TRY_ADDREF_P(zport);
             sw_zend_call_method_with_1_params(zport, swoole_server_port_ce, nullptr, "set", nullptr, zsetting);
         }
     }

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -943,7 +943,14 @@ void ServerObject::on_before_start() {
             sw_zend_read_property_ex(swoole_server_port_ce, zport, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
         // use swoole_server->setting
         if (zport_setting == nullptr || ZVAL_IS_NULL(zport_setting)) {
-            sw_zend_call_method_with_1_params(zport, swoole_server_port_ce, nullptr, "set", nullptr, zsetting);
+            zval retval;
+            sw_zend_call_method_with_1_params(zport, swoole_server_port_ce, nullptr, "set", &retval, zsetting);
+            if (!Z_BVAL_P(&retval)) {
+                ListenPort *port = php_swoole_server_port_get_and_check_ptr(zport);
+                php_swoole_fatal_error(
+                    E_ERROR, "failed to set the options of port[%s:%d]", port->get_host(), port->get_port());
+                return;
+            }
         }
     }
 
@@ -2415,8 +2422,12 @@ static PHP_METHOD(swoole_server, set) {
         RETURN_FALSE;
     }
 
+    zval retval;
     sw_zend_call_method_with_1_params(
-        server_object->property->ports.at(0), swoole_server_port_ce, nullptr, "set", nullptr, zset);
+        server_object->property->ports.at(0), swoole_server_port_ce, nullptr, "set", &retval, zset);
+    if (!Z_BVAL_P(&retval)) {
+        RETURN_FALSE;
+    }
 
     zval *zsetting = sw_zend_read_and_convert_property_array(swoole_server_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
     php_array_merge(Z_ARRVAL_P(zsetting), Z_ARRVAL_P(zset));

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -554,6 +554,8 @@ static PHP_METHOD(swoole_server_port, set) {
     zval *zsetting = sw_zend_read_and_convert_property_array(swoole_server_port_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
     php_array_merge(Z_ARRVAL_P(zsetting), Z_ARRVAL_P(zset));
     property->zsetting = zsetting;
+
+    RETURN_TRUE;
 }
 
 static PHP_METHOD(swoole_server_port, on) {

--- a/tests/swoole_server_port/set_return_value.phpt
+++ b/tests/swoole_server_port/set_return_value.phpt
@@ -1,0 +1,21 @@
+--TEST--
+swoole_server_port: set returns whether the settings were applied
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', 0, SWOOLE_BASE);
+$port = $server->ports[0];
+
+Assert::same((new ReflectionMethod($port, 'set'))->getReturnType()->getName(), 'bool');
+Assert::true($port->set(['backlog' => 128]));
+Assert::true($server->set(['worker_num' => 1]));
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_server_port/set_return_value_inherited.phpt
+++ b/tests/swoole_server_port/set_return_value_inherited.phpt
@@ -1,0 +1,34 @@
+--TEST--
+swoole_server_port: inherited settings are rejected before server startup
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', 0, SWOOLE_BASE);
+$server->listen('127.0.0.1', 0, SWOOLE_SOCK_TCP | SWOOLE_SSL);
+Assert::true($server->set([
+    'log_file' => '/dev/null',
+    'worker_num' => 1,
+    'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+    'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+    'ssl_sni_certs' => true,
+]));
+$server->on('Receive', function () {});
+$server->on('WorkerStart', function (Server $server) {
+    $server->shutdown();
+});
+$server->start();
+
+echo "UNEXPECTED\n";
+?>
+--EXPECTF--
+Warning: Swoole\Server\Port::set(): ssl_sni_certs requires an array mapping host names to cert paths in %s on line %d
+
+Fatal error: Swoole\Server::start(): failed to set the options of port[127.0.0.1:%d] in %s on line %d%A

--- a/tests/swoole_server_port/set_return_value_ssl.phpt
+++ b/tests/swoole_server_port/set_return_value_ssl.phpt
@@ -1,0 +1,30 @@
+--TEST--
+swoole_server_port: set returns false when SSL settings are rejected
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', 0, SWOOLE_BASE, SWOOLE_SOCK_TCP | SWOOLE_SSL);
+$settings = [
+    'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+    'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+    'ssl_sni_certs' => true,
+];
+
+Assert::false($server->ports[0]->set($settings));
+Assert::false($server->set($settings));
+
+echo "DONE\n";
+?>
+--EXPECTF--
+Warning: Swoole\Server\Port::set(): ssl_sni_certs requires an array mapping host names to cert paths in %s on line %d
+
+Warning: Swoole\Server\Port::set(): ssl_sni_certs requires an array mapping host names to cert paths in %s on line %d
+DONE


### PR DESCRIPTION
Swoole\Server\Port::set() can reject invalid port options, but it is declared void and its internal callers ignore the result.

This changes the public return type to bool. Server::set() now returns false before merging its setting array when the primary port rejects an option. A secondary port can reject inherited options only during start(), so startup stops and reports that listener.

A false result does not roll back native server options already applied before port validation. Callers should not continue to start() after Server::set() returns false.

This also removes an unmatched reference increment when inherited settings are applied to secondary ports.