### PR TITLE
Fix missing reactor socket lookups

### DIFF
--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -112,6 +112,24 @@ TEST(reactor, wait) {
     ASSERT_EQ(SwooleTG.reactor, nullptr);
 }
 
+TEST(reactor, get_missing_socket) {
+    UnixSocket p(true, SOCK_DGRAM);
+    ASSERT_TRUE(p.ready());
+    ASSERT_EQ(swoole_event_init(0), SW_OK);
+
+    auto sock = p.get_socket(false);
+    const int fd = sock->get_fd();
+
+    // Use nonfatal assertions so the reactor is always freed before later tests.
+    EXPECT_EQ(swoole_event_get_socket(fd), nullptr);
+    EXPECT_FALSE(SwooleTG.reactor->exists(fd));
+    EXPECT_EQ(SwooleTG.reactor->get_event_num(), 0);
+    EXPECT_EQ(swoole_event_add(sock, SW_EVENT_READ), SW_OK);
+    EXPECT_EQ(swoole_event_get_socket(fd), sock);
+    EXPECT_EQ(swoole_event_del(sock), SW_OK);
+    EXPECT_EQ(swoole_event_free(), SW_OK);
+}
+
 TEST(reactor, write) {
     int ret;
     UnixSocket p(true, SOCK_DGRAM);

--- a/include/swoole_reactor.h
+++ b/include/swoole_reactor.h
@@ -274,8 +274,12 @@ class Reactor {
         return sockets_;
     }
 
-    network::Socket *get_socket(const int fd) {
-        return sockets_[fd];
+    network::Socket *get_socket(const int fd) const {
+        auto i = sockets_.find(fd);
+        if (i == sockets_.end()) {
+            return nullptr;
+        }
+        return i->second;
     }
 
     void foreach_socket(const std::function<void(int, network::Socket *)> &callback) const {


### PR DESCRIPTION
The reactor socket accessor used `operator[]`. Looking up an unregistered descriptor returned `nullptr`, but also inserted a null entry into the reactor socket map and changed its event count.

Use `find()` so missing lookups remain read-only. Add focused coverage for missing and registered descriptors.