### PR TITLE
Fix memory errors in Server cpu_affinity_ignore parsing

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2223,31 +2223,36 @@ static PHP_METHOD(swoole_server, set) {
     }
     // cpu affinity set
     if (php_swoole_array_get_value(vht, "cpu_affinity_ignore", ztmp)) {
-        int ignore_num = zend_hash_num_elements(Z_ARRVAL_P(ztmp));
-        if (ignore_num >= SW_CPU_NUM) {
-            php_swoole_fatal_error(E_ERROR, "cpu_affinity_ignore num must be less than cpu num (%d)", SW_CPU_NUM);
+        if (!ZVAL_IS_ARRAY(ztmp)) {
+            php_swoole_fatal_error(E_ERROR, "cpu_affinity_ignore must be array");
             RETURN_FALSE;
         }
-        int available_num = SW_CPU_NUM - ignore_num;
-        int *available_cpu = (int *) sw_malloc(sizeof(int) * available_num);
-        if (!available_cpu) {
-            php_swoole_fatal_error(E_WARNING, "malloc() failed");
-            RETURN_FALSE;
-        }
-        int flag, i, available_i = 0;
-
+        std::vector<bool> ignored_cpus(SW_CPU_NUM, false);
+        int ignore_num = 0;
         zval *zval_core = nullptr;
-        for (i = 0; i < SW_CPU_NUM; i++) {
-            flag = 1;
-            SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(ztmp), zval_core)
-            if (i == zval_get_long(zval_core)) {
-                flag = 0;
-                break;
+        SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(ztmp), zval_core)
+        zend_long cpu_id = zval_get_long(zval_core);
+        if (cpu_id >= 0 && cpu_id < SW_CPU_NUM && !ignored_cpus[cpu_id]) {
+            ignored_cpus[cpu_id] = true;
+            ignore_num++;
+        }
+        SW_HASHTABLE_FOREACH_END();
+
+        int available_num = 0;
+        int *available_cpu = nullptr;
+        if (ignore_num > 0 && ignore_num < SW_CPU_NUM) {
+            available_num = SW_CPU_NUM - ignore_num;
+            available_cpu = (int *) sw_malloc(sizeof(int) * available_num);
+            if (!available_cpu) {
+                php_swoole_fatal_error(E_WARNING, "malloc() failed");
+                RETURN_FALSE;
             }
-            SW_HASHTABLE_FOREACH_END();
-            if (flag) {
-                available_cpu[available_i] = i;
-                available_i++;
+            int available_i = 0;
+            for (int i = 0; i < SW_CPU_NUM; i++) {
+                if (!ignored_cpus[i]) {
+                    available_cpu[available_i] = i;
+                    available_i++;
+                }
             }
         }
         serv->cpu_affinity_available_num = available_num;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -767,6 +767,7 @@ Server::~Server() {
     for (auto port : ports) {
         delete port;
     }
+    sw_free(cpu_affinity_available);
     sw_shm_free(gs);
 }
 

--- a/tests/swoole_server/cpu_affinity_ignore_type.phpt
+++ b/tests/swoole_server/cpu_affinity_ignore_type.phpt
@@ -1,0 +1,17 @@
+--TEST--
+swoole_server: cpu_affinity_ignore requires an array
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', 0);
+$server->set([
+    'cpu_affinity_ignore' => 0,
+]);
+?>
+--EXPECTF--
+Fatal error: Swoole\Server::set(): cpu_affinity_ignore must be array in %s on line %d

--- a/tests/swoole_server/cpu_affinity_ignore_values.phpt
+++ b/tests/swoole_server/cpu_affinity_ignore_values.phpt
@@ -1,0 +1,27 @@
+--TEST--
+swoole_server: cpu_affinity_ignore ignores unusable CPU IDs
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', 0);
+$cpuNum = swoole_cpu_num();
+
+$server->set([
+    'cpu_affinity_ignore' => [-1, $cpuNum, 0, 0],
+]);
+$server->set([
+    'cpu_affinity_ignore' => [-1, $cpuNum],
+]);
+$server->set([
+    'cpu_affinity_ignore' => range(0, $cpuNum - 1),
+]);
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
`Server::set()` sized the `cpu_affinity_available` allocation from the raw number of `cpu_affinity_ignore` entries, then filled it from the unique valid CPU IDs. Duplicate, negative, and out-of-range IDs could make those counts disagree and write past the allocation. A non-array value was read as an array and crashed. The stored allocation was also not released when the server was destroyed.

This requires the option itself to be an array, ignores unusable CPU IDs, and counts each valid ID once. When no usable custom set remains, it stores a null pointer and zero count, matching the representation expected by the consumers that existed before #5320. Server destruction now releases the stored allocation.

`Server::set()` still accepts and parses this option, although the parsed result has had no consumers since #5320.

The focused PHPTs fail on unchanged 6.1 and pass with this change. The memory reports require an ASAN build:

```sh
phpize
./configure --enable-asan --enable-openssl --enable-sockets
make -j$(nproc)
```

On unchanged 6.1, ASAN reports a null read for a non-array value and a heap-buffer-overflow for duplicate and invalid CPU IDs. LeakSanitizer reports the stored allocation when a configured server is started and stopped. These reports are gone with this change.