### PR TITLE
Fix coroutine HTTP client socket initialization

### DIFF
--- a/ext-src/swoole_http2_client_coro.cc
+++ b/ext-src/swoole_http2_client_coro.cc
@@ -100,6 +100,7 @@ class Client {
         open_ssl = _ssl;
         _zobject = *zobj;
         zobject = &_zobject;
+        ZVAL_NULL(&zsocket);
         Http2::init_settings(&local_settings);
         local_window_size = local_settings.init_window_size;
     }

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -583,6 +583,7 @@ Client::Client(const zval *zobject, const std::string &host, zend_long port, zen
     this->ssl = ssl;
 #endif
     _zobject = *zobject;
+    ZVAL_NULL(&zsocket);
     // TODO: zend_read_property cache here (strong type properties)
 }
 

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -2151,6 +2151,10 @@ static PHP_METHOD(swoole_http_client_coro, recv) {
 
 static PHP_METHOD(swoole_http_client_coro, close) {
     Client *phc = http_client_coro_get_client(ZEND_THIS);
+    if (!ZVAL_IS_OBJECT(&phc->zsocket)) {
+        php_swoole_socket_set_error_properties(ZEND_THIS, SW_ERROR_CLIENT_NO_CONNECTION);
+        RETURN_FALSE;
+    }
     SW_CLIENT_PRESERVE_SOCKET(&phc->zsocket);
     RETURN_BOOL(phc->close());
 }

--- a/tests/swoole_http2_client_coro/close_before_connect.phpt
+++ b/tests/swoole_http2_client_coro/close_before_connect.phpt
@@ -1,0 +1,13 @@
+--TEST--
+swoole_http2_client_coro: close before connect
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$client = new Swoole\Coroutine\Http2\Client('127.0.0.1', 9501);
+Assert::false($client->close());
+Assert::same($client->errCode, SOCKET_EBADF);
+?>
+--EXPECT--

--- a/tests/swoole_http_client_coro/close_before_connect.phpt
+++ b/tests/swoole_http_client_coro/close_before_connect.phpt
@@ -1,0 +1,12 @@
+--TEST--
+swoole_http_client_coro: close before connect
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$client = new Swoole\Coroutine\Http\Client('127.0.0.1', 9501);
+Assert::false($client->close());
+?>
+--EXPECT--

--- a/tests/swoole_http_client_coro/close_before_connect.phpt
+++ b/tests/swoole_http_client_coro/close_before_connect.phpt
@@ -8,5 +8,6 @@ require __DIR__ . '/../include/bootstrap.php';
 
 $client = new Swoole\Coroutine\Http\Client('127.0.0.1', 9501);
 Assert::false($client->close());
+Assert::same($client->errCode, SWOOLE_ERROR_CLIENT_NO_CONNECTION);
 ?>
 --EXPECT--


### PR DESCRIPTION
## Summary

`Swoole\Coroutine\Http\Client` and `Swoole\Coroutine\Http2\Client` leave their internal `zsocket` uninitialized until `connect()` creates a socket. Their public `close()` methods read that value before checking whether the native socket exists. If the leftover bytes look like an object, Swoole takes and releases a reference to a value that was never a valid `zval`.

Initialize both values to null, matching the state restored after a socket closes and the existing `Swoole\Coroutine\Client` behavior. `Swoole\Coroutine\Http\Client::close()` now sets `SWOOLE_ERROR_CLIENT_NO_CONNECTION` when no socket exists, matching its other connection-dependent methods and `Swoole\Coroutine\Client::close()`; before, it returned false without updating `errCode`.

The HTTP/1 PHPT's error assertion fails on unchanged 6.1. Neither PHPT can expose the uninitialized read because whether it causes visible damage depends on the leftover bytes.

The C++ core tests cannot reach PHP-extension `zval` state, normal PHPT assertions cannot inspect it, and Swoole's Valgrind runner suppresses undefined-value reports.

## Reproduction

From the repository root, build without `--enable-asan`:

```sh
phpize
./configure --enable-swoole-dev --enable-debug-log --enable-sockets --enable-mysqlnd --enable-swoole-curl
make -j$(nproc)
```

Then run these commands from the same directory:

```sh
USE_ZEND_ALLOC=0 valgrind --tool=memcheck --track-origins=yes --error-exitcode=99 \
  php -n -d extension=sockets -d extension=modules/swoole.so \
  -r '$client = new Swoole\Coroutine\Http\Client("127.0.0.1", 9501); $client->close();'

USE_ZEND_ALLOC=0 valgrind --tool=memcheck --track-origins=yes --error-exitcode=99 \
  php -n -d extension=sockets -d extension=modules/swoole.so \
  -r '$client = new Swoole\Coroutine\Http2\Client("127.0.0.1", 9501); $client->close();'
```

On unpatched `6.1`, the HTTP/1 command exits 99 and reports:

```text
Conditional jump or move depends on uninitialised value(s)
   at ... zim_swoole_http_client_coro_close (swoole_http_client_coro.cc:2153)
 Uninitialised value was created by a heap allocation
   at ... operator new(unsigned long)
   by ... zim_swoole_http_client_coro___construct (swoole_http_client_coro.cc:1804)
ERROR SUMMARY: 1 errors from 1 contexts
```

The HTTP/2 command has the same trace through `zim_swoole_http2_client_coro_close` at line 1363 and its `new Client` at line 812. These line numbers are from unpatched `6.1`.

With this patch, both commands exit 0 with:

```text
ERROR SUMMARY: 0 errors from 0 contexts
```
