### PR TITLE
Fix Coroutine HTTP server startup failures

### DIFF
--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -429,7 +429,13 @@ static PHP_METHOD(swoole_http_server_coro, start) {
     /* check settings */
     zval *zsettings =
         sw_zend_read_and_convert_property_array(swoole_http_server_coro_ce, ZEND_THIS, ZEND_STRL("settings"), 0);
-    php_swoole_socket_set_protocol(hs->socket, zsettings);
+    if (!php_swoole_socket_set_protocol(hs->socket, zsettings)) {
+        zend_update_property_long(swoole_http_server_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("errCode"), EINVAL);
+        zend_update_property_string(
+            swoole_http_server_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("errMsg"), swoole_strerror(EINVAL));
+        hs->running = false;
+        RETURN_FALSE;
+    }
     HashTable *vht = Z_ARRVAL_P(zsettings);
     zval *ztmp;
     // parse cookie header
@@ -522,7 +528,9 @@ static PHP_METHOD(swoole_http_server_coro, start) {
             } else {
                 http_server_coro_set_error(ZEND_THIS, sock);
                 php_swoole_fatal_error(E_WARNING, "accept failed, Error: %s[%d]", sock->errMsg, sock->errCode);
-                break;
+                // Stop keep-alive connections after the listener can no longer accept.
+                hs->running = false;
+                RETURN_FALSE;
             }
         }
     }

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1149,7 +1149,7 @@ bool Socket::ssl_context_create() {
     }
     ssl_context->http_v2 = http2;
     if (!ssl_context->create()) {
-        set_err();
+        set_err(SW_ERROR_SSL_CREATE_CONTEXT_FAILED);
         return false;
     }
     socket->ssl_send_ = 1;

--- a/tests/swoole_http_server_coro/accept_failure.phpt
+++ b/tests/swoole_http_server_coro/accept_failure.phpt
@@ -1,0 +1,36 @@
+--TEST--
+swoole_http_server_coro: report an accept failure
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+
+$warnings = [];
+set_error_handler(function ($errno, $message) use (&$warnings) {
+    $warnings[] = $message;
+    return true;
+});
+
+Coroutine\run(function () {
+    $server = new Server('127.0.0.1', 0, true);
+    Assert::true($server->set([
+        'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+        'ssl_key_file' => SSL_FILE_DIR . '/client.key',
+    ]));
+    Assert::false($server->start());
+    Assert::same($server->errCode, SWOOLE_ERROR_SSL_CREATE_CONTEXT_FAILED);
+});
+
+restore_error_handler();
+Assert::count($warnings, 1);
+Assert::startsWith($warnings[0], 'Swoole\\Coroutine\\Http\\Server::start(): accept failed, Error: ');
+?>
+--EXPECTF--
+[%s]	WARNING	SSLContext::create(): SSL_CTX_use_PrivateKey_file(%s) failed, Error: %s[%d]

--- a/tests/swoole_http_server_coro/invalid_settings.phpt
+++ b/tests/swoole_http_server_coro/invalid_settings.phpt
@@ -1,0 +1,53 @@
+--TEST--
+swoole_http_server_coro: reject invalid startup settings
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+
+$warnings = [];
+set_error_handler(function ($errno, $message) use (&$warnings) {
+    $warnings[] = $message;
+    return true;
+});
+
+Coroutine\run(function () use (&$warnings) {
+    $server = new Server('127.0.0.1', 0);
+    $server->handle('/', function ($request, $response) use ($server) {
+        $response->end('OK');
+        $server->shutdown();
+    });
+    Assert::true($server->set(['package_length_type' => '?']));
+
+    $cid = Coroutine::create(function () use ($server) {
+        Coroutine::sleep(0.01);
+        $server->shutdown();
+    });
+
+    // The warning is emitted on the unchanged branch too; the return value proves the setting was rejected.
+    Assert::false($server->start());
+    Assert::true(Coroutine::join([$cid]));
+    Assert::same($server->errCode, SOCKET_EINVAL);
+    Assert::same($server->errMsg, swoole_strerror(SOCKET_EINVAL));
+    Assert::same($warnings, [
+        "Swoole\\Coroutine\\Http\\Server::start(): Unknown package_length_type name '?', see pack(). Link: https://php.net/pack",
+    ]);
+
+    $warnings = [];
+    Assert::true($server->set(['package_length_type' => 'N']));
+    $cid = Coroutine::create(function () use ($server) {
+        Coroutine::sleep(0.01);
+        Assert::same(httpGetBody("http://127.0.0.1:{$server->port}/"), 'OK');
+    });
+    Assert::true($server->start());
+    Assert::true(Coroutine::join([$cid]));
+    Assert::same($warnings, []);
+});
+
+restore_error_handler();
+?>
+--EXPECT--


### PR DESCRIPTION
`Swoole\Coroutine\Http\Server::start()` returned true when protocol settings were rejected or the accept loop stopped on a terminal error.

This returns false for both cases and preserves the listener so callers can fix settings and start the same server again.

SSL context creation now reports `SW_ERROR_SSL_CREATE_CONTEXT_FAILED` instead of inherited `errno` state. This gives the server a stable error and prevents the accept loop from treating the failure as a retryable socket error.

The tests cover invalid settings, reuse after correcting them, and SSL accept setup failure.