### PR TITLE
Fix coroutine HTTP server request boundaries and 100 Continue

### DIFF
--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -403,10 +403,6 @@ static int http_request_on_header_value(llhttp_t *parser, const char *at, size_t
         ctx->set_compression_method(at, length);
     }
 #endif
-    else if (SW_STRCASEEQ(header_name, header_len, "transfer-encoding") && SW_STR_ISTARTS_WITH(at, length, "chunked")) {
-        ctx->recv_chunked = 1;
-    }
-
 _add_header:
     zval tmp;
     ZVAL_STRINGL(&tmp, (char *) at, length);
@@ -476,6 +472,7 @@ static int http_request_on_headers_complete(llhttp_t *parser) {
         (ctx->request.version == 101 ? SW_ZSTR_KNOWN(SW_ZEND_STR_HTTP11) : SW_ZSTR_KNOWN(SW_ZEND_STR_HTTP10)));
 
     ctx->keepalive = llhttp_should_keep_alive(parser);
+    ctx->recv_chunked = !!(parser->flags & F_CHUNKED);
     ctx->current_header_name = nullptr;
 
     return 0;
@@ -787,7 +784,7 @@ static int http_request_on_body(llhttp_t *parser, const char *at, size_t length)
         ctx->request.body_length += length;
     }
 
-    if (ctx->mt_parser != nullptr) {
+    if (ctx->mt_parser != nullptr && !ctx->recv_chunked) {
         if (is_beginning) {
             /* Compatibility: some clients may send extra EOL */
             do {
@@ -809,6 +806,21 @@ static int http_request_on_body(llhttp_t *parser, const char *at, size_t length)
 static int http_request_message_complete(llhttp_t *parser) {
     auto *ctx = static_cast<HttpContext *>(parser->data);
     size_t content_length = ctx->request.chunked_body ? ctx->request.chunked_body->length : ctx->request.body_length;
+
+    if (ctx->mt_parser != nullptr && ctx->request.chunked_body != nullptr) {
+        // The bundled multipart parser rejects calls that end inside a part header. llhttp body spans can end at
+        // receive boundaries, so parse the dechunked body in one pass here instead of parsing each span.
+        const char *at = ctx->request.chunked_body->str;
+        size_t length = ctx->request.chunked_body->length;
+        /* Compatibility: some clients may send extra EOL */
+        while (length != 0 && (*at == '\r' || *at == '\n')) {
+            at++;
+            length--;
+        }
+        if (!ctx->parse_multipart_data(at, length)) {
+            return -1;
+        }
+    }
 
     if (ctx->request.chunked_body != nullptr && ctx->parse_body && ctx->request.post_form_urlencoded) {
         /* parse dechunked content */

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -616,6 +616,14 @@ static PHP_METHOD(swoole_http_server_coro, onAccept) {
             if (total_length > buffer->size) {
                 buffer->extend(total_length);
             }
+            // This block runs once per request, so the interim response is not repeated while the body arrives.
+            if (!ctx->completed) {
+                zval *zexpect = zend_hash_str_find(Z_ARRVAL_P(ctx->request.zheader), ZEND_STRL("expect"));
+                if (zexpect && Z_TYPE_P(zexpect) == IS_STRING &&
+                    SW_STRCASEEQ(Z_STRVAL_P(zexpect), Z_STRLEN_P(zexpect), "100-continue")) {
+                    sock->send_all(SW_STRL(SW_HTTP_100_CONTINUE_PACKET));
+                }
+            }
         }
 
         if (!ctx->completed) {

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -615,8 +615,15 @@ static PHP_METHOD(swoole_http_server_coro, onAccept) {
 
         if (!ctx->completed) {
             // Make sure the complete request package is received
-            if (ctx->recv_chunked && memcmp(buffer->str + buffer->length - (sizeof(SW_HTTP_CHUNK_EOF) - 1),
-                                            SW_STRL(SW_HTTP_CHUNK_EOF)) != 0) {
+            if (ctx->recv_chunked && !buffer->ends_with(SW_STRL(SW_HTTP_CHUNK_EOF))) {
+                if (buffer->length >= sock->protocol.package_max_length) {
+                    ctx->response.status = SW_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                    break;
+                }
+                if (buffer->length == buffer->size) {
+                    buffer->extend(
+                        SW_MIN(buffer->size + SW_BUFFER_SIZE_BIG, (size_t) sock->protocol.package_max_length));
+                }
                 goto _recv_request;
             }
             if (buffer->length < total_length) {

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -597,40 +597,39 @@ static PHP_METHOD(swoole_http_server_coro, onAccept) {
             // The HTTP header must be parsed first
             // Header contains CRLFx2
             header_length += 4;
+            // Check the header first so package_max_length - header_length cannot underflow.
+            if (header_length > sock->protocol.package_max_length) {
+                ctx->response.status = SW_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                break;
+            }
             size_t parsed_n = ctx->parse(buffer->str, header_length);
             if (parsed_n != header_length) {
                 ctx->response.status = SW_HTTP_BAD_REQUEST;
                 break;
             }
             buffer->offset += header_length;
-            total_length = header_length + ctx->get_content_length();
-            if (ctx->get_content_length() > 0 && total_length > sock->protocol.package_max_length) {
+            if (ctx->get_content_length() > sock->protocol.package_max_length - header_length) {
                 ctx->response.status = SW_HTTP_REQUEST_ENTITY_TOO_LARGE;
                 break;
             }
+            total_length = header_length + ctx->get_content_length();
             if (total_length > buffer->size) {
                 buffer->extend(total_length);
             }
         }
 
         if (!ctx->completed) {
-            // Make sure the complete request package is received
-            if (ctx->recv_chunked && !buffer->ends_with(SW_STRL(SW_HTTP_CHUNK_EOF))) {
-                if (buffer->length >= sock->protocol.package_max_length) {
-                    ctx->response.status = SW_HTTP_REQUEST_ENTITY_TOO_LARGE;
-                    break;
-                }
-                if (buffer->length == buffer->size) {
-                    buffer->extend(
-                        SW_MIN(buffer->size + SW_BUFFER_SIZE_BIG, (size_t) sock->protocol.package_max_length));
-                }
-                goto _recv_request;
-            }
-            if (buffer->length < total_length) {
+            if (!ctx->recv_chunked && buffer->length < total_length) {
                 goto _recv_request;
             }
 
-            size_t parsed_n = ctx->parse(buffer->str + buffer->offset, buffer->length - buffer->offset);
+            size_t parse_length = buffer->length - buffer->offset;
+            if (ctx->recv_chunked) {
+                // Header and incomplete-body checks keep the offset within the limit. Do not run body callbacks for
+                // bytes that the request limit will reject.
+                parse_length = SW_MIN(parse_length, sock->protocol.package_max_length - (size_t) buffer->offset);
+            }
+            size_t parsed_n = ctx->parse(buffer->str + buffer->offset, parse_length);
             buffer->offset += parsed_n;
 
             swoole_trace_log(SW_TRACE_CO_HTTP_SERVER,
@@ -643,6 +642,22 @@ static PHP_METHOD(swoole_http_server_coro, onAccept) {
             if (ctx->parser.error != HPE_OK && ctx->parser.error != HPE_PAUSED_H2_UPGRADE) {
                 ctx->response.status = SW_HTTP_BAD_REQUEST;
                 break;
+            }
+
+            if (ctx->recv_chunked) {
+                if (!ctx->completed) {
+                    if (buffer->length >= sock->protocol.package_max_length) {
+                        ctx->response.status = SW_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                        break;
+                    }
+                    if (buffer->length == buffer->size) {
+                        buffer->extend(
+                            SW_MIN(buffer->size + SW_BUFFER_SIZE_BIG, (size_t) sock->protocol.package_max_length));
+                    }
+                    goto _recv_request;
+                }
+                // llhttp pauses at the exact end of this request, before any pipelined bytes.
+                total_length = buffer->offset;
             }
         }
 

--- a/tests/swoole_http_server_coro/chunked_completion.phpt
+++ b/tests/swoole_http_server_coro/chunked_completion.phpt
@@ -1,0 +1,106 @@
+--TEST--
+swoole_http_server_coro: parse chunked request completion exactly
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+use Swoole\Coroutine\Socket;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+function recv_all(Socket $socket): string
+{
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
+Coroutine\run(function () {
+    $server = new Server('127.0.0.1', 0);
+    $handled = 0;
+    $requests = [];
+
+    Coroutine::create(function () use ($server, &$handled, &$requests) {
+        $server->handle('/', function (Request $request, Response $response) use (&$handled, &$requests) {
+            $handled++;
+            $requests[] = [
+                'path' => '/',
+                'content' => $request->rawContent(),
+                'data' => $request->getData(),
+                'trailer' => $request->header['x-trailer'] ?? null,
+            ];
+            $response->end('FIRST');
+        });
+        $server->handle('/next', function (Request $request, Response $response) use (&$handled, &$requests) {
+            $handled++;
+            $requests[] = ['path' => '/next', 'data' => $request->getData()];
+            $response->end('SECOND');
+        });
+        $server->handle('/encoded', function (Request $request, Response $response) use (&$handled, &$requests) {
+            $handled++;
+            $requests[] = ['path' => '/encoded', 'content' => $request->rawContent()];
+            $response->end('ENCODED');
+        });
+        $server->start();
+    });
+    Coroutine::sleep(0.001);
+
+    $payload = str_repeat('A', hexdec('1fa'));
+    $header = "POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n";
+    $first = $header . "5\r\n0\r\n\r\n";
+    $second = "\r\n1f";
+    $third = "a\r\n{$payload}\r\n0\r\nX-Trailer: yes\r\n\r\n";
+    $chunkedRequest = $first . $second . $third;
+    $pipelineRequest = "GET /next HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $server->port, -1));
+    Assert::same($socket->sendAll($first), strlen($first));
+    Coroutine::sleep(0.05);
+    Assert::same($handled, 0);
+    Assert::same($socket->sendAll($second), strlen($second));
+    Coroutine::sleep(0.01);
+    Assert::same($handled, 0);
+    Assert::same($socket->sendAll($third . $pipelineRequest), strlen($third . $pipelineRequest));
+    $response = recv_all($socket);
+
+    Assert::same(substr_count($response, 'HTTP/1.1 200 OK'), 2);
+    Assert::contains($response, 'FIRST');
+    Assert::contains($response, 'SECOND');
+    Assert::same($requests[0]['path'], '/');
+    Assert::same($requests[0]['content'], "0\r\n\r\n" . $payload);
+    Assert::same($requests[0]['data'], $chunkedRequest);
+    Assert::same($requests[0]['trailer'], 'yes');
+    Assert::same($requests[1]['path'], '/next');
+    Assert::same($requests[1]['data'], $pipelineRequest);
+
+    $encoded = gzencode(str_repeat('encoded-data-', 8));
+    $encodedRequest = "POST /encoded HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Transfer-Encoding: gzip, chunked\r\n" .
+        "Connection: close\r\n\r\n" .
+        dechex(strlen($encoded)) . "\r\n{$encoded}\r\n0\r\n\r\n";
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $server->port, -1));
+    Assert::same($socket->sendAll($encodedRequest), strlen($encodedRequest));
+    $response = recv_all($socket);
+    $server->shutdown();
+
+    Assert::contains($response, 'HTTP/1.1 200 OK');
+    Assert::contains($response, 'ENCODED');
+    Assert::same($requests[2]['path'], '/encoded');
+    // This checks chunked framing; Swoole leaves other transfer codings unchanged.
+    Assert::same($requests[2]['content'], $encoded);
+    Assert::same($handled, 3);
+
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server_coro/chunked_large_body.phpt
+++ b/tests/swoole_http_server_coro/chunked_large_body.phpt
@@ -1,5 +1,5 @@
 --TEST--
-swoole_http_server_coro: receive a large chunked request body
+swoole_http_server_coro: enforce chunked request package limits
 --SKIPIF--
 <?php require __DIR__ . '/../include/skipif.inc'; ?>
 --FILE--
@@ -34,16 +34,25 @@ function send_chunked_request(Server $server, string $request): string
     return $response;
 }
 
-Coroutine\run(function () {
+function start_http_server(int $limit, callable $handler): Server
+{
     $server = new Server('127.0.0.1', 0);
-    $server->set(['package_max_length' => 300000]);
+    $server->set(['package_max_length' => $limit]);
+    Coroutine::create(function () use ($server, $handler) {
+        $server->handle('/', $handler);
+        $server->start();
+    });
+    Coroutine::sleep(0.001);
+    return $server;
+}
 
+Coroutine\run(function () {
     $handled = 0;
     $receivedLength = 0;
     $receivedHash = '';
-
-    Coroutine::create(function () use ($server, &$handled, &$receivedLength, &$receivedHash) {
-        $server->handle('/', function (Request $request, Response $response) use (
+    $server = start_http_server(
+        300000,
+        function (Request $request, Response $response) use (
             &$handled,
             &$receivedLength,
             &$receivedHash
@@ -53,10 +62,8 @@ Coroutine\run(function () {
             $receivedLength = strlen($content);
             $receivedHash = md5($content);
             $response->end('OK');
-        });
-        $server->start();
-    });
-    Coroutine::sleep(0.001);
+        }
+    );
 
     $body = str_repeat('0123456789abcdef', 17500);
     $successResponse = send_chunked_request($server, make_chunked_request('/', $body));
@@ -67,6 +74,39 @@ Coroutine\run(function () {
     Assert::same($receivedLength, strlen($body));
     Assert::same($receivedHash, md5($body));
     Assert::contains($largeResponse, 'HTTP/1.1 413 Payload Too Large');
+    Assert::same($handled, 1);
+
+    $exactBody = str_repeat('E', 7000);
+    $exactRequest = make_chunked_request('/', $exactBody);
+    $limit = strlen($exactRequest);
+    $handled = 0;
+    $receivedLength = 0;
+    $server = start_http_server(
+        $limit,
+        function (Request $request, Response $response) use (&$handled, &$receivedLength) {
+            $handled++;
+            $receivedLength = strlen($request->rawContent());
+            $response->end('OK');
+        }
+    );
+
+    $exactResponse = send_chunked_request($server, $exactRequest);
+    $overResponse = send_chunked_request($server, make_chunked_request('/', $exactBody . 'X'));
+    $overflowResponse = send_chunked_request(
+        $server,
+        "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 18446744073709551615\r\nConnection: close\r\n\r\n"
+    );
+    $headerResponse = send_chunked_request(
+        $server,
+        "GET / HTTP/1.1\r\nHost: localhost\r\nX-Fill: " . str_repeat('H', $limit) . "\r\nConnection: close\r\n\r\n"
+    );
+    $server->shutdown();
+
+    Assert::contains($exactResponse, 'HTTP/1.1 200 OK');
+    Assert::same($receivedLength, strlen($exactBody));
+    Assert::contains($overResponse, 'HTTP/1.1 413 Payload Too Large');
+    Assert::contains($overflowResponse, 'HTTP/1.1 413 Payload Too Large');
+    Assert::contains($headerResponse, 'HTTP/1.1 413 Payload Too Large');
     Assert::same($handled, 1);
 
     echo "DONE\n";

--- a/tests/swoole_http_server_coro/chunked_large_body.phpt
+++ b/tests/swoole_http_server_coro/chunked_large_body.phpt
@@ -1,0 +1,76 @@
+--TEST--
+swoole_http_server_coro: receive a large chunked request body
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+use Swoole\Coroutine\Socket;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+function make_chunked_request(string $path, string $body): string
+{
+    return "POST {$path} HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Transfer-Encoding: chunked\r\n" .
+        "Connection: close\r\n\r\n" .
+        dechex(strlen($body)) . "\r\n{$body}\r\n0\r\n\r\n";
+}
+
+function send_chunked_request(Server $server, string $request): string
+{
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $server->port, -1));
+    $socket->sendAll($request);
+
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
+Coroutine\run(function () {
+    $server = new Server('127.0.0.1', 0);
+    $server->set(['package_max_length' => 300000]);
+
+    $handled = 0;
+    $receivedLength = 0;
+    $receivedHash = '';
+
+    Coroutine::create(function () use ($server, &$handled, &$receivedLength, &$receivedHash) {
+        $server->handle('/', function (Request $request, Response $response) use (
+            &$handled,
+            &$receivedLength,
+            &$receivedHash
+        ) {
+            $handled++;
+            $content = $request->rawContent();
+            $receivedLength = strlen($content);
+            $receivedHash = md5($content);
+            $response->end('OK');
+        });
+        $server->start();
+    });
+    Coroutine::sleep(0.001);
+
+    $body = str_repeat('0123456789abcdef', 17500);
+    $successResponse = send_chunked_request($server, make_chunked_request('/', $body));
+    $largeResponse = send_chunked_request($server, make_chunked_request('/', str_repeat('B', 320000)));
+    $server->shutdown();
+
+    Assert::contains($successResponse, 'HTTP/1.1 200 OK');
+    Assert::same($receivedLength, strlen($body));
+    Assert::same($receivedHash, md5($body));
+    Assert::contains($largeResponse, 'HTTP/1.1 413 Payload Too Large');
+    Assert::same($handled, 1);
+
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server_coro/chunked_multipart.phpt
+++ b/tests/swoole_http_server_coro/chunked_multipart.phpt
@@ -1,0 +1,97 @@
+--TEST--
+swoole_http_server_coro: parse chunked multipart data split across boundaries
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+use Swoole\Coroutine\Socket;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+Coroutine\run(function () {
+    $server = new Server('127.0.0.1', 0);
+    $server->set(['http_parse_files' => true]);
+    $handled = 0;
+    $result = [];
+
+    Coroutine::create(function () use ($server, &$handled, &$result) {
+        $server->handle('/', function (Request $request, Response $response) use (&$handled, &$result) {
+            $handled++;
+            $result = [
+                'field' => $request->post['field'] ?? null,
+                'name' => $request->files['file']['name'] ?? null,
+                'raw' => $request->rawContent(),
+                'content' => isset($request->files['file']['tmp_name'])
+                    ? file_get_contents($request->files['file']['tmp_name'])
+                    : null,
+            ];
+            $response->end('OK');
+        });
+        $server->start();
+    });
+    Coroutine::sleep(0.001);
+
+    $boundary = 'swoole-chunked-boundary';
+    $fileContent = "prefix0\r\n\r\nsuffix";
+    $body = "--{$boundary}\r\n" .
+        "Content-Disposition: form-data; name=\"field\"\r\n\r\n" .
+        "value\r\n" .
+        "--{$boundary}\r\n" .
+        "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" .
+        "Content-Type: text/plain\r\n\r\n" .
+        $fileContent . "\r\n" .
+        "--{$boundary}--\r\n";
+
+    // Split the first part header at a chunk boundary, the second at a receive boundary, and end another receive on
+    // body bytes that look like a terminating chunk.
+    $chunkBoundary = strpos($body, 'name="field"') + strlen('name="fi');
+    $receiveBoundary = strpos($body, 'name="file"') + strlen('name="fi');
+    $falseEnd = strpos($body, "0\r\n\r\n") + 5;
+    $firstChunk = substr($body, 0, $chunkBoundary);
+    $secondChunk = substr($body, $chunkBoundary);
+    $receiveOffset = $receiveBoundary - $chunkBoundary;
+    $falseEndOffset = $falseEnd - $chunkBoundary;
+    $parts = [
+        dechex(strlen($firstChunk)) . "\r\n{$firstChunk}\r\n" .
+            dechex(strlen($secondChunk)) . "\r\n" . substr($secondChunk, 0, $receiveOffset),
+        substr($secondChunk, $receiveOffset, $falseEndOffset - $receiveOffset),
+        substr($secondChunk, $falseEndOffset) . "\r\n",
+    ];
+    $header = "POST / HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Content-Type: multipart/form-data; boundary={$boundary}\r\n" .
+        "Transfer-Encoding: chunked\r\n" .
+        "Connection: close\r\n\r\n";
+
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $server->port, -1));
+    foreach ($parts as $index => $part) {
+        $data = ($index === 0 ? $header : '') . $part;
+        Assert::same($socket->sendAll($data), strlen($data));
+        Coroutine::sleep(0.05);
+        Assert::same($handled, 0);
+    }
+    Assert::same($socket->sendAll("0\r\n\r\n"), 5);
+
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    $server->shutdown();
+
+    Assert::contains($response, 'HTTP/1.1 200 OK');
+    Assert::same($result['field'], 'value');
+    Assert::same($result['name'], 'test.txt');
+    Assert::same($result['raw'], $body);
+    Assert::same($result['content'], $fileContent);
+    Assert::same($handled, 1);
+
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server_coro/expect_100_continue.phpt
+++ b/tests/swoole_http_server_coro/expect_100_continue.phpt
@@ -1,0 +1,88 @@
+--TEST--
+swoole_http_server_coro: send 100 Continue before receiving the request body
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http\Server;
+use Swoole\Coroutine\Socket;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+function recv_all(Socket $socket): string
+{
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
+function connect_to(Server $server): Socket
+{
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $server->port, -1));
+    return $socket;
+}
+
+Coroutine\run(function () {
+    $server = new Server('127.0.0.1', 0);
+    $continue = "HTTP/1.1 100 Continue\r\n\r\n";
+    Coroutine::create(function () use ($server) {
+        $server->handle('/', function (Request $request, Response $response) {
+            $response->end($request->rawContent());
+        });
+        $server->start();
+    });
+    Coroutine::sleep(0.001);
+
+    $body = 'content-length-body';
+    $headers = "POST / HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Expect: 100-continue\r\n" .
+        'Content-Length: ' . strlen($body) . "\r\n" .
+        "Connection: close\r\n\r\n";
+    $socket = connect_to($server);
+    Assert::same($socket->sendAll($headers), strlen($headers));
+    Assert::same($socket->recvAll(strlen($continue), 1), $continue);
+    Assert::same($socket->sendAll(substr($body, 0, 8)), 8);
+    Coroutine::sleep(0.05);
+    Assert::same($socket->sendAll(substr($body, 8)), strlen($body) - 8);
+    $response = recv_all($socket);
+    Assert::notContains($response, $continue);
+    Assert::contains($response, $body);
+
+    $body = 'chunked-body';
+    $headers = "POST / HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Expect: 100-continue\r\n" .
+        "Transfer-Encoding: chunked\r\n" .
+        "Connection: close\r\n\r\n";
+    $chunks = dechex(strlen($body)) . "\r\n{$body}\r\n0\r\n\r\n";
+    $socket = connect_to($server);
+    Assert::same($socket->sendAll($headers), strlen($headers));
+    Assert::same($socket->recvAll(strlen($continue), 1), $continue);
+    Assert::same($socket->sendAll($chunks), strlen($chunks));
+    Assert::contains(recv_all($socket), $body);
+
+    $body = 'ordinary-body';
+    $request = "POST / HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        'Content-Length: ' . strlen($body) . "\r\n" .
+        "Connection: close\r\n\r\n{$body}";
+    $socket = connect_to($server);
+    Assert::same($socket->sendAll($request), strlen($request));
+    $response = recv_all($socket);
+    Assert::notContains($response, 'HTTP/1.1 100 Continue');
+    Assert::contains($response, $body);
+
+    $server->shutdown();
+
+    echo "DONE\n";
+});
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
`Swoole\Coroutine\Http\Server` previously looked only at the last five received bytes to decide whether a chunked request was complete. Those bytes can appear inside the body, while trailers and pipelined requests put other bytes after the real ending. Large chunked requests also stopped when they filled the initial receive buffer, even below `package_max_length`.

Header and body size checks had related boundary errors. Oversized headers were not checked, large `Content-Length` values could wrap the total size, and transfer-encoding lists ending in `chunked` were not recognized correctly.

The coroutine server also waited for declared-length and chunked request bodies without sending `HTTP/1.1 100 Continue`. Clients that wait for that interim response stalled until their fallback timeout.

This change parses chunked input as it arrives and uses the parser-reported completion point as the exact end of each request, preserving following pipelined bytes. It validates header and body sizes before arithmetic or parsing can cross the configured limit, recognizes chunked framing from the parser, and sends `100 Continue` once before waiting for either body framing mode.

Chunked multipart bodies are parsed once after dechunking completes, so part headers may span chunk and network boundaries. `Request::getData()` now contains only the current complete request, matching the ordinary HTTP server.

The tests cover large and fragmented chunked bodies, multipart input, trailers, pipelines, exact limits, overflowing declared lengths, declared-length and chunked expect-continue handshakes, one-shot interim responses, and requests without `Expect`. Each regression fails on the unchanged branch and passes with the fix.