### PR TITLE
Fix WebSocket ping failure handling

### DIFF
--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -1210,7 +1210,11 @@ static PHP_METHOD(swoole_http_response, ping) {
     } else if (ctx->websocket) {
         String *buffer = ctx->get_write_buffer();
         buffer->clear();
-        WebSocket::encode(buffer, ZSTR_VAL(zdata), ZSTR_LEN(zdata), WebSocket::OPCODE_PING, WebSocket::FLAG_FIN);
+        if (sw_unlikely(!WebSocket::encode(
+                buffer, ZSTR_VAL(zdata), ZSTR_LEN(zdata), WebSocket::OPCODE_PING, WebSocket::FLAG_FIN))) {
+            swoole_set_last_error(SW_ERROR_WEBSOCKET_PACK_FAILED);
+            RETURN_FALSE;
+        }
         RETURN_BOOL(ctx->send(ctx, buffer->str, buffer->length));
     } else {
         php_swoole_fatal_error(E_WARNING, "only supports websocket or http2 client");

--- a/tests/swoole_http_server_coro/ping.phpt
+++ b/tests/swoole_http_server_coro/ping.phpt
@@ -7,8 +7,6 @@ swoole_http_server_coro: test ping function
 require __DIR__ . '/../include/bootstrap.php';
 use Swoole\Coroutine\Http\Client;
 use Swoole\Coroutine\Http\Server;
-use Swoole\Http\Request;
-use Swoole\Http\Response;
 use SwooleTest\ProcessManager as ProcessManager;
 
 $pm = new ProcessManager;
@@ -19,12 +17,15 @@ $pm->parentFunc = function (int $pid) use ($pm) {
         Assert::true($client->upgrade('/'));
         Assert::true($client->push('Hello World'));
         $frame = $client->recv();
-        Assert::true($frame->opcode == SWOOLE_WEBSOCKET_OPCODE_PING);
-        Assert::true($frame->data == 'Hello World');
+        Assert::same($frame->opcode, SWOOLE_WEBSOCKET_OPCODE_PING);
+        Assert::same($frame->data, str_repeat('A', 125));
+        $frame = $client->recv();
+        Assert::same($frame->opcode, SWOOLE_WEBSOCKET_OPCODE_PING);
+        Assert::same($frame->data, 'Hello World');
         Assert::true($client->ping());
         $frame = $client->recv();
-        Assert::true($frame->opcode == SWOOLE_WEBSOCKET_OPCODE_PING);
-        Assert::true($frame->data == '');
+        Assert::same($frame->opcode, SWOOLE_WEBSOCKET_OPCODE_PING);
+        Assert::same($frame->data, '');
     });
     $pm->kill();
 };
@@ -35,8 +36,11 @@ $pm->childFunc = function () use ($pm) {
         $server->handle('/', function ($request, $response) {
             $response->upgrade();
             $response->recv();
-            $response->ping('Hello World');
-            $response->ping();
+            Assert::false($response->ping(str_repeat('A', 126)));
+            Assert::same(swoole_last_error(), SWOOLE_ERROR_WEBSOCKET_PACK_FAILED);
+            Assert::true($response->ping(str_repeat('A', 125)));
+            Assert::true($response->ping('Hello World'));
+            Assert::true($response->ping());
         });
         $pm->wakeup();
         $server->start();
@@ -46,4 +50,5 @@ $pm->childFunc = function () use ($pm) {
 $pm->childFirst();
 $pm->run();
 ?>
---EXPECT--
+--EXPECTF--
+[%s]	WARNING	websocket::encode(): invalid websocket control frame: opcode=9, fin=1, payload_length=126


### PR DESCRIPTION
Response::ping() ignored the result of WebSocket::encode(). When the encoder rejected an oversized control-frame payload, ping() sent the empty buffer and returned true without sending a frame.

It now checks the encoder result, sets SWOOLE_ERROR_WEBSOCKET_PACK_FAILED, and returns false before sending.

The existing ping test covers both sides of the 125-byte control-frame limit and exercises the encoder guard.