### PR TITLE
Fix HTTP deflate responses using the raw deflate format

### DIFF
--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -531,9 +531,8 @@ bool HttpContext::compress(const char *data, size_t length) {
     else if (compression_method == HTTP_COMPRESS_GZIP) {
         encoding = 0x1f;
     }
-    // deflate: -0xf
     else if (compression_method == HTTP_COMPRESS_DEFLATE) {
-        encoding = -0xf;
+        encoding = SW_ZLIB_ENCODING_DEFLATE;
     }
 #endif
 #ifdef SW_HAVE_BROTLI

--- a/tests/swoole_http_server/compression_deflate.phpt
+++ b/tests/swoole_http_server/compression_deflate.phpt
@@ -1,0 +1,51 @@
+--TEST--
+swoole_http_server: deflate response uses the zlib data format
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_constant_not_defined('SWOOLE_HAVE_ZLIB');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+const HTTP_GET_REQUEST = "GET / HTTP/1.1\r\nAccept-Encoding: deflate\r\n\r\n";
+
+$content = str_repeat(get_safe_random(256), 8);
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm, $content) {
+    Co\run(function () use ($pm, $content) {
+        $client = new Co\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+        if (Assert::true($client->connect('127.0.0.1', $pm->getFreePort()))) {
+            if (Assert::eq($client->sendAll(HTTP_GET_REQUEST), strlen(HTTP_GET_REQUEST))) {
+                $response = $client->recv();
+                Assert::contains($response, 'Content-Encoding: deflate');
+                $body = substr($response, strpos($response, "\r\n\r\n") + 4);
+                Assert::eq(gzuncompress($body), $content);
+            }
+        }
+        $client->close();
+    });
+    $pm->kill();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm, $content) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $http->set([
+        'log_file' => '/dev/null',
+        'http_compression' => true,
+    ]);
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($content) {
+        $response->end($content);
+    });
+    $http->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
Backports #6180 to the 6.1 branch. HttpContext::compress() set the deflate window size to -0xf, which emits a raw deflate stream instead of the zlib format that Content-Encoding: deflate calls for. gzuncompress() could not read the body, even though gzinflate() and Swoole's own coroutine client still worked, since the client retries with raw deflate after a Z_DATA_ERROR. The branch now uses SW_ZLIB_ENCODING_DEFLATE, the same constant the client already inflates with.

Same root cause and fix as #6180. The code here matches master, so nothing needed adapting. Fixes #6179.
