### PR TITLE
Fix poll dispatch after file descriptor reuse

### DIFF
--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -338,6 +338,76 @@ TEST(reactor, poll) {
     reactor_test_func(&reactor);
 }
 
+struct PollSocketState {
+    network::Socket *sockets[2];
+    network::Socket *dispatched_socket = nullptr;
+    network::Socket *replacement_socket = nullptr;
+    int source_fd = -1;
+    int replacement_count = 0;
+};
+
+TEST(reactor, poll_readiness_after_fd_reuse) {
+    UnixSocket sockets[2] = {
+        UnixSocket(false, SOCK_STREAM),
+        UnixSocket(false, SOCK_STREAM),
+    };
+    ASSERT_TRUE(sockets[0].ready());
+    ASSERT_TRUE(sockets[1].ready());
+
+    int pipe_fds[2];
+    ASSERT_EQ(pipe(pipe_fds), 0);
+
+    Reactor reactor(32, Reactor::TYPE_POLL);
+    reactor.once = true;
+
+    PollSocketState state;
+    state.sockets[0] = sockets[0].get_socket(false);
+    state.sockets[1] = sockets[1].get_socket(false);
+    state.source_fd = pipe_fds[0];
+    state.sockets[0]->fd_type = SW_FD_STREAM;
+    state.sockets[1]->fd_type = SW_FD_STREAM;
+    state.sockets[0]->object = &state;
+    state.sockets[1]->object = &state;
+
+    reactor.set_handler(SW_FD_STREAM, SW_EVENT_READ, [](Reactor *reactor, Event *event) -> int {
+        auto *state = static_cast<PollSocketState *>(event->socket->object);
+        char data;
+        EXPECT_EQ(event->socket->read(&data, sizeof(data)), 1);
+        state->dispatched_socket = event->socket;
+
+        network::Socket *other_socket = event->socket == state->sockets[0] ? state->sockets[1] : state->sockets[0];
+        EXPECT_EQ(reactor->del(other_socket), SW_OK);
+        const int fd = other_socket->move_fd();
+        EXPECT_EQ(dup2(state->source_fd, fd), fd);
+
+        state->replacement_socket = make_socket(fd, SW_FD_USER);
+        state->replacement_socket->object = &state->replacement_count;
+        EXPECT_EQ(reactor->add(state->replacement_socket, SW_EVENT_READ), SW_OK);
+        return SW_OK;
+    });
+    reactor.set_handler(SW_FD_USER, SW_EVENT_READ, [](Reactor *, Event *event) -> int {
+        (*(int *) event->socket->object)++;
+        return SW_OK;
+    });
+
+    ASSERT_EQ(reactor.add(state.sockets[0], SW_EVENT_READ), SW_OK);
+    ASSERT_EQ(reactor.add(state.sockets[1], SW_EVENT_READ), SW_OK);
+    ASSERT_EQ(sockets[0].get_socket(true)->write("x", 1), 1);
+    ASSERT_EQ(sockets[1].get_socket(true)->write("x", 1), 1);
+    ASSERT_EQ(reactor.wait(), SW_OK);
+
+    ASSERT_EQ(state.replacement_count, 0);
+    ASSERT_NE(state.dispatched_socket, nullptr);
+    ASSERT_NE(state.replacement_socket, nullptr);
+
+    // A local Reactor does not defer Socket::free(), so release sockets after the batch.
+    ASSERT_EQ(reactor.del(state.dispatched_socket), SW_OK);
+    ASSERT_EQ(reactor.del(state.replacement_socket), SW_OK);
+    state.replacement_socket->free();
+    ASSERT_EQ(close(pipe_fds[0]), 0);
+    ASSERT_EQ(close(pipe_fds[1]), 0);
+}
+
 TEST(reactor, poll_extra) {
     Reactor reactor(32, Reactor::TYPE_POLL);
 

--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -438,7 +438,7 @@ TEST(reactor, poll_extra) {
     ASSERT_EQ(reactor.del(&fake_sock3), SW_ERR);
     ASSERT_EQ(swoole_get_last_error(), SW_ERROR_SOCKET_NOT_EXISTS);
 
-    network::Socket fake_socks[32];
+    network::Socket fake_socks[32]{};
     SW_LOOP_N(32) {
         fake_socks[i].fd = i + 1024;
         if (i <= 30) {
@@ -448,8 +448,7 @@ TEST(reactor, poll_extra) {
         }
     }
 
-    for (auto i = 31; i <= 0; i--) {
-        fake_socks[i].fd = i + 1024;
+    for (auto i = 31; i >= 0; i--) {
         if (i <= 30) {
             ASSERT_EQ(reactor.del(&fake_socks[i]), SW_OK);
         } else {

--- a/src/reactor/poll.cc
+++ b/src/reactor/poll.cc
@@ -22,6 +22,7 @@ using network::Socket;
 
 class ReactorPoll final : public ReactorImpl {
     pollfd *events_;
+    Socket **event_sockets_;
     int max_events_;
     int set_events() const;
 
@@ -43,22 +44,25 @@ ReactorImpl *make_reactor_poll(Reactor *_reactor, int max_events) {
 
 ReactorPoll::ReactorPoll(Reactor *_reactor, int max_events) : ReactorImpl(_reactor) {
     events_ = new pollfd[max_events];
+    event_sockets_ = new Socket *[max_events];
     max_events_ = max_events;
     reactor_->max_event_num = max_events;
 }
 
 ReactorPoll::~ReactorPoll() {
     delete[] events_;
+    delete[] event_sockets_;
 }
 
 int ReactorPoll::set_events() const {
-    const auto sockets = reactor_->get_sockets();
+    const auto &sockets = reactor_->get_sockets();
     int count = 0;
-    for (const auto pair : sockets) {
+    for (const auto &pair : sockets) {
         const auto _socket = pair.second;
         events_[count].fd = _socket->fd;
         events_[count].events = translate_events_to_poll(_socket->events);
         events_[count].revents = 0;
+        event_sockets_[count] = _socket;
         count++;
     }
     return count;
@@ -166,19 +170,13 @@ int ReactorPoll::wait() {
             SW_REACTOR_CONTINUE;
         } else {
             for (int i = 0; i < event_num; i++) {
-                /**
-                 * A revents value of 0 indicates that no events have occurred on this socket,
-                 * so the next file descriptor should be checked;
-                 * likewise, if the file descriptor has already been removed, it should be skipped.
-                 * It is essential to check whether this file descriptor exists in the reactor,
-                 * as the event handler may remove a file descriptor with pending but already triggered readable or
-                 * writable events that have not yet been processed.
-                 */
-                if (events_[i].revents == 0 || !reactor_->exists(events_[i].fd)) {
+                if (events_[i].revents == 0) {
                     continue;
                 }
 
-                event.socket = reactor_->get_socket(events_[i].fd);
+                // An earlier handler may remove a socket and register a new one on the same fd, so dispatch the
+                // socket this entry was built from rather than whichever socket now holds that fd.
+                event.socket = event_sockets_[i];
                 event.fd = events_[i].fd;
                 event.reactor_id = reactor_->id;
                 event.type = event.socket->fd_type;


### PR DESCRIPTION
The poll reactor resolves ready file descriptors through the current registration table. If a callback replaces another socket with the same descriptor, a later result from that poll batch can be sent to the new socket.

Epoll keeps each result bound to the socket stored in the kernel event. Give poll the same guarantee by storing the socket beside each `pollfd`. Existing `removed` checks still suppress sockets removed by an earlier handler, without copying the registration table or repeating its lookups.

Also repair the dead removal loop in the existing poll capacity test so its deletion assertions run.

Poll is the default reactor on macOS and BSD unless kqueue is enabled.