### PR TITLE
Enforce server TLS peer verification

### DIFF
--- a/core-tests/src/protocol/ssl.cpp
+++ b/core-tests/src/protocol/ssl.cpp
@@ -18,15 +18,51 @@
 */
 
 #include "test_core.h"
+#include "swoole_util.h"
 
 #include <openssl/sha.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/buffer.h>
 #include <openssl/err.h>
+#include <openssl/pem.h>
 
 using swoole::SSLContext;
 using swoole::String;
+
+static std::pair<int, int> verify_certificate(SSL_CTX *context, const std::string &file) {
+    BIO *bio = BIO_new_file(file.c_str(), "r");
+    if (bio == nullptr) {
+        ADD_FAILURE() << "BIO_new_file() failed for " << file;
+        return {-2, -2};
+    }
+    ON_SCOPE_EXIT {
+        BIO_free(bio);
+    };
+    X509 *cert = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+    if (cert == nullptr) {
+        ADD_FAILURE() << "PEM_read_bio_X509() failed for " << file;
+        return {-2, -2};
+    }
+    ON_SCOPE_EXIT {
+        X509_free(cert);
+    };
+    X509_STORE_CTX *store_ctx = X509_STORE_CTX_new();
+    if (store_ctx == nullptr) {
+        ADD_FAILURE() << "X509_STORE_CTX_new() failed";
+        return {-2, -2};
+    }
+    ON_SCOPE_EXIT {
+        X509_STORE_CTX_free(store_ctx);
+    };
+    if (!X509_STORE_CTX_init(store_ctx, SSL_CTX_get_cert_store(context), cert, nullptr)) {
+        ADD_FAILURE() << "X509_STORE_CTX_init() failed for " << file;
+        return {-2, -2};
+    }
+    int result = X509_verify_cert(store_ctx);
+    int error = X509_STORE_CTX_get_error(store_ctx);
+    return {result, error};
+}
 
 TEST(ssl, destroy) {
     swoole_ssl_init();
@@ -67,9 +103,39 @@ TEST(ssl, get_error) {
 }
 
 TEST(ssl, password) {
-    SSLContext ctx;
+    SSLContext ctx{};
     ctx.key_file = swoole::test::get_ssl_dir() + "/passwd_key.pem";
     ctx.passphrase = "swoole";
     ctx.cert_file = swoole::test::get_ssl_dir() + "/passwd.crt";
-    ASSERT_TRUE(ctx.create());
+    ASSERT_TRUE(ctx.create(SW_SSL_CLIENT));
+}
+
+TEST(ssl, server_client_certificate) {
+    const char *cert_file = getenv("SSL_CERT_FILE");
+    bool cert_file_was_set = cert_file != nullptr;
+    std::string previous_cert_file = cert_file_was_set ? cert_file : "";
+    ON_SCOPE_EXIT {
+        if (cert_file_was_set) {
+            setenv("SSL_CERT_FILE", previous_cert_file.c_str(), 1);
+        } else {
+            unsetenv("SSL_CERT_FILE");
+        }
+    };
+
+    std::string ssl_dir = swoole::test::get_ssl_dir();
+    ASSERT_EQ(setenv("SSL_CERT_FILE", (ssl_dir + "/mosquitto.org.crt").c_str(), 1), 0);
+
+    SSLContext ctx{};
+    ctx.client_cert_file = ssl_dir + "/ca-cert.pem";
+    ASSERT_TRUE(ctx.create(SW_SSL_SERVER));
+    EXPECT_TRUE(SSL_CTX_get_verify_mode(ctx.get_context()) & SSL_VERIFY_PEER);
+    EXPECT_NE(SSL_CTX_get_verify_depth(ctx.get_context()), 0);
+
+    auto configured_ca = verify_certificate(ctx.get_context(), ssl_dir + "/client-cert.pem");
+    ASSERT_EQ(configured_ca.first, 1);
+    ASSERT_EQ(configured_ca.second, X509_V_OK);
+
+    auto default_ca = verify_certificate(ctx.get_context(), ssl_dir + "/mosquitto.org.crt");
+    EXPECT_EQ(default_ca.first, 0);
+    EXPECT_EQ(default_ca.second, X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT);
 }

--- a/core-tests/src/protocol/ssl.cpp
+++ b/core-tests/src/protocol/ssl.cpp
@@ -111,6 +111,17 @@ TEST(ssl, password) {
 }
 
 TEST(ssl, server_client_certificate) {
+    // Peer verification without a trust source is valid only when self-signed certificates are allowed.
+    SSLContext invalid_ctx{};
+    invalid_ctx.verify_peer = 1;
+    ASSERT_FALSE(invalid_ctx.create(SW_SSL_SERVER));
+
+    SSLContext self_signed_ctx{};
+    self_signed_ctx.verify_peer = 1;
+    self_signed_ctx.allow_self_signed = 1;
+    ASSERT_TRUE(self_signed_ctx.create(SW_SSL_SERVER));
+
+    // Use a distinct default CA to prove server contexts do not import it.
     const char *cert_file = getenv("SSL_CERT_FILE");
     bool cert_file_was_set = cert_file != nullptr;
     std::string previous_cert_file = cert_file_was_set ? cert_file : "";
@@ -129,6 +140,7 @@ TEST(ssl, server_client_certificate) {
     ctx.client_cert_file = ssl_dir + "/ca-cert.pem";
     ASSERT_TRUE(ctx.create(SW_SSL_SERVER));
     EXPECT_TRUE(SSL_CTX_get_verify_mode(ctx.get_context()) & SSL_VERIFY_PEER);
+    // client_cert_file must not force OpenSSL's verification depth to zero.
     EXPECT_NE(SSL_CTX_get_verify_depth(ctx.get_context()), 0);
 
     auto configured_ca = verify_certificate(ctx.get_context(), ssl_dir + "/client-cert.pem");

--- a/core-tests/src/server/http_server.cpp
+++ b/core-tests/src/server/http_server.cpp
@@ -1276,7 +1276,7 @@ TEST(http_server, client_ca) {
     port->set_ssl_key_file(test::get_ssl_dir() + "/server.key");
     port->set_ssl_verify_peer(true);
     port->set_ssl_allow_self_signed(true);
-    port->set_ssl_cafile(test::get_ssl_dir() + "/ca.crt");
+    port->set_ssl_cafile(test::get_ssl_dir() + "/ca-cert.pem");
     port->ssl_init();
 
     pid_t pid = fork();
@@ -1291,8 +1291,8 @@ TEST(http_server, client_ca) {
 
         sleep(1);
         pid_t pid2;
-        string client_cert = " --cert " + test::get_ssl_dir() + "/client.crt";
-        string client_key = " --key " + test::get_ssl_dir() + "/client.key";
+        string client_cert = " --cert " + test::get_ssl_dir() + "/client-cert.pem";
+        string client_key = " --key " + test::get_ssl_dir() + "/client-key.pem";
         string command = "curl https://127.0.0.1:" + port_num + " " + client_cert + client_key +
                          " -k -vvv --stderr /tmp/client_ca.txt";
         swoole_shell_exec(command.c_str(), &pid2, 0);

--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -1173,6 +1173,13 @@ SW_API bool php_swoole_socket_set_ssl(Socket *sock, const zval *zset) {
     if (php_swoole_array_get_value(vht, "ssl_allow_self_signed", ztmp)) {
         sock->set_ssl_allow_self_signed(zval_is_true(ztmp));
     }
+    if (php_swoole_array_get_value(vht, "ssl_client_cert_file", ztmp)) {
+        zend::String str_v(ztmp);
+        if (!sock->set_ssl_client_cert_file(str_v.to_std_string())) {
+            php_swoole_fatal_error(E_WARNING, "ssl client cert file[%s] not found", str_v.val());
+            return false;
+        }
+    }
     if (php_swoole_array_get_value(vht, "ssl_cafile", ztmp)) {
         sock->set_ssl_cafile(zend::String(ztmp).to_std_string());
     }

--- a/include/swoole_coroutine_socket.h
+++ b/include/swoole_coroutine_socket.h
@@ -167,6 +167,10 @@ class Socket {
         return ssl_context->set_cert_file(file);
     }
 
+    bool set_ssl_client_cert_file(const std::string &file) const {
+        return ssl_context->set_client_cert_file(file);
+    }
+
     void set_ssl_cafile(const std::string &file) const {
         ssl_context->cafile = file;
     }

--- a/include/swoole_ssl.h
+++ b/include/swoole_ssl.h
@@ -131,7 +131,6 @@ struct SSLContext {
     uchar verify_peer : 1;
     uchar allow_self_signed : 1;
     uint32_t protocols;
-    uint8_t create_flag;
     SSL_CTX *context;
 
     SSL_CTX *get_context() const {
@@ -173,8 +172,8 @@ struct SSLContext {
         return true;
     }
 
-    bool create();
-    bool set_capath() const;
+    bool create(int flags);
+    bool set_capath(int flags) const;
     bool set_ciphers() const;
     bool set_client_certificate() const;
     bool set_ecdh_curve() const;

--- a/include/swoole_ssl.h
+++ b/include/swoole_ssl.h
@@ -131,7 +131,7 @@ struct SSLContext {
     uchar verify_peer : 1;
     uchar allow_self_signed : 1;
     uint32_t protocols;
-    SSL_CTX *context;
+    SSL_CTX *context = nullptr;
 
     SSL_CTX *get_context() const {
         return context;

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1148,7 +1148,7 @@ bool Socket::ssl_context_create() {
 #endif
     }
     ssl_context->http_v2 = http2;
-    if (!ssl_context->create()) {
+    if (!ssl_context->create(ssl_is_server ? SW_SSL_SERVER : SW_SSL_CLIENT)) {
         set_err(SW_ERROR_SSL_CREATE_CONTEXT_FAILED);
         return false;
     }
@@ -1238,6 +1238,15 @@ bool Socket::ssl_handshake() {
 }
 
 bool Socket::ssl_verify(bool allow_self_signed) {
+    if (ssl_is_server) {
+        // SSL_get_verify_result() returns X509_V_OK when the peer did not provide a certificate.
+        X509 *cert = socket->ssl_get_peer_certificate();
+        if (cert == nullptr) {
+            set_err(SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE);
+            return false;
+        }
+        X509_free(cert);
+    }
     if (!socket->ssl_verify(allow_self_signed)) {
         set_err(SW_ERROR_SSL_VERIFY_FAILED);
         return false;

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1242,6 +1242,10 @@ bool Socket::ssl_verify(bool allow_self_signed) {
         // SSL_get_verify_result() returns X509_V_OK when the peer did not provide a certificate.
         X509 *cert = socket->ssl_get_peer_certificate();
         if (cert == nullptr) {
+            swoole_error_log(SW_LOG_NOTICE,
+                             SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE,
+                             "peer certificate from fd#%d is required",
+                             socket->fd);
             set_err(SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE);
             return false;
         }

--- a/src/network/client.cc
+++ b/src/network/client.cc
@@ -258,7 +258,7 @@ int Client::ssl_handshake() const {
     }
     if (!ssl_context->ready()) {
         ssl_context->http_v2 = http2;
-        if (!ssl_context->create()) {
+        if (!ssl_context->create(SW_SSL_CLIENT)) {
             return SW_ERR;
         }
     }

--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -186,7 +186,7 @@ static int ssl_passwd_callback(char *buf, int num, int verify, void *data) {
     return 0;
 }
 
-bool SSLContext::create() {
+bool SSLContext::create(int flags) {
     if (!openssl_init) {
         swoole_ssl_init();
     }
@@ -351,11 +351,15 @@ bool SSLContext::create() {
     }
 #endif
 
-    auto rs = set_capath();
-    if (verify_peer) {
-        if (!rs) {
-            return false;
-        }
+    auto rs = set_capath(flags);
+    if (verify_peer && !rs) {
+        return false;
+    }
+
+    // client_cert_file also requests a certificate for optional capture when verification is disabled.
+    const bool verify_client = (flags & SW_SSL_SERVER) && (verify_peer || !client_cert_file.empty());
+    if (verify_client) {
+        SSL_CTX_set_verify(context, SSL_VERIFY_PEER, swoole_ssl_verify_callback);
     } else {
         SSL_CTX_set_verify(context, SSL_VERIFY_NONE, nullptr);
     }
@@ -385,7 +389,7 @@ bool SSLContext::create() {
     SSL_CTX_set_grease_enabled(context, grease);
 #endif
 
-    if (!client_cert_file.empty() && !set_client_certificate()) {
+    if ((flags & SW_SSL_SERVER) && !client_cert_file.empty() && !set_client_certificate()) {
         return false;
     }
 
@@ -397,14 +401,14 @@ bool SSLContext::create() {
     return true;
 }
 
-bool SSLContext::set_capath() const {
+bool SSLContext::set_capath(int flags) const {
     if (!cafile.empty() || !capath.empty()) {
         const char *_cafile = cafile.empty() ? nullptr : cafile.c_str();
         const char *_capath = capath.empty() ? nullptr : capath.c_str();
         if (!SSL_CTX_load_verify_locations(context, _cafile, _capath)) {
             return false;
         }
-    } else {
+    } else if (!(flags & SW_SSL_SERVER)) {
         if (!SSL_CTX_set_default_verify_paths(context)) {
             ssl_error("SSL_CTX_set_default_verify_paths() failed");
             return false;
@@ -450,10 +454,6 @@ bool SSLContext::set_ciphers() const {
 
 bool SSLContext::set_client_certificate() const {
     const char *_cert_file = client_cert_file.c_str();
-    int depth = verify_depth;
-
-    SSL_CTX_set_verify(context, SSL_VERIFY_PEER, swoole_ssl_verify_callback);
-    SSL_CTX_set_verify_depth(context, depth);
 
     if (SSL_CTX_load_verify_locations(context, _cert_file, nullptr) == 0) {
         ssl_error("SSL_CTX_load_verify_locations(\"%s\") failed", _cert_file);

--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -190,6 +190,11 @@ bool SSLContext::create(int flags) {
     if (!openssl_init) {
         swoole_ssl_init();
     }
+    if ((flags & SW_SSL_SERVER) && verify_peer && !allow_self_signed && cafile.empty() && capath.empty() &&
+        client_cert_file.empty()) {
+        swoole_warning("server SSL peer verification requires ssl_client_cert_file, ssl_cafile, or ssl_capath");
+        return false;
+    }
 
     const SSL_METHOD *method;
 #ifdef SW_SUPPORT_DTLS

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -171,7 +171,7 @@ bool ListenPort::ssl_context_create(SSLContext *context) const {
     if (open_http2_protocol) {
         context->http_v2 = 1;
     }
-    if (!context->create()) {
+    if (!context->create(SW_SSL_SERVER)) {
         swoole_warning("failed to create ssl content");
         return false;
     }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -66,6 +66,16 @@ static inline ReturnCode ReactorThread_verify_ssl_state(Reactor *reactor, Listen
                 return SW_ERROR;
             }
         }
+    } else if (port->get_ssl_verify_peer()) {
+        // SSL_get_verify_result() returns X509_V_OK when the peer did not provide a certificate.
+        X509 *cert = _socket->ssl_get_peer_certificate();
+        if (cert == nullptr) {
+            return SW_ERROR;
+        }
+        X509_free(cert);
+        if (!_socket->ssl_verify(port->get_ssl_allow_self_signed())) {
+            return SW_ERROR;
+        }
     }
 
     if (serv->onConnect) {

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -50,6 +50,10 @@ static inline ReturnCode ReactorThread_verify_ssl_state(Reactor *reactor, Listen
     if (!port->get_ssl_client_cert_file().empty()) {
         if (!_socket->ssl_get_peer_certificate(sw_tg_buffer())) {
             if (port->get_ssl_verify_peer()) {
+                swoole_error_log(SW_LOG_NOTICE,
+                                 SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE,
+                                 "peer certificate from fd#%d is required",
+                                 _socket->fd);
                 return SW_ERROR;
             }
         } else {
@@ -70,6 +74,10 @@ static inline ReturnCode ReactorThread_verify_ssl_state(Reactor *reactor, Listen
         // SSL_get_verify_result() returns X509_V_OK when the peer did not provide a certificate.
         X509 *cert = _socket->ssl_get_peer_certificate();
         if (cert == nullptr) {
+            swoole_error_log(SW_LOG_NOTICE,
+                             SW_ERROR_SSL_EMPTY_PEER_CERTIFICATE,
+                             "peer certificate from fd#%d is required",
+                             _socket->fd);
             return SW_ERROR;
         }
         X509_free(cert);

--- a/tests/swoole_http_server/client_ca.phpt
+++ b/tests/swoole_http_server/client_ca.phpt
@@ -11,14 +11,30 @@ $pm = new ProcessManager;
 $html = base64_encode(random_bytes(rand(2048, 65536)));
 
 $pm->parentFunc = function ($pid) use ($pm, $html) {
-    go(function () use ($pm, $html) {
-        $commnd = "curl https://127.0.0.1:" . $pm->getFreePort() . " --cert " . SSL_FILE_DIR. "/client.crt" .
-        " --key ". SSL_FILE_DIR. "/client.key -k -vvv --stderr /tmp/client_ca.txt";
-        $out = shell_exec($commnd);
-        Assert::eq($out, $html);
+    $stderr1 = tempnam('/tmp', 'swoole_client_ca_');
+    $stderr2 = tempnam('/tmp', 'swoole_client_ca_');
+    try {
+        $url = "https://127.0.0.1:{$pm->getFreePort()}";
+        $command = sprintf(
+            'curl --silent --show-error --insecure --max-time 10 --stderr %s %s',
+            escapeshellarg($stderr1),
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command) ?: '', '');
+
+        $command = sprintf(
+            'curl --silent --show-error --insecure --max-time 10 --cert %s --key %s --stderr %s %s',
+            escapeshellarg(SSL_FILE_DIR . '/client-cert.pem'),
+            escapeshellarg(SSL_FILE_DIR . '/client-key.pem'),
+            escapeshellarg($stderr2),
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command), $html);
+    } finally {
+        unlink($stderr1);
+        unlink($stderr2);
         $pm->kill();
-    });
-    Swoole\Event::wait();
+    }
     echo "DONE\n";
 };
 
@@ -30,7 +46,7 @@ $pm->childFunc = function () use ($pm, $html) {
         'ssl_key_file' => SSL_FILE_DIR . '/server.key',
         'ssl_verify_peer' => true,
         'ssl_verify_depth' => 10,
-        'ssl_cafile' => SSL_FILE_DIR . '/ca.crt',
+        'ssl_cafile' => SSL_FILE_DIR . '/ca-cert.pem',
     ]);
     $serv->on("workerStart", function ($serv) use ($pm) {
         $pm->wakeup();

--- a/tests/swoole_http_server/client_ca.phpt
+++ b/tests/swoole_http_server/client_ca.phpt
@@ -41,7 +41,6 @@ $pm->parentFunc = function ($pid) use ($pm, $html) {
 $pm->childFunc = function () use ($pm, $html) {
     $serv = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SERVER_MODE_RANDOM, SWOOLE_SOCK_TCP | SWOOLE_SSL);
     $serv->set([
-        'log_file' => '/dev/null',
         'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
         'ssl_key_file' => SSL_FILE_DIR . '/server.key',
         'ssl_verify_peer' => true,
@@ -60,5 +59,6 @@ $pm->childFunc = function () use ($pm, $html) {
 $pm->childFirst();
 $pm->run();
 ?>
---EXPECT--
+--EXPECTF--
+[%s]	NOTICE	ReactorThread_verify_ssl_state() (ERRNO %d): peer certificate from fd#%d is required
 DONE

--- a/tests/swoole_http_server_coro/invalid_settings.phpt
+++ b/tests/swoole_http_server_coro/invalid_settings.phpt
@@ -46,8 +46,43 @@ Coroutine\run(function () use (&$warnings) {
     Assert::true($server->start());
     Assert::true(Coroutine::join([$cid]));
     Assert::same($warnings, []);
+
+    $server = new Server('127.0.0.1', 0, true);
+    $server->handle('/', function ($request, $response) use ($server) {
+        $response->end('OK');
+        $server->shutdown();
+    });
+    Assert::true($server->set([
+        'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+        'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+        'ssl_client_cert_file' => __DIR__ . '/not-found.pem',
+    ]));
+
+    $cid = Coroutine::create(function () use ($server) {
+        Coroutine::sleep(0.01);
+        $server->shutdown();
+    });
+
+    Assert::false($server->start());
+    Assert::true(Coroutine::join([$cid]));
+    Assert::same($server->errCode, SOCKET_EINVAL);
+    Assert::same($server->errMsg, swoole_strerror(SOCKET_EINVAL));
+    Assert::same($warnings, [
+        'Swoole\\Coroutine\\Http\\Server::start(): ssl client cert file[' . __DIR__ . '/not-found.pem] not found',
+    ]);
+
+    $warnings = [];
+    Assert::true($server->set(['ssl_client_cert_file' => SSL_FILE_DIR . '/ca-cert.pem']));
+    $cid = Coroutine::create(function () use ($server) {
+        Coroutine::sleep(0.01);
+        Assert::same(httpGetBody("https://127.0.0.1:{$server->port}/"), 'OK');
+    });
+    Assert::true($server->start());
+    Assert::true(Coroutine::join([$cid]));
+    Assert::same($warnings, []);
 });
 
 restore_error_handler();
 ?>
---EXPECT--
+--EXPECTF--
+[%s]	WARNING	SSLContext::set_client_cert_file(): ssl client cert file[%s] not found

--- a/tests/swoole_http_server_coro/ssl_cafile.phpt
+++ b/tests/swoole_http_server_coro/ssl_cafile.phpt
@@ -1,0 +1,75 @@
+--TEST--
+swoole_http_server_coro: verify client certificate with ssl_cafile
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+skip_if_command_not_found('curl');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http\Server;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    try {
+        $port = $pm->getFreePort();
+        $url = "https://127.0.0.1:{$port}/";
+
+        $command = sprintf(
+            'curl --silent --insecure --max-time 10 %s',
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command) ?: '', '');
+
+        // client.crt is expired and is not signed by ca-cert.pem; either failure proves chain validation ran.
+        $command = sprintf(
+            'curl --silent --insecure --max-time 10 --cert %s --key %s %s',
+            escapeshellarg(SSL_FILE_DIR . '/client.crt'),
+            escapeshellarg(SSL_FILE_DIR . '/client.key'),
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command) ?: '', '');
+
+        $command = sprintf(
+            'curl --silent --insecure --max-time 10 --cert %s --key %s %s',
+            escapeshellarg(SSL_FILE_DIR . '/client-cert.pem'),
+            escapeshellarg(SSL_FILE_DIR . '/client-key.pem'),
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command), 'OK');
+    } finally {
+        $pm->kill();
+    }
+};
+
+$pm->childFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $server = new Server('127.0.0.1', $pm->getFreePort(), true);
+        $server->set([
+            'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+            'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+            'ssl_verify_peer' => true,
+            'ssl_cafile' => SSL_FILE_DIR . '/ca-cert.pem',
+        ]);
+        $server->handle('/', function ($request, $response) use ($server) {
+            $response->end('OK');
+            $server->shutdown();
+        });
+        $pm->wakeup();
+        $server->start();
+    });
+    Swoole\Event::wait();
+};
+
+$pm->childFirst();
+$pm->run();
+echo "DONE\n";
+?>
+--EXPECTF--
+[%s]	NOTICE	Socket::ssl_verify() (ERRNO %d): can not verify peer from fd#%d with error#%d: %s
+DONE

--- a/tests/swoole_http_server_coro/ssl_cafile.phpt
+++ b/tests/swoole_http_server_coro/ssl_cafile.phpt
@@ -26,11 +26,11 @@ $pm->parentFunc = function () use ($pm) {
         );
         Assert::same(shell_exec($command) ?: '', '');
 
-        // client.crt is expired and is not signed by ca-cert.pem; either failure proves chain validation ran.
+        // server.crt is valid for client authentication but is signed by a CA that is not trusted here.
         $command = sprintf(
             'curl --silent --insecure --max-time 10 --cert %s --key %s %s',
-            escapeshellarg(SSL_FILE_DIR . '/client.crt'),
-            escapeshellarg(SSL_FILE_DIR . '/client.key'),
+            escapeshellarg(SSL_FILE_DIR . '/server.crt'),
+            escapeshellarg(SSL_FILE_DIR . '/server.key'),
             escapeshellarg($url),
         );
         Assert::same(shell_exec($command) ?: '', '');
@@ -71,5 +71,6 @@ $pm->run();
 echo "DONE\n";
 ?>
 --EXPECTF--
-[%s]	NOTICE	Socket::ssl_verify() (ERRNO %d): can not verify peer from fd#%d with error#%d: %s
+[%s]	NOTICE	Socket::ssl_verify() (ERRNO %d): peer certificate from fd#%d is required
+[%s]	NOTICE	Socket::ssl_verify() (ERRNO %d): can not verify peer from fd#%d with error#21: unable to verify the first certificate
 DONE

--- a/tests/swoole_http_server_coro/ssl_client_cert_file.phpt
+++ b/tests/swoole_http_server_coro/ssl_client_cert_file.phpt
@@ -1,0 +1,65 @@
+--TEST--
+swoole_http_server_coro: verify client certificate
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+skip_if_command_not_found('curl');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http\Server;
+use SwooleTest\ProcessManager;
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    try {
+        $port = $pm->getFreePort();
+        $url = "https://127.0.0.1:{$port}/";
+
+        $command = sprintf(
+            'curl --silent --insecure --max-time 10 %s',
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command) ?: '', '');
+
+        $command = sprintf(
+            'curl --silent --insecure --max-time 10 --cert %s --key %s %s',
+            escapeshellarg(SSL_FILE_DIR . '/client-cert.pem'),
+            escapeshellarg(SSL_FILE_DIR . '/client-key.pem'),
+            escapeshellarg($url),
+        );
+        Assert::same(shell_exec($command), 'OK');
+    } finally {
+        $pm->kill();
+    }
+};
+
+$pm->childFunc = function () use ($pm) {
+    go(function () use ($pm) {
+        $server = new Server('127.0.0.1', $pm->getFreePort(), true);
+        $server->set([
+            'ssl_cert_file' => SSL_FILE_DIR . '/server.crt',
+            'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+            'ssl_verify_peer' => true,
+            'ssl_client_cert_file' => SSL_FILE_DIR . '/ca-cert.pem',
+        ]);
+        $server->handle('/', function ($request, $response) use ($server) {
+            $response->end('OK');
+            $server->shutdown();
+        });
+        $pm->wakeup();
+        $server->start();
+    });
+    Swoole\Event::wait();
+};
+
+$pm->childFirst();
+$pm->run();
+echo "DONE\n";
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server_coro/ssl_client_cert_file.phpt
+++ b/tests/swoole_http_server_coro/ssl_client_cert_file.phpt
@@ -61,5 +61,6 @@ $pm->childFirst();
 $pm->run();
 echo "DONE\n";
 ?>
---EXPECT--
+--EXPECTF--
+[%s]	NOTICE	Socket::ssl_verify() (ERRNO %d): peer certificate from fd#%d is required
 DONE

--- a/tests/swoole_runtime/ssl/enable_crypto.phpt
+++ b/tests/swoole_runtime/ssl/enable_crypto.phpt
@@ -19,7 +19,7 @@ go(function () use ($ready) {
     stream_context_set_option($context, 'ssl', 'verify_peer', true);
     stream_context_set_option($context, 'ssl', 'local_cert', SSL_FILE_DIR.'/server.crt');
     stream_context_set_option($context, 'ssl', 'local_pk', SSL_FILE_DIR.'/server.key');
-    stream_context_set_option($context, 'ssl', 'cafile', SSL_FILE_DIR.'/ca.crt');
+    stream_context_set_option($context, 'ssl', 'cafile', SSL_FILE_DIR.'/ca-cert.pem');
 
     $socket = stream_socket_server("ssl://0.0.0.0:8000", $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $context);
     if (!$socket) {
@@ -43,8 +43,8 @@ go(function () use ($ready) {
         echo "$errstr ($errno)<br />\n";
     } else {
         stream_context_set_option($fp, ["ssl" => [
-            "local_cert" => SSL_FILE_DIR . '/client.crt',
-            "local_pk" => SSL_FILE_DIR . '/client.key',
+            "local_cert" => SSL_FILE_DIR . '/client-cert.pem',
+            "local_pk" => SSL_FILE_DIR . '/client-key.pem',
         ]]);
         // Enable SSL encryption after the connection is established
         Assert::assert(stream_socket_enable_crypto($fp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT));

--- a/tests/swoole_runtime/ssl/local_cert.phpt
+++ b/tests/swoole_runtime/ssl/local_cert.phpt
@@ -19,7 +19,7 @@ go(function () use ($ready) {
     stream_context_set_option($context, 'ssl', 'verify_peer', true);
     stream_context_set_option($context, 'ssl', 'local_cert', SSL_FILE_DIR.'/server.crt');
     stream_context_set_option($context, 'ssl', 'local_pk', SSL_FILE_DIR.'/server.key');
-    stream_context_set_option($context, 'ssl', 'cafile', SSL_FILE_DIR.'/ca.crt');
+    stream_context_set_option($context, 'ssl', 'cafile', SSL_FILE_DIR.'/ca-cert.pem');
 
     $socket = stream_socket_server("ssl://0.0.0.0:8000", $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $context);
     if (!$socket) {
@@ -38,8 +38,8 @@ go(function () use ($ready) {
     $ready->pop();
 
     $context = stream_context_create();
-    stream_context_set_option($context, 'ssl', 'local_cert', SSL_FILE_DIR . '/client.crt');
-    stream_context_set_option($context, 'ssl', 'local_pk', SSL_FILE_DIR . '/client.key');
+    stream_context_set_option($context, 'ssl', 'local_cert', SSL_FILE_DIR . '/client-cert.pem');
+    stream_context_set_option($context, 'ssl', 'local_pk', SSL_FILE_DIR . '/client-key.pem');
 
     $fp = stream_socket_client("ssl://127.0.0.1:8000", $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $context);
     if (!$fp) {

--- a/tests/swoole_runtime/ssl/without_key.phpt
+++ b/tests/swoole_runtime/ssl/without_key.phpt
@@ -15,11 +15,8 @@ $ready = new Chan;
 
 go(function () use ($ready) {
     $context = stream_context_create();
-    stream_context_set_option($context, 'ssl', 'allow_self_signed', true);
-    stream_context_set_option($context, 'ssl', 'verify_peer', true);
     stream_context_set_option($context, 'ssl', 'local_cert', SSL_FILE_DIR.'/server.crt');
     stream_context_set_option($context, 'ssl', 'local_pk', SSL_FILE_DIR.'/server.key');
-    stream_context_set_option($context, 'ssl', 'cafile', SSL_FILE_DIR.'/ca.crt');
 
     $socket = stream_socket_server("ssl://0.0.0.0:8000", $errno, $errstr, STREAM_SERVER_BIND | STREAM_SERVER_LISTEN, $context);
     if (!$socket) {

--- a/tests/swoole_server/ssl/verify_03.phpt
+++ b/tests/swoole_server/ssl/verify_03.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_server/ssl: server verify client failed
+swoole_server/ssl: server rejects client without certificate
 --SKIPIF--
 <?php
 require __DIR__ . '/../../include/skipif.inc';
@@ -44,3 +44,4 @@ $pm->childFirst();
 $pm->run();
 ?>
 --EXPECTF--
+[%s]	NOTICE	ReactorThread_verify_ssl_state() (ERRNO %d): peer certificate from fd#%d is required


### PR DESCRIPTION
Servers accepted `ssl_cafile` and `ssl_capath` for peer verification but did not request or require a client certificate. Coroutine TLS listeners also ignored `ssl_client_cert_file`.

Use the socket role when creating TLS contexts, require client certificates for every supported trust source, and keep outbound client verification unchanged. Missing client certificates now report the existing SSL error.

A server configured with `ssl_verify_peer` but none of `ssl_client_cert_file`, `ssl_cafile`, or `ssl_capath` now fails at `set()` unless `ssl_allow_self_signed` is enabled. Previously this configuration silently used `SSL_VERIFY_NONE`.