### PR TITLE
Fix cancellation during hooked TLS connect

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -926,7 +926,7 @@ static inline int socket_xport_api(php_stream *stream, Socket *sock, php_stream_
     case STREAM_XPORT_OP_CONNECT_ASYNC:
         xparam->outputs.returncode = socket_connect(stream, sock, xparam);
 #ifdef SW_USE_OPENSSL
-        if (sock->ssl_is_enable() &&
+        if (xparam->outputs.returncode == 0 && sock->ssl_is_enable() &&
             (socket_xport_crypto_setup(stream) < 0 || socket_xport_crypto_enable(stream, 1) < 0)) {
             xparam->outputs.returncode = -1;
         }

--- a/tests/swoole_runtime/ssl/cancel_connect.phpt
+++ b/tests/swoole_runtime/ssl/cancel_connect.phpt
@@ -1,0 +1,78 @@
+--TEST--
+swoole_runtime/ssl: cancel connect
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\Server;
+use Swoole\Coroutine\Server\Connection;
+use Swoole\Runtime;
+
+use function Swoole\Coroutine\go;
+use function Swoole\Coroutine\run;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_TCP | SWOOLE_HOOK_TLS);
+
+run(function () {
+    $server = new Server('127.0.0.1');
+    $connected = new Channel(1);
+    $release = new Channel(1);
+
+    go(function () use ($server, $connected, $release) {
+        $server->handle(function (Connection $conn) use ($server, $connected, $release) {
+            Assert::stringNotEmpty($conn->recv());
+            $connected->push(true);
+            $release->pop();
+            $conn->close();
+            $server->shutdown();
+        });
+        $server->start();
+    });
+
+    $canceled = false;
+    $cid = go(function () use ($server, &$canceled) {
+        $context = stream_context_create([
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+            ],
+        ]);
+
+        try {
+            stream_socket_client(
+                "tls://127.0.0.1:{$server->port}",
+                $errno,
+                $errstr,
+                30,
+                STREAM_CLIENT_CONNECT,
+                $context
+            );
+        } catch (CanceledException $e) {
+            $canceled = true;
+        }
+    });
+
+    $connected->pop();
+    Assert::true(Coroutine::cancel($cid, true));
+
+    try {
+        Assert::false(Coroutine::exists($cid));
+        Assert::true($canceled);
+    } finally {
+        $release->push(true);
+    }
+});
+
+echo "DONE\n";
+?>
+--EXPECTF--
+Warning: stream_socket_client(): Unable to connect to tls://127.0.0.1:%d (Operation canceled) in %s on line %d
+DONE


### PR DESCRIPTION
Hooked TLS streams complete their handshake during the socket connect. When that connect is canceled, the stream transport still tries to enable crypto again. Cancellation is deferred until another peer event, and its observable state is lost. If the peer responds, the redundant handshake can complete even though its result is discarded.

Only run the post-connect crypto step after a successful connect. Successful connections still use it for peer certificate capture.

The regression test holds a TLS handshake open, cancels the client, and verifies that cancellation finishes before the peer is released.