### PR TITLE
Fix coroutine exception delivery during SPL directory iteration

### DIFF
--- a/ext-src/php_swoole_coroutine.h
+++ b/ext-src/php_swoole_coroutine.h
@@ -60,6 +60,7 @@ struct PHPContext {
     zend_error_handling_t error_handling;
     zend_class_entry *exception_class;
     zend_object *exception;
+    const zend_op *opline_before_exception;
     zend_output_globals *output_ptr;
     /*
      * for var serialize/unserialize,
@@ -259,6 +260,7 @@ class PHPCoroutine {
         main_context.co = nullptr;
         main_context.fiber_context = EG(main_fiber_context);
         main_context.fiber_init_notified = true;
+        EG(opline_before_exception) = nullptr;
         save_context(&main_context);
     }
 

--- a/ext-src/swoole_coroutine.cc
+++ b/ext-src/swoole_coroutine.cc
@@ -333,6 +333,7 @@ PHPContext *PHPCoroutine::create_context(const Args *args) {
     EG(error_handling) = EH_NORMAL;
     EG(exception_class) = nullptr;
     EG(exception) = nullptr;
+    EG(opline_before_exception) = nullptr;
     EG(jit_trace_num) = 0;
 
     call->func = static_cast<zend_function *>(&swoole_coroutine_internal_function);
@@ -534,6 +535,7 @@ inline void PHPCoroutine::save_vm_stack(PHPContext *ctx) {
     ctx->error_handling = EG(error_handling);
     ctx->exception_class = EG(exception_class);
     ctx->exception = EG(exception);
+    ctx->opline_before_exception = EG(opline_before_exception);
     if (UNEXPECTED(ctx->in_silence)) {
         ctx->tmp_error_reporting = EG(error_reporting);
         EG(error_reporting) = ctx->ori_error_reporting;
@@ -555,6 +557,7 @@ inline void PHPCoroutine::restore_vm_stack(PHPContext *ctx) {
     EG(error_handling) = ctx->error_handling;
     EG(exception_class) = ctx->exception_class;
     EG(exception) = ctx->exception;
+    EG(opline_before_exception) = ctx->opline_before_exception;
     if (UNEXPECTED(ctx->in_silence)) {
         EG(error_reporting) = ctx->tmp_error_reporting;
     }
@@ -1361,29 +1364,57 @@ static PHP_METHOD(swoole_coroutine, cancel) {
     if (throw_exception) {
         auto *task = PHPCoroutine::get_context_by_cid(cid);
         // The coroutine does not exist or is not a PHP coroutine, and cannot be canceled or throw an exception
-        if (!task) {
+        if (!task || !task->co) {
             swoole_set_last_error(SW_ERROR_CO_NOT_EXISTS);
             RETURN_FALSE;
         }
 
-        if (task->exception && task->exception_class == swoole_coroutine_canceled_exception_ce) {
+        bool is_current = task->co == Coroutine::get_current();
+        if (!is_current && task->exception && task->exception_class == swoole_coroutine_canceled_exception_ce) {
             swoole_set_last_error(SW_ERROR_CO_CANCELED);
             RETURN_FALSE;
         }
 
+        zend_object *exception = zend_objects_new(swoole_coroutine_canceled_exception_ce);
+        object_properties_init(exception, swoole_coroutine_canceled_exception_ce);
+
+        // The live Co::cancel frame is internal, so Zend redirects the user caller when this call
+        // returns; the saved context describes a stale frame and must not be written here.
+        if (is_current) {
+            zend_string *filename = zend_get_executed_filename_ex();
+            if (filename) {
+                zend::object_set(exception, ZSTR_KNOWN(ZEND_STR_FILE), filename);
+                zend::object_set(exception, ZSTR_KNOWN(ZEND_STR_LINE), zend_get_executed_lineno());
+            }
+            zval zexception;
+            ZVAL_OBJ(&zexception, exception);
+            zend_throw_exception_object(&zexception);
+            RETURN_THROWS();
+        }
+
         zend_object *previous = task->exception;
         task->exception_class = swoole_coroutine_canceled_exception_ce;
-        task->exception = zend_objects_new(task->exception_class);
-        object_properties_init(task->exception, task->exception_class);
+        task->exception = exception;
         if (previous) {
-            zend_exception_set_previous(task->exception, previous);
+            zend_exception_set_previous(exception, previous);
         }
 
         zend_execute_data *ex_backup = EG(current_execute_data);
         EG(current_execute_data) = task->execute_data;
-        zend::object_set(task->exception, ZSTR_KNOWN(ZEND_STR_FILE), zend_get_executed_filename_ex());
-        zend::object_set(task->exception, ZSTR_KNOWN(ZEND_STR_LINE), zend_get_executed_lineno());
+        zend_string *filename = zend_get_executed_filename_ex();
+        if (filename) {
+            zend::object_set(exception, ZSTR_KNOWN(ZEND_STR_FILE), filename);
+            zend::object_set(exception, ZSTR_KNOWN(ZEND_STR_LINE), zend_get_executed_lineno());
+        }
         EG(current_execute_data) = ex_backup;
+
+        // Mirrors zend_throw_exception_internal(): internal frames have no opline and Zend redirects
+        // the caller when the call returns.
+        if (!previous && task->execute_data->func && ZEND_USER_CODE(task->execute_data->func->type) &&
+            task->execute_data->opline->opcode != ZEND_HANDLE_EXCEPTION) {
+            task->opline_before_exception = task->execute_data->opline;
+            task->execute_data->opline = EG(exception_op);
+        }
 
         // Ignore the result of Co::cancel(). Even if the coroutine is in an irrevocable state,
         // it will directly throw an exception and terminate the coroutine

--- a/tests/swoole_coroutine/cancel/directory_iterator_fetch.phpt
+++ b/tests/swoole_coroutine/cancel/directory_iterator_fetch.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_coroutine/cancel: cancel DirectoryIterator during fetch
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Event;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_FILE);
+
+$directory = sys_get_temp_dir() . '/swoole_cancel_directory_iterator_fetch_' . getmypid();
+if (!is_dir($directory)) {
+    mkdir($directory);
+}
+touch($directory . '/entry');
+
+register_shutdown_function(function () use ($directory) {
+    @unlink($directory . '/entry');
+    @rmdir($directory);
+});
+
+run(function () use ($directory) {
+    try {
+        $iterator = new DirectoryIterator($directory);
+        $cid = Coroutine::getCid();
+        foreach ($iterator as $entry) {
+            Event::defer(function () use ($cid) {
+                Assert::true(Coroutine::cancel($cid, true));
+            });
+        }
+        Assert::true(false, 'foreach must not complete');
+    } catch (CanceledException $e) {
+    }
+
+    Assert::eq(iterator_count(new DirectoryIterator($directory)), 3);
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/cancel/directory_iterator_reset.phpt
+++ b/tests/swoole_coroutine/cancel/directory_iterator_reset.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_coroutine/cancel: cancel DirectoryIterator during rewind
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Event;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_FILE);
+
+$directory = sys_get_temp_dir() . '/swoole_cancel_directory_iterator_reset_' . getmypid();
+if (!is_dir($directory)) {
+    mkdir($directory);
+}
+touch($directory . '/entry');
+
+register_shutdown_function(function () use ($directory) {
+    @unlink($directory . '/entry');
+    @rmdir($directory);
+});
+
+run(function () use ($directory) {
+    try {
+        $iterator = new DirectoryIterator($directory);
+        $cid = Coroutine::getCid();
+        Event::defer(function () use ($cid) {
+            Assert::true(Coroutine::cancel($cid, true));
+        });
+        foreach ($iterator as $entry) {
+        }
+        Assert::true(false, 'foreach must not complete');
+    } catch (CanceledException $e) {
+    }
+
+    Assert::eq(iterator_count(new DirectoryIterator($directory)), 3);
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/cancel/directory_iterator_temporary.phpt
+++ b/tests/swoole_coroutine/cancel/directory_iterator_temporary.phpt
@@ -1,0 +1,51 @@
+--TEST--
+swoole_coroutine/cancel: cancel temporary DirectoryIterator during rewind
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Event;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_FILE);
+
+$directory = sys_get_temp_dir() . '/swoole_cancel_directory_iterator_temporary_' . getmypid();
+if (!is_dir($directory)) {
+    mkdir($directory);
+}
+touch($directory . '/entry');
+
+register_shutdown_function(function () use ($directory) {
+    @unlink($directory . '/entry');
+    @rmdir($directory);
+});
+
+function createDirectoryIterator(string $directory): DirectoryIterator
+{
+    $iterator = new DirectoryIterator($directory);
+    $cid = Coroutine::getCid();
+    Event::defer(function () use ($cid) {
+        Assert::true(Coroutine::cancel($cid, true));
+    });
+    return $iterator;
+}
+
+run(function () use ($directory) {
+    try {
+        foreach (createDirectoryIterator($directory) as $entry) {
+        }
+        Assert::true(false, 'foreach must not complete');
+    } catch (CanceledException $e) {
+    }
+
+    Assert::eq(iterator_count(new DirectoryIterator($directory)), 3);
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/cancel/recursive_directory_iterator.phpt
+++ b/tests/swoole_coroutine/cancel/recursive_directory_iterator.phpt
@@ -1,0 +1,47 @@
+--TEST--
+swoole_coroutine/cancel: cancel RecursiveDirectoryIterator during rewind
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Event;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_FILE);
+
+$directory = sys_get_temp_dir() . '/swoole_cancel_recursive_directory_iterator_' . getmypid();
+if (!is_dir($directory)) {
+    mkdir($directory);
+}
+touch($directory . '/entry');
+
+register_shutdown_function(function () use ($directory) {
+    @unlink($directory . '/entry');
+    @rmdir($directory);
+});
+
+run(function () use ($directory) {
+    try {
+        $iterator = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
+        $cid = Coroutine::getCid();
+        Event::defer(function () use ($cid) {
+            Assert::true(Coroutine::cancel($cid, true));
+        });
+        foreach ($iterator as $entry) {
+        }
+        Assert::true(false, 'foreach must not complete');
+    } catch (CanceledException $e) {
+    }
+
+    $iterator = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
+    Assert::eq(iterator_count($iterator), 1);
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/cancel/recursive_iterator_iterator.phpt
+++ b/tests/swoole_coroutine/cancel/recursive_iterator_iterator.phpt
@@ -1,0 +1,49 @@
+--TEST--
+swoole_coroutine/cancel: cancel RecursiveIteratorIterator during rewind
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+use Swoole\Event;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_FILE);
+
+$directory = sys_get_temp_dir() . '/swoole_cancel_recursive_iterator_iterator_' . getmypid();
+if (!is_dir($directory)) {
+    mkdir($directory);
+}
+touch($directory . '/entry');
+
+register_shutdown_function(function () use ($directory) {
+    @unlink($directory . '/entry');
+    @rmdir($directory);
+});
+
+run(function () use ($directory) {
+    try {
+        $inner = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
+        $iterator = new RecursiveIteratorIterator($inner, RecursiveIteratorIterator::SELF_FIRST);
+        $cid = Coroutine::getCid();
+        Event::defer(function () use ($cid) {
+            Assert::true(Coroutine::cancel($cid, true));
+        });
+        foreach ($iterator as $entry) {
+        }
+        Assert::true(false, 'foreach must not complete');
+    } catch (CanceledException $e) {
+    }
+
+    $inner = new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS);
+    $iterator = new RecursiveIteratorIterator($inner, RecursiveIteratorIterator::SELF_FIRST);
+    Assert::eq(iterator_count($iterator), 1);
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_coroutine/cancel/throw_exception_internal_callable.phpt
+++ b/tests/swoole_coroutine/cancel/throw_exception_internal_callable.phpt
@@ -1,0 +1,24 @@
+--TEST--
+swoole_coroutine/cancel: throw exception in coroutine with internal callable
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Runtime;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_SLEEP);
+
+run(function () {
+    $cid = Coroutine::create('usleep', 1000000);
+    Coroutine::cancel($cid, true);
+});
+?>
+--EXPECTF--
+Fatal error: Uncaught Swoole\Coroutine\CanceledException in :0
+Stack trace:
+%A
+  thrown in Unknown on line 0

--- a/tests/swoole_coroutine/cancel/throw_exception_outside_coroutine.phpt
+++ b/tests/swoole_coroutine/cancel/throw_exception_outside_coroutine.phpt
@@ -1,0 +1,15 @@
+--TEST--
+swoole_coroutine/cancel: reject throwing cancellation outside a coroutine
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Coroutine;
+
+Assert::eq(Coroutine::getCid(), -1);
+Assert::false(Coroutine::cancel(Coroutine::getCid(), true));
+Assert::eq(swoole_last_error(), SWOOLE_ERROR_CO_NOT_EXISTS);
+?>
+--EXPECT--

--- a/tests/swoole_coroutine/cancel/throw_exception_self.phpt
+++ b/tests/swoole_coroutine/cancel/throw_exception_self.phpt
@@ -1,0 +1,23 @@
+--TEST--
+swoole_coroutine/cancel: throw exception in current coroutine
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use function Swoole\Coroutine\run;
+use Swoole\Coroutine;
+use Swoole\Coroutine\CanceledException;
+
+run(function () {
+    try {
+        Coroutine::cancel(Coroutine::getCid(), true);
+        Assert::true(false, 'cancel must throw');
+    } catch (CanceledException $e) {
+        echo "DONE\n";
+    }
+});
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
Cancellation could resume a user frame with an exception while leaving it on the interrupted foreach operation. SPL directory iteration then repeated that operation instead of entering the surrounding catch block, causing the coroutine to hang. A temporary iterator could also be released more than once.

Preserve Zend's exception state per coroutine and move suspended user frames into its exception handler. Also use the live frame for throwing self-cancellation, reject the non-coroutine main context consistently, and handle targets with no user PHP frame. The non-throwing self-cancellation result is unchanged.

Tests cover shallow and recursive directory iteration, retained and temporary iterators, self-cancellation, internal callables, and calls outside a coroutine.
