### PR TITLE
Fix coroutine client setting failures and cleanup

### DIFF
--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -596,8 +596,10 @@ static PHP_METHOD(swoole_client_coro, enableSSL) {
         RETURN_FALSE;
     }
     zval *zset = sw_zend_read_property_ex(swoole_client_coro_ce, ZEND_THIS, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
-    if (php_swoole_array_length_safe(zset) > 0) {
-        php_swoole_socket_set_ssl(cli, zset);
+    if (php_swoole_array_length_safe(zset) > 0 && !php_swoole_socket_set_ssl(cli, zset)) {
+        php_swoole_socket_set_error_properties(ZEND_THIS, SW_ERROR_INVALID_PARAMS);
+        cli->close();
+        RETURN_FALSE;
     }
     if (!cli->ssl_handshake()) {
         php_swoole_socket_set_error_properties(ZEND_THIS, cli);

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -213,10 +213,13 @@ static sw_inline Socket *client_coro_get_socket_for_connect(zval *zobject, int p
     if (!sock) {
         return nullptr;
     }
+    // The destructor callback requires client->socket and clears it when close() succeeds.
     client->socket = sock;
     zval *zset = sw_zend_read_property_ex(swoole_client_coro_ce, zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0);
-    if (zset && ZVAL_IS_ARRAY(zset)) {
-        php_swoole_socket_set(sock, zset);
+    if (zset && ZVAL_IS_ARRAY(zset) && !php_swoole_socket_set(sock, zset)) {
+        php_swoole_socket_set_error_properties(zobject, SW_ERROR_INVALID_PARAMS);
+        sock->close();
+        return nullptr;
     }
     return sock;
 }

--- a/ext-src/swoole_client_coro.cc
+++ b/ext-src/swoole_client_coro.cc
@@ -137,6 +137,7 @@ static void client_coro_socket_dtor(ClientCoroObject *client) {
         client->socket->protocol.private_data_1 = nullptr;
     }
     client->socket = nullptr;
+    zend_update_property_long(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("fd"), -1);
     zend_update_property_null(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("socket"));
     zend_update_property_bool(Z_OBJCE_P(&client->zobject), SW_Z8_OBJ_P(&client->zobject), ZEND_STRL("connected"), 0);
     zval_ptr_dtor(&client->zsocket);

--- a/ext-src/swoole_http2_client_coro.cc
+++ b/ext-src/swoole_http2_client_coro.cc
@@ -135,10 +135,11 @@ class Client {
         return true;
     }
 
-    void apply_setting(const zval *zset) const {
+    bool apply_setting(const zval *zset) const {
         if (socket_ && ZVAL_IS_ARRAY(zset)) {
-            php_swoole_socket_set(socket_, zset);
+            return php_swoole_socket_set(socket_, zset);
         }
+        return true;
     }
 
     bool recv_packet(double _timeout) const {
@@ -438,8 +439,12 @@ bool Client::connect() {
     socket_->protocol.package_body_offset = 0;
     socket_->protocol.get_package_length = Http2::get_frame_length;
 
-    apply_setting(
-        sw_zend_read_property_ex(swoole_http2_client_coro_ce, zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0));
+    if (!apply_setting(
+            sw_zend_read_property_ex(swoole_http2_client_coro_ce, zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0))) {
+        update_error_properties(SW_ERROR_INVALID_PARAMS, swoole_strerror(SW_ERROR_INVALID_PARAMS));
+        close();
+        return false;
+    }
 
     if (!socket_->connect(host, port)) {
         io_error();
@@ -841,9 +846,7 @@ static PHP_METHOD(swoole_http2_client_coro, set) {
         sw_zend_read_and_convert_property_array(swoole_http2_client_coro_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
     php_array_merge(Z_ARRVAL_P(zsetting), Z_ARRVAL_P(zset));
 
-    h2c->apply_setting(zset);
-
-    RETURN_TRUE;
+    RETURN_BOOL(h2c->apply_setting(zset));
 }
 
 /**

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -197,7 +197,7 @@ class Client {
 #ifdef SW_HAVE_COMPRESSION
     bool decompress_response(const char *in, size_t in_len);
 #endif
-    void apply_setting(zval *zset, bool check_all = true);
+    bool apply_setting(zval *zset, bool check_all = true);
     void set_basic_auth(const std::string &username, const std::string &password);
     bool exec(const std::string &_path);
     bool recv_response(double timeout = 0);
@@ -739,9 +739,9 @@ bool Client::decompress_response(const char *in, size_t in_len) {
 }
 #endif
 
-void Client::apply_setting(zval *zset, const bool check_all) {
+bool Client::apply_setting(zval *zset, const bool check_all) {
     if (!ZVAL_IS_ARRAY(zset) || php_swoole_array_length(zset) == 0) {
-        return;
+        return true;
     }
     if (check_all) {
         zval *ztmp;
@@ -777,8 +777,9 @@ void Client::apply_setting(zval *zset, const bool check_all) {
         }
         WebSocket::apply_setting(websocket_settings, vht, false);
     }
+    bool retval = true;
     if (socket) {
-        php_swoole_socket_set(socket, zset);
+        retval = php_swoole_socket_set(socket, zset);
 #ifdef SW_USE_OPENSSL
         if (socket->http_proxy && !socket->ssl_is_enable())
 #else
@@ -788,6 +789,7 @@ void Client::apply_setting(zval *zset, const bool check_all) {
             socket->http_proxy->dont_handshake = 1;
         }
     }
+    return retval;
 }
 
 void Client::set_basic_auth(const std::string &username, const std::string &password) {
@@ -832,6 +834,8 @@ bool Client::connect() {
     }
     ZVAL_OBJ(&zsocket, object);
     socket = php_swoole_get_socket(&zsocket);
+    // close() requires the destructor to clear socket and release zsocket on a settings failure.
+    socket->set_dtor([this](Socket *_socket) { socket_dtor(); });
 
 #ifdef SW_USE_OPENSSL
     if (ssl && !socket->enable_ssl_encrypt()) {
@@ -842,7 +846,12 @@ bool Client::connect() {
 #endif
 
     // apply settings
-    apply_setting(sw_zend_read_property_ex(Z_OBJCE_P(zobject), zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0), false);
+    if (!apply_setting(sw_zend_read_property_ex(Z_OBJCE_P(zobject), zobject, SW_ZSTR_KNOWN(SW_ZEND_STR_SETTING), 0),
+                       false)) {
+        set_error(SW_ERROR_INVALID_PARAMS, swoole_strerror(SW_ERROR_INVALID_PARAMS), HTTP_ESTATUS_CONNECT_FAILED);
+        close();
+        return false;
+    }
 
     // reset the properties that depend on the connection
     websocket = false;
@@ -853,7 +862,6 @@ bool Client::connect() {
     double _timeout = connect_timeout == 0 ? network::Socket::default_connect_timeout : connect_timeout;
     socket->set_timeout(_timeout, SW_TIMEOUT_CONNECT);
     socket->set_resolve_context(&resolve_context_);
-    socket->set_dtor([this](Socket *_socket) { socket_dtor(); });
     socket->set_buffer_allocator(sw_zend_string_allocator());
 
     if (!socket->connect(host, port)) {
@@ -1820,8 +1828,7 @@ static PHP_METHOD(swoole_http_client_coro, set) {
         zval *zsettings =
             sw_zend_read_and_convert_property_array(swoole_http_client_coro_ce, ZEND_THIS, ZEND_STRL("setting"), 0);
         php_array_merge(Z_ARRVAL_P(zsettings), Z_ARRVAL_P(zset));
-        phc->apply_setting(zset);
-        RETURN_TRUE;
+        RETURN_BOOL(phc->apply_setting(zset));
     }
 }
 

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -1079,7 +1079,10 @@ SW_API bool php_swoole_socket_set(Socket *cli, const zval *zset) {
             auto socks5_port = zval_get_long(ztmp);
             if (php_swoole_array_get_value(vht, "socks5_username", ztmp)) {
                 user = zend::String(ztmp).to_std_string();
-                if (!user.empty() && php_swoole_array_get_value(vht, "socks5_password", ztmp)) {
+                if (user.empty()) {
+                    php_swoole_fatal_error(E_WARNING, "socks5_username should not be empty");
+                    ret = false;
+                } else if (php_swoole_array_get_value(vht, "socks5_password", ztmp)) {
                     pwd = zend::String(ztmp).to_std_string();
                 } else {
                     php_swoole_fatal_error(E_WARNING, "socks5_password should not be null");
@@ -1108,10 +1111,13 @@ SW_API bool php_swoole_socket_set(Socket *cli, const zval *zset) {
             if (php_swoole_array_get_value(vht, "http_proxy_username", ztmp) ||
                 php_swoole_array_get_value(vht, "http_proxy_user", ztmp)) {
                 user = zend::String(ztmp).to_std_string();
-                if (!user.empty() && php_swoole_array_get_value(vht, "http_proxy_password", ztmp)) {
+                if (user.empty()) {
+                    php_swoole_fatal_error(E_WARNING, "http_proxy_username should not be empty");
+                    ret = false;
+                } else if (php_swoole_array_get_value(vht, "http_proxy_password", ztmp)) {
                     pwd = zend::String(ztmp).to_std_string();
                 } else {
-                    php_swoole_fatal_error(E_WARNING, "socks5_password should not be null");
+                    php_swoole_fatal_error(E_WARNING, "http_proxy_password should not be null");
                     ret = false;
                 }
             }

--- a/tests/swoole_client_coro/enableSSL.phpt
+++ b/tests/swoole_client_coro/enableSSL.phpt
@@ -1,7 +1,10 @@
 --TEST--
 swoole_client_coro: enableSSL
 --SKIPIF--
-<?php require __DIR__ . '/../include/skipif.inc'; ?>
+<?php require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+skip_if_offline();
+?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';

--- a/tests/swoole_client_coro/invalid_deferred_settings.phpt
+++ b/tests/swoole_client_coro/invalid_deferred_settings.phpt
@@ -1,0 +1,69 @@
+--TEST--
+swoole_client_coro: reject invalid deferred settings
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Client;
+
+use function Swoole\Coroutine\run;
+
+$server = stream_socket_server('tcp://127.0.0.1:0');
+$address = stream_socket_get_name($server, false);
+$port = (int) substr($address, strrpos($address, ':') + 1);
+$warnings = [];
+
+set_error_handler(function ($errno, $message) use (&$warnings) {
+    $warnings[] = $message;
+    return true;
+});
+
+run(function () use ($port, &$warnings) {
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
+        'socks5_host' => '127.0.0.1',
+    ]));
+
+    // Retry with the same client to verify that the rejected socket was released.
+    $results = [
+        $client->connect('127.0.0.1', $port),
+        $client->connect('127.0.0.1', $port),
+    ];
+    Assert::same($results, [false, false]);
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::null($client->socket);
+    Assert::count($warnings, 2);
+    foreach ($warnings as $warning) {
+        Assert::endsWith($warning, 'socks5_port should not be null');
+    }
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
+        'http_proxy_host' => '127.0.0.1',
+        'http_proxy_port' => null,
+    ]));
+    Assert::false($client->connect('127.0.0.1', $port));
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::null($client->socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'http_proxy_port should not be null');
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
+        'package_length_type' => '?',
+    ]));
+    Assert::false($client->connect('127.0.0.1', $port));
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::null($client->socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], "Unknown package_length_type name '?', see pack(). Link: https://php.net/pack");
+});
+
+restore_error_handler();
+fclose($server);
+?>
+--EXPECT--

--- a/tests/swoole_client_coro/invalid_deferred_settings.phpt
+++ b/tests/swoole_client_coro/invalid_deferred_settings.phpt
@@ -33,6 +33,7 @@ run(function () use ($port, &$warnings) {
     ];
     Assert::same($results, [false, false]);
     Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
     Assert::null($client->socket);
     Assert::count($warnings, 2);
     foreach ($warnings as $warning) {
@@ -42,14 +43,59 @@ run(function () use ($port, &$warnings) {
     $warnings = [];
     $client = new Client(SWOOLE_SOCK_TCP);
     Assert::true($client->set([
+        'socks5_host' => '127.0.0.1',
+        'socks5_port' => $port,
+        'socks5_username' => '',
+        'socks5_password' => 'secret',
+    ]));
+    Assert::false($client->connect('127.0.0.1', $port));
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
+    Assert::null($client->socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'socks5_username should not be empty');
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
         'http_proxy_host' => '127.0.0.1',
         'http_proxy_port' => null,
     ]));
     Assert::false($client->connect('127.0.0.1', $port));
     Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
     Assert::null($client->socket);
     Assert::count($warnings, 1);
     Assert::endsWith($warnings[0], 'http_proxy_port should not be null');
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
+        'http_proxy_host' => '127.0.0.1',
+        'http_proxy_port' => $port,
+        'http_proxy_username' => 'user',
+    ]));
+    Assert::false($client->connect('127.0.0.1', $port));
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
+    Assert::null($client->socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'http_proxy_password should not be null');
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->set([
+        'http_proxy_host' => '127.0.0.1',
+        'http_proxy_port' => $port,
+        'http_proxy_username' => '',
+        'http_proxy_password' => 'secret',
+    ]));
+    Assert::false($client->connect('127.0.0.1', $port));
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
+    Assert::null($client->socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'http_proxy_username should not be empty');
 
     $warnings = [];
     $client = new Client(SWOOLE_SOCK_TCP);
@@ -58,9 +104,22 @@ run(function () use ($port, &$warnings) {
     ]));
     Assert::false($client->connect('127.0.0.1', $port));
     Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->fd, -1);
     Assert::null($client->socket);
     Assert::count($warnings, 1);
     Assert::endsWith($warnings[0], "Unknown package_length_type name '?', see pack(). Link: https://php.net/pack");
+
+    $warnings = [];
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $port));
+    Assert::greaterThanEq($client->fd, 0);
+    Assert::true($client->close());
+    Assert::same($client->fd, -1);
+    Assert::true($client->connect('127.0.0.1', $port));
+    Assert::greaterThanEq($client->fd, 0);
+    Assert::true($client->close());
+    Assert::same($client->fd, -1);
+    Assert::count($warnings, 0);
 });
 
 restore_error_handler();

--- a/tests/swoole_client_coro/invalid_ssl_settings.phpt
+++ b/tests/swoole_client_coro/invalid_ssl_settings.phpt
@@ -1,0 +1,81 @@
+--TEST--
+swoole_client_coro: reject invalid TLS settings in enableSSL
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Client;
+use Swoole\Coroutine\Server;
+use Swoole\Coroutine\Server\Connection;
+
+use function Swoole\Coroutine\go;
+use function Swoole\Coroutine\run;
+
+Co::set(['log_file' => '/dev/null']);
+
+$serverResult = null;
+$warnings = [];
+
+run(function () use (&$serverResult, &$warnings) {
+    $server = new Server('127.0.0.1', 0, true);
+    $server->set([
+        'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+        'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+    ]);
+    $server->handle(function (Connection $conn) {
+        $data = $conn->recv();
+        $conn->send($data);
+    });
+    go(function () use ($server, &$serverResult) {
+        $serverResult = $server->start();
+    });
+
+    set_error_handler(function ($errno, $message) use (&$warnings) {
+        $warnings[] = $message;
+        return true;
+    });
+
+    $missingCert = __DIR__ . '/missing.crt';
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $server->port));
+    Assert::true($client->set([
+        'ssl_cert_file' => $missingCert,
+        // This setting used to be skipped after the invalid certificate while the handshake still succeeded.
+        'ssl_verify_peer' => true,
+    ]));
+    Assert::false($client->enableSSL());
+    Assert::eq($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::null($client->socket);
+    Assert::false($client->connected);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], "ssl cert file[{$missingCert}] not found");
+
+    Assert::false($client->enableSSL());
+    Assert::eq($client->errCode, SWOOLE_ERROR_CLIENT_NO_CONNECTION);
+
+    // Close the connection left open by the unfixed implementation.
+    $client->close();
+
+    restore_error_handler();
+
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $server->port));
+    Assert::true($client->set([
+        // Keep the settings array non-empty so enableSSL() applies it.
+        'ssl_verify_peer' => false,
+    ]));
+    Assert::true($client->enableSSL());
+    Assert::same($client->send('valid'), 5);
+    Assert::same($client->recv(), 'valid');
+    Assert::true($client->close());
+
+    $server->shutdown();
+});
+
+Assert::true($serverResult);
+?>
+--EXPECT--

--- a/tests/swoole_http2_client_coro/invalid_socket_settings.phpt
+++ b/tests/swoole_http2_client_coro/invalid_socket_settings.phpt
@@ -1,0 +1,56 @@
+--TEST--
+swoole_http2_client_coro: reject invalid socket settings
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http2\Client;
+
+use function Swoole\Coroutine\run;
+
+$server = stream_socket_server('tcp://127.0.0.1:0');
+$address = stream_socket_get_name($server, false);
+$port = (int) substr($address, strrpos($address, ':') + 1);
+$warnings = [];
+
+set_error_handler(function ($errno, $message) use (&$warnings) {
+    $warnings[] = $message;
+    return true;
+});
+
+run(function () use ($port, &$warnings) {
+    $client = new Client('127.0.0.1', $port);
+    Assert::true($client->set(['socks5_host' => '127.0.0.1']));
+
+    // A retained socket would skip the settings on the second call and emit only one warning.
+    $results = [$client->connect(), $client->connect()];
+    Assert::same($results, [false, false]);
+    Assert::same($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::null($client->socket);
+    Assert::count($warnings, 2);
+    foreach ($warnings as $warning) {
+        Assert::endsWith($warning, 'socks5_port should not be null');
+    }
+
+    $warnings = [];
+    $client = new Client('127.0.0.1', $port);
+    Assert::true($client->connect());
+    $result = $client->set(['socks5_host' => '127.0.0.1']);
+    // close() clears both properties, so capture the state after set() first.
+    $connected = $client->connected;
+    $socket = $client->socket;
+    $client->close();
+
+    Assert::false($result);
+    Assert::true($connected);
+    Assert::notNull($socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'socks5_port should not be null');
+});
+
+restore_error_handler();
+fclose($server);
+?>
+--EXPECT--

--- a/tests/swoole_http_client_coro/invalid_socket_settings.phpt
+++ b/tests/swoole_http_client_coro/invalid_socket_settings.phpt
@@ -1,0 +1,62 @@
+--TEST--
+swoole_http_client_coro: reject invalid socket settings
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http\Client;
+
+use function Swoole\Coroutine\run;
+
+$server = stream_socket_server('tcp://127.0.0.1:0');
+$address = stream_socket_get_name($server, false);
+$port = (int) substr($address, strrpos($address, ':') + 1);
+$warnings = [];
+
+set_error_handler(function ($errno, $message) use (&$warnings) {
+    $warnings[] = $message;
+    return true;
+});
+
+run(function () use ($port, &$warnings) {
+    $client = new Client('127.0.0.1', $port);
+    Assert::true($client->set([
+        'socks5_host' => '127.0.0.1',
+        // Bound the unpatched path, which connects directly and waits for a response.
+        'timeout' => 0.5,
+    ]));
+
+    // A retained socket would skip the settings on the second call and emit only one warning.
+    $results = [$client->get('/'), $client->get('/')];
+    Assert::same($results, [false, false]);
+    Assert::same($client->errCode, SWOOLE_ERROR_INVALID_PARAMS);
+    Assert::same($client->statusCode, SWOOLE_HTTP_CLIENT_ESTATUS_CONNECT_FAILED);
+    Assert::null($client->socket);
+    Assert::count($warnings, 2);
+    foreach ($warnings as $warning) {
+        Assert::endsWith($warning, 'socks5_port should not be null');
+    }
+
+    $warnings = [];
+    $client = new Client('127.0.0.1', $port);
+    Assert::true($client->set(['defer' => true]));
+    Assert::true($client->get('/'));
+    $result = $client->set(['socks5_host' => '127.0.0.1']);
+    // close() clears both properties, so capture the state after set() first.
+    $connected = $client->connected;
+    $socket = $client->socket;
+    $client->close();
+
+    Assert::false($result);
+    Assert::true($connected);
+    Assert::notNull($socket);
+    Assert::count($warnings, 1);
+    Assert::endsWith($warnings[0], 'socks5_port should not be null');
+});
+
+restore_error_handler();
+fclose($server);
+?>
+--EXPECT--


### PR DESCRIPTION
`Swoole\Coroutine\Client`, `Http\Client`, and `Http2\Client` store socket settings until a socket exists. Errors while applying them were ignored. Invalid proxy settings could connect to the target instead of through the proxy, and `enableSSL()` could continue after its TLS settings were rejected.

Stop when deferred settings are invalid—before connecting, or before the TLS handshake on an upgrade. A TLS settings failure closes the partially configured socket; normal handshake failures keep their existing behavior. A failed `set()` on an established connection returns `false` without closing it.

`Swoole\Coroutine\Client::$fd` now reports `-1` after `close()` and after rejected setup, instead of keeping a released descriptor. Proxy credential failures also distinguish an empty username from a missing password and name the correct setting.

Tests cover invalid proxy, protocol, and TLS settings, cleanup and retry, established connections, descriptor state, and proxy credential warnings.