### PR TITLE
Skip stale reactor readiness events

### DIFF
--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -338,6 +338,45 @@ TEST(reactor, poll) {
     reactor_test_func(&reactor);
 }
 
+static void test_stale_event(Reactor::Type type) {
+    UnixSocket p(false, SOCK_STREAM);
+    ASSERT_TRUE(p.ready());
+
+    Reactor reactor(1024, type);
+    reactor.once = true;
+
+    int write_count = 0;
+
+    reactor.set_handler(SW_FD_STREAM, SW_EVENT_READ, [](Reactor *reactor, Event *event) -> int {
+        char data;
+        ssize_t n = event->socket->read(&data, sizeof(data));
+        EXPECT_EQ(n, 1);
+        EXPECT_EQ(reactor->set(event->socket, SW_EVENT_READ), SW_OK);
+        return SW_OK;
+    });
+    reactor.set_handler(SW_FD_STREAM, SW_EVENT_WRITE, [](Reactor *, Event *event) -> int {
+        (*(int *) event->socket->object)++;
+        return SW_OK;
+    });
+
+    auto socket = p.get_socket(false);
+    socket->fd_type = SW_FD_STREAM;
+    socket->object = &write_count;
+    ASSERT_EQ(reactor.add(socket, SW_EVENT_READ | SW_EVENT_WRITE), SW_OK);
+    ASSERT_EQ(p.get_socket(true)->write("x", 1), 1);
+    ASSERT_EQ(reactor.wait(), SW_OK);
+    ASSERT_EQ(socket->events, SW_EVENT_READ);
+    ASSERT_EQ(write_count, 0);
+}
+
+TEST(reactor, epoll_stale_event) {
+    test_stale_event(Reactor::TYPE_EPOLL);
+}
+
+TEST(reactor, poll_stale_event) {
+    test_stale_event(Reactor::TYPE_POLL);
+}
+
 TEST(reactor, poll_extra) {
     Reactor reactor(32, Reactor::TYPE_POLL);
 

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -48,7 +48,7 @@ int Socket::readable_event_callback(Reactor *reactor, Event *event) {
     socket->set_err(0);
 #ifdef SW_USE_OPENSSL
     if (sw_unlikely(socket->want_event != SW_EVENT_NULL)) {
-        if (socket->want_event == SW_EVENT_READ) {
+        if (socket->want_event == SW_EVENT_READ && socket->write_co) {
             socket->write_co->resume();
         }
     } else
@@ -57,7 +57,9 @@ int Socket::readable_event_callback(Reactor *reactor, Event *event) {
         if (socket->recv_barrier && (*socket->recv_barrier)() && !event->socket->event_hup) {
             return SW_OK;
         }
-        socket->read_co->resume();
+        if (socket->read_co) {
+            socket->read_co->resume();
+        }
     }
 
     return SW_OK;
@@ -68,7 +70,7 @@ int Socket::writable_event_callback(Reactor *reactor, Event *event) {
     socket->set_err(0);
 #ifdef SW_USE_OPENSSL
     if (sw_unlikely(socket->want_event != SW_EVENT_NULL)) {
-        if (socket->want_event == SW_EVENT_WRITE) {
+        if (socket->want_event == SW_EVENT_WRITE && socket->read_co) {
             socket->read_co->resume();
         }
     } else
@@ -77,7 +79,9 @@ int Socket::writable_event_callback(Reactor *reactor, Event *event) {
         if (socket->send_barrier && (*socket->send_barrier)() && !event->socket->event_hup) {
             return SW_OK;
         }
-        socket->write_co->resume();
+        if (socket->write_co) {
+            socket->write_co->resume();
+        }
     }
 
     return SW_OK;

--- a/src/reactor/epoll.cc
+++ b/src/reactor/epoll.cc
@@ -210,7 +210,8 @@ int ReactorEpoll::wait() {
                 event.socket->event_hup = 1;
             }
             // read
-            if ((events_[i].events & EPOLLIN) && !event.socket->removed) {
+            if ((events_[i].events & EPOLLIN) && !event.socket->removed &&
+                Reactor::isset_read_event(event.socket->events)) {
                 handler = reactor_->get_handler(event.type, SW_EVENT_READ);
                 ret = handler(reactor_, &event);
                 if (ret < 0) {
@@ -218,7 +219,8 @@ int ReactorEpoll::wait() {
                 }
             }
             // write
-            if ((events_[i].events & EPOLLOUT) && !event.socket->removed) {
+            if ((events_[i].events & EPOLLOUT) && !event.socket->removed &&
+                Reactor::isset_write_event(event.socket->events)) {
                 handler = reactor_->get_handler(event.type, SW_EVENT_WRITE);
                 ret = handler(reactor_, &event);
                 if (ret < 0) {

--- a/src/reactor/kqueue.cc
+++ b/src/reactor/kqueue.cc
@@ -300,9 +300,11 @@ int ReactorKqueue::wait() {
             switch (kevent->filter) {
             case EVFILT_READ:
             case EVFILT_WRITE: {
-                if (fetch_event(&event, udata)) {
-                    handler = reactor_->get_handler(event.type,
-                                                    kevent->filter == EVFILT_READ ? SW_EVENT_READ : SW_EVENT_WRITE);
+                const EventType ev = kevent->filter == EVFILT_READ ? SW_EVENT_READ : SW_EVENT_WRITE;
+                if (fetch_event(&event, udata) &&
+                    (ev == SW_EVENT_READ ? Reactor::isset_read_event(event.socket->events)
+                                         : Reactor::isset_write_event(event.socket->events))) {
+                    handler = reactor_->get_handler(event.type, ev);
                     if (sw_unlikely(handler(reactor_, &event) < 0)) {
                         swoole_sys_warning("kqueue event %s socket#%d handler failed",
                                            kevent->filter == EVFILT_READ ? "read" : "write",

--- a/src/reactor/poll.cc
+++ b/src/reactor/poll.cc
@@ -188,7 +188,8 @@ int ReactorPoll::wait() {
                 }
                 swoole_trace("Event: fd=%d|reactor_id=%d|type=%d", event.fd, reactor_->id, event.type);
                 // in
-                if ((events_[i].revents & POLLIN) && !event.socket->removed) {
+                if ((events_[i].revents & POLLIN) && !event.socket->removed &&
+                    Reactor::isset_read_event(event.socket->events)) {
                     handler = reactor_->get_handler(event.type, SW_EVENT_READ);
                     ret = handler(reactor_, &event);
                     if (ret < 0) {
@@ -197,7 +198,8 @@ int ReactorPoll::wait() {
                     }
                 }
                 // out
-                if ((events_[i].revents & POLLOUT) && !event.socket->removed) {
+                if ((events_[i].revents & POLLOUT) && !event.socket->removed &&
+                    Reactor::isset_write_event(event.socket->events)) {
                     handler = reactor_->get_handler(event.type, SW_EVENT_WRITE);
                     ret = handler(reactor_, &event);
                     if (ret < 0) {


### PR DESCRIPTION
A native wait can report read and write readiness for the same socket. If the first handler changes the socket's registered events, epoll, poll, and kqueue could still dispatch a later event that is no longer registered. For coroutine sockets, that could try to resume a waiter that has already been cleared.

Check the socket's current event before each dispatch, using the same predicates used when events are registered. Also ignore coroutine callbacks when no waiter remains.

The regression test changes a socket from read/write to read-only inside the read handler and verifies that the pending write event is skipped. The kqueue change is compiled by macOS CI.

This change is independent of #6182.
