### PR TITLE
Improve PHPT hang diagnostics and fix flaky socket tests

### DIFF
--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1658,10 +1658,10 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                             // - If this is running a small enough number of tests,
                             //   reduce the batch size to give batches to more workers.
                             $files = [];
-                            $maxBatchSize = $valgrind ? 1 : 4;
+                            $maxBatchSize = $valgrind ? 1 : ($shuffle ? 4 : 32);
                             $averageFilesPerWorker = max(1, (int)ceil($totalFileCount / count($workerProcs)));
                             $batchSize = min($maxBatchSize, $averageFilesPerWorker);
-                            while (count($files) < $batchSize && $file = array_pop($test_files)) {
+                            while (count($files) <= $batchSize && $file = array_pop($test_files)) {
                                 foreach ($fileConflictsWith[$file] as $conflictKey) {
                                     if (isset($activeConflicts[$conflictKey])) {
                                         $waitingTests[$conflictKey][] = $file;

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1285,11 +1285,21 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
             return $data;
         }
 
-        if (!$pipes) {
-            $stat = proc_get_status($proc);
-            if (!$stat['running']) {
-                break;
+        $currentStat = proc_get_status($proc);
+        if (!$currentStat['running']) {
+            $stat = $currentStat;
+            foreach ($pipes as $pipe) {
+                stream_set_blocking($pipe, false);
+                while (($line = fread($pipe, 8192)) !== '') {
+                    $data .= $line;
+                }
+                fclose($pipe);
             }
+            $pipes = [];
+            break;
+        }
+
+        if (!$pipes) {
             usleep((int) min(10000, $remaining * 1000000));
             continue;
         }
@@ -1299,20 +1309,17 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
         $w = null;
         $e = null;
 
-        $seconds = (int) $remaining;
-        $microseconds = (int) (($remaining - $seconds) * 1000000);
+        // Poll the process itself as descendants may inherit its pipes and keep
+        // them open after the test process has already exited.
+        $selectTimeout = min($remaining, 1.0);
+        $seconds = (int) $selectTimeout;
+        $microseconds = (int) (($selectTimeout - $seconds) * 1000000);
         $n = @stream_select($r, $w, $e, $seconds, $microseconds);
 
         if ($n === false) {
             continue;
         } else if ($n === 0) {
-            /* timed out */
-            $data .= "\n ** ERROR: process timed out after {$timeout} seconds **\n";
-            proc_terminate($proc, 9);
-            foreach ($pipes as $pipe) {
-                fclose($pipe);
-            }
-            return $data;
+            continue;
         } else if ($n > 0) {
             foreach ($r as $readyPipe) {
                 $pipeIndex = array_search($readyPipe, $pipes, true);

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -116,6 +116,10 @@ Options:
     --show-slow [n]
                 Show all tests that took longer than [n] milliseconds to run.
 
+    --status-interval [n]
+                Report currently running parallel tests every [n] seconds.
+                The default is 30 seconds. Use 0 to disable status reports.
+
     --no-clean  Do not execute clean section if any.
 
     --color
@@ -152,7 +156,7 @@ function main()
            $repeat, $result_tests_file, $slow_min_ms, $start_time, $switch,
            $temp_source, $temp_target, $temp_urlbase, $test_cnt, $test_dirs,
            $test_files, $test_idx, $test_list, $test_results, $testfile,
-           $user_tests, $valgrind, $sum_results, $shuffle;
+           $user_tests, $valgrind, $sum_results, $shuffle, $status_interval;
     // Parallel testing
     global $workers, $workerID;
 
@@ -422,6 +426,7 @@ NO_PROC_OPEN_ERROR;
     $preload = false;
     $shuffle = false;
     $workers = null;
+    $status_interval = 30;
 
     $cfgtypes = ['show', 'keep'];
     $cfgfiles = ['skip', 'php', 'clean', 'out', 'diff', 'exp', 'mem'];
@@ -591,6 +596,13 @@ NO_PROC_OPEN_ERROR;
                     break;
                 case '--show-slow':
                     $slow_min_ms = $argv[++$i];
+                    break;
+                case '--status-interval':
+                    $status_interval = $argv[++$i] ?? null;
+                    if ($status_interval === null || !preg_match('/^\d+$/', $status_interval)) {
+                        error("'$status_interval' is not a valid status interval");
+                    }
+                    $status_interval = intval($status_interval, 10);
                     break;
                 case '--temp-source':
                     $temp_source = $argv[++$i];
@@ -1259,56 +1271,74 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
     }
 
     $timeout = $valgrind ? 300 : ($env['TEST_TIMEOUT'] ?? 60);
+    $deadline = microtime(true) + $timeout;
+    $stat = null;
 
     while (true) {
+        $remaining = $deadline - microtime(true);
+        if ($remaining <= 0) {
+            $data .= "\n ** ERROR: process timed out after {$timeout} seconds **\n";
+            proc_terminate($proc, 9);
+            foreach ($pipes as $pipe) {
+                fclose($pipe);
+            }
+            return $data;
+        }
+
+        if (!$pipes) {
+            $stat = proc_get_status($proc);
+            if (!$stat['running']) {
+                break;
+            }
+            usleep((int) min(10000, $remaining * 1000000));
+            continue;
+        }
+
         /* hide errors from interrupted syscalls */
         $r = $pipes;
         $w = null;
         $e = null;
 
-        $n = @stream_select($r, $w, $e, $timeout);
+        $seconds = (int) $remaining;
+        $microseconds = (int) (($remaining - $seconds) * 1000000);
+        $n = @stream_select($r, $w, $e, $seconds, $microseconds);
 
         if ($n === false) {
-            break;
+            continue;
         } else if ($n === 0) {
             /* timed out */
-            $data .= "\n ** ERROR: process timed out **\n";
+            $data .= "\n ** ERROR: process timed out after {$timeout} seconds **\n";
             proc_terminate($proc, 9);
+            foreach ($pipes as $pipe) {
+                fclose($pipe);
+            }
             return $data;
         } else if ($n > 0) {
-            // swoole patch: fix blocking read
-            if (SWOOLE_IS_MUSL_LIBC) {
-                if ($captureStdOut) {
-                    $line = fread($pipes[1], 8192);
-                } elseif ($captureStdErr) {
-                    $line = fread($pipes[2], 8192);
-                } else {
-                    $line = '';
+            foreach ($r as $readyPipe) {
+                $pipeIndex = array_search($readyPipe, $pipes, true);
+                if ($pipeIndex === false) {
+                    continue;
                 }
-            } else {
-                $line = '';
-                if ($captureStdOut && in_array($pipes[1], $r)) {
-                    $line .= fread($pipes[1], 8192);
+
+                $line = fread($readyPipe, 8192);
+                if ($line === '' && feof($readyPipe)) {
+                    fclose($readyPipe);
+                    unset($pipes[$pipeIndex]);
+                    continue;
                 }
-                if ($captureStdErr && in_array($pipes[2], $r)) {
-                    $line .= fread($pipes[2], 8192);
+
+                $data .= $line;
+                if (strlen($data) > SWOOLE_TEST_OUTPUT_MAX_SIZE) {
+                    echo "FATAL ERROR: The output content exceeds the maximum size\n";
+                    echo "========================================================\n";
+                    echo substr($data, 0, 65536);
+                    exit(253);
                 }
-            }
-            if (strlen($line) == 0) {
-                /* EOF */
-                break;
-            }
-            $data .= $line;
-            if (strlen($data) > SWOOLE_TEST_OUTPUT_MAX_SIZE) {
-                echo "FATAL ERROR: The output content exceeds the maximum size\n";
-                echo "========================================================\n";
-                echo substr($data, 0, 65536);
-                exit(253);
             }
         }
     }
 
-    $stat = proc_get_status($proc);
+    $stat ??= proc_get_status($proc);
 
     if ($stat['signaled']) {
         $data .= "\nTermsig=" . $stat['stopsig'] . "\n";
@@ -1347,10 +1377,13 @@ function run_all_tests($test_files, $env, $redir_tested = null)
         }
         $test_idx++;
 
+        $testStartedAt = microtime(true);
+
         if ($workerID) {
             send_message($workerSock, [
                     "type" => "begin",
                     "file" => $name,
+                    "started_at" => $testStartedAt,
             ]);
         }
 
@@ -1372,6 +1405,7 @@ function run_all_tests($test_files, $env, $redir_tested = null)
                     "index" => $index,
                     "result" => $result,
                     "text" => $resultText,
+                    "duration" => microtime(true) - $testStartedAt,
                     "PHP_FAILED_TESTS" => $PHP_FAILED_TESTS
                 ]);
                 continue;
@@ -1390,7 +1424,7 @@ function run_all_tests($test_files, $env, $redir_tested = null)
 
 /** The heart of parallel testing. */
 function run_all_tests_parallel($test_files, $env, $redir_tested) {
-    global $workers, $test_idx, $test_cnt, $test_results, $failed_tests_file, $result_tests_file, $PHP_FAILED_TESTS, $shuffle, $SHOW_ONLY_GROUPS, $valgrind;
+    global $workers, $test_idx, $test_cnt, $test_results, $failed_tests_file, $result_tests_file, $PHP_FAILED_TESTS, $shuffle, $SHOW_ONLY_GROUPS, $valgrind, $status_interval;
 
     // The PHP binary running run-tests.php, and run-tests.php itself
     // This PHP executable is *not* necessarily the same as the tested version
@@ -1538,6 +1572,8 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
 
     $rawMessageBuffers = [];
     $testsInProgress = 0;
+    $activeTests = [];
+    $lastStatusReport = microtime(true);
 
     // Map from conflict key to worker ID.
     $activeConflicts = [];
@@ -1549,12 +1585,22 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
         $toRead = array_values($workerSocks);
         $toWrite = NULL;
         $toExcept = NULL;
-        if (stream_select($toRead, $toWrite, $toExcept, 10)) {
+        $pollTimeout = 10;
+        if ($status_interval > 0 && $activeTests) {
+            $untilStatusReport = $status_interval - (microtime(true) - $lastStatusReport);
+            $pollTimeout = max(1, min($pollTimeout, (int) ceil($untilStatusReport)));
+        }
+        if (stream_select($toRead, $toWrite, $toExcept, $pollTimeout)) {
             foreach ($toRead as $workerSock) {
                 $i = array_search($workerSock, $workerSocks);
                 if ($i === FALSE) {
                     kill_children($workerProcs);
                     error("Could not find worker stdout in array of worker stdouts, THIS SHOULD NOT HAPPEN.");
+                }
+                if (feof($workerSock)) {
+                    show_running_tests($activeTests);
+                    kill_children($workerProcs);
+                    error("Worker $i died unexpectedly");
                 }
                 while (FALSE !== ($rawMessage = fgets($workerSock))) {
                     // work around fgets truncating things
@@ -1577,6 +1623,7 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                     switch ($message["type"]) {
                         case "tests_finished":
                             $testsInProgress--;
+                            unset($activeTests[$i]);
                             foreach ($activeConflicts as $key => $workerId) {
                                 if ($workerId === $i) {
                                     unset($activeConflicts[$key]);
@@ -1604,10 +1651,10 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                             // - If this is running a small enough number of tests,
                             //   reduce the batch size to give batches to more workers.
                             $files = [];
-                            $maxBatchSize = $valgrind ? 1 : ($shuffle ? 4 : 32);
+                            $maxBatchSize = $valgrind ? 1 : 4;
                             $averageFilesPerWorker = max(1, (int)ceil($totalFileCount / count($workerProcs)));
                             $batchSize = min($maxBatchSize, $averageFilesPerWorker);
-                            while (count($files) <= $batchSize && $file = array_pop($test_files)) {
+                            while (count($files) < $batchSize && $file = array_pop($test_files)) {
                                 foreach ($fileConflictsWith[$file] as $conflictKey) {
                                     if (isset($activeConflicts[$conflictKey])) {
                                         $waitingTests[$conflictKey][] = $file;
@@ -1637,8 +1684,12 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                             }
                             break;
                         case "begin":
-                            if (!$SHOW_ONLY_GROUPS) {
-                                show_test($test_idx, get_shortname($message['file']));
+                            $activeTests[$i] = [
+                                'file' => $message['file'],
+                                'started_at' => $message['started_at'] ?? microtime(true),
+                            ];
+                            if (!$SHOW_ONLY_GROUPS || persistent_test_output()) {
+                                show_test($test_idx, get_shortname($message['file']), $i);
                             }
                             break;
                         case "test_result":
@@ -1653,6 +1704,8 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                             }
 
                             echo $resultText;
+                            show_test_end($i, $result, $message['duration'] ?? null, get_shortname($name));
+                            unset($activeTests[$i]);
 
                             if (!is_array($name) && $result != 'REDIR') {
                                 $test_results[$index] = $result;
@@ -1695,6 +1748,11 @@ function run_all_tests_parallel($test_files, $env, $redir_tested) {
                     }
                 }
             }
+        }
+
+        if ($status_interval > 0 && microtime(true) - $lastStatusReport >= $status_interval) {
+            show_running_tests($activeTests);
+            $lastStatusReport = microtime(true);
         }
     }
 
@@ -3345,15 +3403,32 @@ function show_redirect_ends($tests, $tested, $tested_file)
     }
 }
 
-function show_test($test_idx, $shortname)
+function persistent_test_output(): bool
+{
+    static $persistent = null;
+
+    if ($persistent === null) {
+        $persistent = getenv('CI') !== false
+            || !function_exists('stream_isatty')
+            || !@stream_isatty(STDOUT);
+    }
+
+    return $persistent;
+}
+
+function show_test($test_idx, $shortname, $parallelWorkerId = 0)
 {
     global $test_cnt;
     global $line_length;
 
     // swoole patch: pretty output
-    $str = "TEST $test_idx/$test_cnt [$shortname]";
+    if ($parallelWorkerId) {
+        $str = "[PHPT START] worker=$parallelWorkerId completed=$test_idx/$test_cnt file=$shortname";
+    } else {
+        $str = "TEST $test_idx/$test_cnt [$shortname]";
+    }
     $line_length = strlen($str);
-    echo $str;
+    echo $str, persistent_test_output() ? "\n" : "";
     flush();
 }
 
@@ -3362,10 +3437,42 @@ function clear_show_test() {
     // Parallel testing
     global $workerID;
 
-    if (!$workerID) {
+    if (!$workerID && !persistent_test_output()) {
         // Write over the last line to avoid random trailing chars on next echo
         echo str_repeat(" ", intval($line_length)), "\r";
     }
+}
+
+function show_test_end($parallelWorkerId, $result, $duration, $shortname): void
+{
+    if (!persistent_test_output()) {
+        return;
+    }
+
+    $durationText = $duration === null ? 'unknown' : sprintf('%.3fs', $duration);
+    echo "[PHPT END] worker=$parallelWorkerId status=$result duration=$durationText file=$shortname\n";
+    flush();
+}
+
+function show_running_tests(array $activeTests): void
+{
+    if (!$activeTests) {
+        return;
+    }
+
+    ksort($activeTests);
+    $now = microtime(true);
+    echo "[PHPT STATUS] running=", count($activeTests), "\n";
+    foreach ($activeTests as $parallelWorkerId => $test) {
+        $elapsed = max(0, $now - $test['started_at']);
+        echo sprintf(
+            "[PHPT RUNNING] worker=%d elapsed=%.1fs file=%s\n",
+            $parallelWorkerId,
+            $elapsed,
+            get_shortname($test['file'])
+        );
+    }
+    flush();
 }
 
 function parse_conflicts(string $text) : array {

--- a/tests/swoole_http_server/sendfile_client_reset.phpt
+++ b/tests/swoole_http_server/sendfile_client_reset.phpt
@@ -13,27 +13,27 @@ use Swoole\Coroutine\System;
 use Swoole\Coroutine\Client;
 use Swoole\Runtime;
 
-const TMP_FILE = '/tmp/sendfile.txt';
-$send_file = get_safe_random(mt_rand(0, rand(16, 32) * 1024 * 1024) + rand(1024, 65536));
-file_put_contents(TMP_FILE, $send_file);
+$tmpFile = tempnam(sys_get_temp_dir(), 'swoole-sendfile-reset-');
+$sendFile = get_safe_random(mt_rand(4, 8) * 1024 * 1024);
+file_put_contents($tmpFile, $sendFile);
 
 $pm = new ProcessManager;
-$pm->parentFunc = function ($pid) use ($pm) {
+$pm->parentFunc = function ($pid) use ($pm, $tmpFile) {
     Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
-    Co\run(function () use ($pm) {
+    Co\run(function () use ($pm, $tmpFile) {
         $client = new Client(SWOOLE_SOCK_TCP);
         $client->set(['socket_buffer_size' => 128 * 1024]);
         Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
         $client->send("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
         $resp = '';
 
-        Co\go(function () use ($pm) {
+        Co\go(function () use ($pm, $tmpFile) {
             $file = file_get_contents('http://127.0.0.1:' . $pm->getFreePort());
-            Assert::eq(md5_file(TMP_FILE), md5($file));
+            Assert::eq(md5_file($tmpFile), md5($file));
         });
 
         while (true) {
-            $data = $client->recv();
+            $data = $client->recv(5.0);
             System::sleep(0.01);
             Assert::notEmpty($data);
             $resp .= $data;
@@ -47,7 +47,7 @@ $pm->parentFunc = function ($pid) use ($pm) {
     echo "DONE\n";
     $pm->kill();
 };
-$pm->childFunc = function () use ($pm) {
+$pm->childFunc = function () use ($pm, $tmpFile) {
     $http = new Server('127.0.0.1', $pm->getFreePort(), SERVER_MODE_RANDOM);
     $http->set([
         'worker_num' => 1,
@@ -56,16 +56,16 @@ $pm->childFunc = function () use ($pm) {
     $http->on('workerStart', function () use ($pm) {
         $pm->wakeup();
     });
-    $http->on('request', function (Request $request, Response $response) {
+    $http->on('request', function (Request $request, Response $response) use ($tmpFile) {
         $response->header('Content-Type', 'application/octet-stream');
         $response->header('Content-Disposition', 'attachment; filename=recvfile.txt');
-        $response->sendfile(TMP_FILE);
+        $response->sendfile($tmpFile);
     });
     $http->start();
 };
 $pm->childFirst();
 $pm->run();
-unlink(TMP_FILE);
+unlink($tmpFile);
 ?>
 --EXPECT--
 DONE

--- a/tests/swoole_http_server/unixsocket2.phpt
+++ b/tests/swoole_http_server/unixsocket2.phpt
@@ -9,13 +9,14 @@ require __DIR__ . '/../include/bootstrap.php';
 use Swoole\Http\Server;
 use Swoole\Http\Response;
 
-const SOCKET = __DIR__ . '/server.sock';
+$socket = tempnam(sys_get_temp_dir(), 'swoole-http-server-');
+unlink($socket);
 
 $pm = new SwooleTest\ProcessManager;
 
-$pm->parentFunc = function ($pid) use ($pm) {
+$pm->parentFunc = function ($pid) use ($pm, $socket) {
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_UNIX_SOCKET_PATH, SOCKET);
+    curl_setopt($ch, CURLOPT_UNIX_SOCKET_PATH, $socket);
     curl_setopt($ch, CURLOPT_URL, "http://localhost/?a=hello&b=12345&test=world");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     $output = curl_exec($ch);
@@ -23,8 +24,8 @@ $pm->parentFunc = function ($pid) use ($pm) {
     $pm->kill();
 };
 
-$pm->childFunc = function () use ($pm) {
-    $serv = new Server(SOCKET, 0, SWOOLE_PROCESS, SWOOLE_SOCK_UNIX_STREAM);
+$pm->childFunc = function () use ($pm, $socket) {
+    $serv = new Server($socket, 0, SWOOLE_PROCESS, SWOOLE_SOCK_UNIX_STREAM);
     $serv->set([
         'log_file' => '/dev/null',
     ]);
@@ -39,6 +40,7 @@ $pm->childFunc = function () use ($pm) {
 
 $pm->childFirst();
 $pm->run();
+@unlink($socket);
 ?>
 --EXPECT--
 string(40) "{"a":"hello","b":"12345","test":"world"}"

--- a/tests/swoole_socket_coro/closed.phpt
+++ b/tests/swoole_socket_coro/closed.phpt
@@ -11,7 +11,7 @@ Assert::assert($server !== false, $errorMessage ?: 'failed to create TCP server'
 $serverAddress = stream_socket_get_name($server, false);
 $port = (int) substr(strrchr($serverAddress, ':'), 1);
 
-go(function () use ($port) {
+go(function () use ($port, $server) {
     $socket = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, 0);
     Assert::assert($socket->connect('127.0.0.1', $port));
     Assert::assert($socket->close());
@@ -39,9 +39,9 @@ go(function () use ($port) {
     $assertBadFileDescriptor();
     Assert::assert(!$socket->getpeername());
     $assertBadFileDescriptor();
+    fclose($server);
     echo "DONE\n";
 });
-fclose($server);
 ?>
 --EXPECT--
 DONE


### PR DESCRIPTION
## Summary

- keep the local TCP listener alive until the closed-socket coroutine finishes its assertions
- emit durable `[PHPT START]` and `[PHPT END]` records with worker ID, status, and duration in CI logs
- report every active parallel worker and its current PHPT every 30 seconds; add `--status-interval` to configure or disable this heartbeat
- enforce an absolute per-test timeout and handle stdout/stderr EOF independently
- stop waiting for output pipes inherited by descendants after the direct PHPT process exits
- make `sendfile_client_reset.phpt` deterministic, bounded, and isolated with a unique temporary file
- isolate `unixsocket2.phpt` with a unique Unix socket path and explicit cleanup

## Root causes found

- `closed.phpt`: the listener was released while `Socket::connect()` was yielding, allowing Linux to reset the queued connection and retain `ECONNRESET` instead of testing post-close `EBADF`
- `sendfile_client_reset.phpt`: the random file could be smaller than the 2 MiB client-close threshold, leaving `recv()` blocked on an HTTP/1.1 keep-alive connection
- the old runner printed `TEST` progress without a durable newline and did not track the active test per worker
- the old timeout loop could stop reading when only one pipe reached EOF, then block forever in `proc_close()`
- fatal-error PHPTs may leave server descendants holding inherited output pipes even though the direct test process has already exited
- `unixsocket2.phpt` reused a repository-local socket path, so an initial transient failure poisoned every retry with `EADDRINUSE`

## Validation

- closed socket PHPT passed 20 local repetitions
- synthetic parallel hang test produced exact START, RUNNING, timeout, and END records
- inherited-pipe fixture completed immediately instead of waiting for its descendant
- `close_before_resume.phpt` and `exec_twice.phpt` both PASS locally and in Linux x86 CI in about 0.2 to 0.3 seconds
- `sendfile_client_reset.phpt` PASS in Linux x86 full CI in 0.536 seconds
- `unixsocket2.phpt` passed five consecutive local runs
- [Linux Unit run](https://github.com/swoole/swoole-src/actions/runs/33473781416): x86_64 full suite SUCCESS in about 5m24s; ARM64 full suite SUCCESS in about 6m02s
- [Windows Unit run](https://github.com/swoole/swoole-src/actions/runs/33471636063): SUCCESS, including IOCP socket and thread groups

macOS still reports existing platform-sensitive failures in `swoole_coroutine_lock/lock.phpt` and `swoole_curl/error.phpt`; neither is a runner timeout or worker-state failure.