### PR TITLE
Fix UNIX datagram address ownership

### DIFF
--- a/include/swoole_socket.h
+++ b/include/swoole_socket.h
@@ -204,7 +204,6 @@ struct Socket {
     uchar nonblock : 1;
     uchar cloexec : 1;
     uchar direct_send : 1;
-    uchar bound : 1;
     uchar listened : 1;
 #ifdef SW_USE_OPENSSL
     uchar ssl_send_ : 1;
@@ -245,9 +244,11 @@ struct Socket {
 #endif
 
     /**
-     * Only used for getsockname, written by the OS, not user. This is the exact actual address.
+     * The local address written by get_name(), or the peer address written by accept() or recvfrom().
+     * Local UNIX sockets keep their cleanup path separately in bind_path.
      */
     Address info;
+    std::string bind_path;
     double dns_timeout = default_dns_timeout;
     double connect_timeout = default_connect_timeout;
     double read_timeout = default_read_timeout;

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1346,6 +1346,10 @@ ssize_t Socket::recvfrom(void *_buf, size_t _n) {
     if (sw_unlikely(!is_available(SW_EVENT_READ))) {
         return -1;
     }
+    // The kernel writes no address for an unnamed UNIX peer, so stale bytes must not survive.
+    if (socket->is_local()) {
+        memset(&socket->info.addr, 0, sizeof(socket->info.addr));
+    }
     socket->info.len = sizeof(socket->info.addr);
     return recvfrom(_buf, _n, reinterpret_cast<sockaddr *>(&socket->info.addr), &socket->info.len);
 }

--- a/src/network/socket.cc
+++ b/src/network/socket.cc
@@ -450,8 +450,8 @@ ssize_t Socket::recvfrom_sync(char *buf, size_t len, int flags, sockaddr *addr, 
 
 static void socket_free_defer(void *ptr) {
     auto *sock = static_cast<Socket *>(ptr);
-    if (sock->is_local() && sock->bound) {
-        ::unlink(sock->get_addr());
+    if (!sock->bind_path.empty()) {
+        ::unlink(sock->bind_path.c_str());
     }
     if (sock->fd != -1 && close(sock->fd) != 0) {
         swoole_sys_warning("close(%d) failed", sock->fd);
@@ -523,7 +523,11 @@ int Socket::bind(const struct sockaddr *sa, socklen_t len) {
     if (::bind(fd, sa, len) < 0) {
         return SW_ERR;
     }
-    bound = 1;
+    if (is_local() && sa->sa_family == AF_UNIX) {
+        auto *un = reinterpret_cast<const sockaddr_un *>(sa);
+        size_t path_max = len > offsetof(sockaddr_un, sun_path) ? len - offsetof(sockaddr_un, sun_path) : 0;
+        bind_path.assign(un->sun_path, strnlen(un->sun_path, SW_MIN(path_max, sizeof(un->sun_path))));
+    }
     return SW_OK;
 }
 

--- a/tests/swoole_socket_coro/unix_dgram_address.phpt
+++ b/tests/swoole_socket_coro/unix_dgram_address.phpt
@@ -1,0 +1,79 @@
+--TEST--
+swoole_socket_coro: keep bound and peer unix dgram addresses separate
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$receiverPath = '/tmp/swoole-unix-dgram-receiver.sock';
+$peerPath = '/tmp/swoole-unix-dgram-peer.sock';
+$unboundReceiverPath = '/tmp/swoole-unix-dgram-unbound-receiver.sock';
+
+@unlink($receiverPath);
+@unlink($peerPath);
+@unlink($unboundReceiverPath);
+
+$boundPeer = null;
+$boundPeerAddress = null;
+$unboundPeerAddress = null;
+
+go(function () use (
+    $receiverPath,
+    $peerPath,
+    $unboundReceiverPath,
+    &$boundPeer,
+    &$boundPeerAddress,
+    &$unboundPeerAddress
+) {
+    $receiver = new Swoole\Coroutine\Socket(AF_UNIX, SOCK_DGRAM, IPPROTO_IP);
+    $boundPeer = new Swoole\Coroutine\Socket(AF_UNIX, SOCK_DGRAM, IPPROTO_IP);
+    Assert::true($receiver->bind($receiverPath));
+    Assert::true($boundPeer->bind($peerPath));
+    Assert::same($boundPeer->sendto($receiverPath, 0, 'hello'), 5);
+    Assert::same($receiver->recvfrom($boundPeerInfo), 'hello');
+    $boundPeerAddress = $boundPeerInfo['address'];
+    unset($receiver);
+
+    $receiver = new Swoole\Coroutine\Socket(AF_UNIX, SOCK_DGRAM, IPPROTO_IP);
+    $unboundPeer = new Swoole\Coroutine\Socket(AF_UNIX, SOCK_DGRAM, IPPROTO_IP);
+    Assert::true($receiver->bind($unboundReceiverPath));
+    Assert::same($unboundPeer->sendto($unboundReceiverPath, 0, 'hello'), 5);
+    Assert::same($receiver->recvfrom($unboundPeerInfo), 'hello');
+    $unboundPeerAddress = $unboundPeerInfo['address'];
+});
+Swoole\Event::wait();
+
+$result = [
+    'receiver_removed' => !file_exists($receiverPath),
+    'peer_preserved' => file_exists($peerPath),
+    'bound_peer_address' => $boundPeerAddress,
+    'unbound_peer_address' => $unboundPeerAddress,
+];
+
+unset($boundPeer);
+$result['peer_removed'] = !file_exists($peerPath);
+
+var_dump($result);
+echo "DONE\n";
+?>
+--CLEAN--
+<?php
+@unlink('/tmp/swoole-unix-dgram-receiver.sock');
+@unlink('/tmp/swoole-unix-dgram-peer.sock');
+@unlink('/tmp/swoole-unix-dgram-unbound-receiver.sock');
+?>
+--EXPECT--
+array(5) {
+  ["receiver_removed"]=>
+  bool(true)
+  ["peer_preserved"]=>
+  bool(true)
+  ["bound_peer_address"]=>
+  string(32) "/tmp/swoole-unix-dgram-peer.sock"
+  ["unbound_peer_address"]=>
+  string(0) ""
+  ["peer_removed"]=>
+  bool(true)
+}
+DONE


### PR DESCRIPTION
UNIX datagram sockets used the same address field for the bound path and the most recent peer. After `recvfrom()`, cleanup could unlink the peer path and leave the socket’s own path behind. An unnamed peer could also return stale address data.

This stores the bound path separately and clears the local peer address before `recvfrom()`. The regression covers cleanup and both bound and unbound peer addresses.

The existing UNIX datagram test did not expose this because its equal-length socket paths deleted each other during cleanup.
