### PR TITLE
Handle fragmented HTTP proxy responses

### DIFF
--- a/core-tests/src/network/client.cpp
+++ b/core-tests/src/network/client.cpp
@@ -274,7 +274,7 @@ TEST(client, async_tcp_http_proxy_handshake_fail) {
 
     ac.onError = [&success](Client *ac) {
         DEBUG() << "connect failed, ERROR: " << errno << "\n";
-        ASSERT_ERREQ(SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR);
+        ASSERT_ERREQ(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
         success = false;
     };
 
@@ -289,6 +289,8 @@ TEST(client, async_tcp_http_proxy_handshake_fail) {
     ASSERT_EQ(ac.connect("www.baidu.com", 80, 1.0), SW_OK);
 
     swoole_event_wait();
+
+    ASSERT_FALSE(success);
 }
 
 TEST(client, async_tcp_socks5_proxy_handshake_fail) {

--- a/core-tests/src/network/client.cpp
+++ b/core-tests/src/network/client.cpp
@@ -324,6 +324,8 @@ TEST(client, async_tcp_socks5_proxy_handshake_fail) {
     ASSERT_EQ(ac.connect("www.baidu.com", 80, 1.0), SW_OK);
 
     swoole_event_wait();
+
+    ASSERT_FALSE(success);
 }
 
 TEST(client, sleep) {

--- a/core-tests/src/protocol/http.cpp
+++ b/core-tests/src/protocol/http.cpp
@@ -1,0 +1,48 @@
+/*
+  +----------------------------------------------------------------------+
+  | Swoole                                                               |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 2.0 of the Apache license,    |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.apache.org/licenses/LICENSE-2.0.html                      |
+  | If you did not receive a copy of the Apache2.0 license and are unable|
+  | to obtain it through the world-wide-web, please send a note to       |
+  | license@swoole.com so we can mail you a copy immediately.            |
+  +----------------------------------------------------------------------+
+  | Author: Tianfeng Han  <rango@swoole.com>                             |
+  +----------------------------------------------------------------------+
+*/
+
+#include "test_core.h"
+#include "swoole_proxy.h"
+
+using swoole::HttpProxy;
+
+TEST(http_proxy, parse_response) {
+    size_t response_length = 0;
+
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("HTTP/1."), &response_length), SW_HTTP_PROXY_RESPONSE_WAIT);
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("not-http"), &response_length), SW_HTTP_PROXY_RESPONSE_ERROR);
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("HTTP/1.1 200 Connection established\r\n"), &response_length),
+              SW_HTTP_PROXY_RESPONSE_WAIT);
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("HTTP/1.1 407 Proxy Authentication Required\r\n"), &response_length),
+              SW_HTTP_PROXY_RESPONSE_ERROR);
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("HTTP/1.1 2000 OK\r\n\r\n"), &response_length),
+              SW_HTTP_PROXY_RESPONSE_ERROR);
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL("HTTP/2 200 OK\r\n\r\n"), &response_length),
+              SW_HTTP_PROXY_RESPONSE_ERROR);
+
+    const char response_1_0[] = "HTTP/1.0 200\r\n\r\n";
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL(response_1_0), &response_length), SW_HTTP_PROXY_RESPONSE_READY);
+    ASSERT_EQ(response_length, sizeof(response_1_0) - 1);
+
+    const char response[] = "HTTP/1.1 200 OK\r\nProxy-Agent: test\r\n\r\nTUNNEL DATA";
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL(response), &response_length), SW_HTTP_PROXY_RESPONSE_READY);
+    ASSERT_EQ(response_length, sizeof("HTTP/1.1 200 OK\r\nProxy-Agent: test\r\n\r\n") - 1);
+
+    const char response_without_reason[] = "HTTP/1.1 200\r\n\r\n";
+    ASSERT_EQ(HttpProxy::parse_response(SW_STRL(response_without_reason), &response_length),
+              SW_HTTP_PROXY_RESPONSE_READY);
+    ASSERT_EQ(response_length, sizeof(response_without_reason) - 1);
+}

--- a/include/swoole_coroutine_socket.h
+++ b/include/swoole_coroutine_socket.h
@@ -560,28 +560,6 @@ class Socket {
     };
 };
 
-class ProtocolSwitch {
-    bool ori_open_eof_check;
-    bool ori_open_length_check;
-    Protocol ori_protocol;
-    Socket *socket_;
-
-  public:
-    explicit ProtocolSwitch(Socket *socket) {
-        ori_open_eof_check = socket->open_eof_check;
-        ori_open_length_check = socket->open_length_check;
-        ori_protocol = socket->protocol;
-        socket_ = socket;
-    }
-
-    ~ProtocolSwitch() {
-        /* revert protocol settings */
-        socket_->open_eof_check = ori_open_eof_check;
-        socket_->open_length_check = ori_open_length_check;
-        socket_->protocol = ori_protocol;
-    }
-};
-
 std::vector<std::string> dns_lookup(const char *domain, int family = AF_INET, double timeout = 2.0);
 std::vector<std::string> dns_lookup_impl_with_socket(const char *domain, int family, double timeout);
 #ifdef SW_USE_CARES

--- a/include/swoole_proxy.h
+++ b/include/swoole_proxy.h
@@ -21,9 +21,6 @@
 #include <functional>
 
 #define SW_SOCKS5_VERSION_CODE 0x05
-#define SW_HTTP_PROXY_CHECK_MESSAGE 0
-#define SW_HTTP_PROXY_HANDSHAKE_RESPONSE "HTTP/1.1 200 Connection established\r\n"
-
 #define SW_HTTP_PROXY_FMT                                                                                              \
     "CONNECT %.*s:%d HTTP/1.1\r\n"                                                                                     \
     "Host: %.*s:%d\r\n"                                                                                                \
@@ -34,6 +31,12 @@ enum swHttpProxyState {
     SW_HTTP_PROXY_STATE_WAIT = 0,
     SW_HTTP_PROXY_STATE_HANDSHAKE,
     SW_HTTP_PROXY_STATE_READY,
+};
+
+enum swHttpProxyResponseStatus {
+    SW_HTTP_PROXY_RESPONSE_ERROR = -1,
+    SW_HTTP_PROXY_RESPONSE_WAIT,
+    SW_HTTP_PROXY_RESPONSE_READY,
 };
 
 enum swSocks5State {
@@ -64,7 +67,7 @@ struct HttpProxy {
 
     std::string get_auth_str() const;
     size_t pack(const String *send_buffer, const std::string &host_name) const;
-    static bool handshake(const String *recv_buffer);
+    static swHttpProxyResponseStatus parse_response(const char *buf, size_t len, size_t *response_length);
 
     static HttpProxy *create(const std::string &host, int port, const std::string &user, const std::string &pwd);
 };

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -271,31 +271,52 @@ bool Socket::http_proxy_handshake() {
         return false;
     }
 
-    String *recv_buffer = get_read_buffer();
-    ON_SCOPE_EXIT {
-        recv_buffer->clear();
-    };
-
-    ProtocolSwitch ps(this);
-    open_eof_check = true;
-    open_length_check = false;
-    protocol.package_eof_len = sizeof("\r\n\r\n") - 1;
-    memcpy(protocol.package_eof, SW_STRS("\r\n\r\n"));
-
-    if (recv_packet() <= 0) {
+    String recv_buffer(SW_BUFFER_SIZE_BIG);
+    TimerController timer(&read_timer, socket->read_timeout, this, timer_callback);
+    if (!timer.start()) {
         return false;
     }
+    while (recv_buffer.length < recv_buffer.size) {
+        ssize_t n_peek = socket->peek(recv_buffer.str + recv_buffer.length, recv_buffer.size - recv_buffer.length, 0);
+        if (n_peek < 0) {
+            if (socket->catch_read_error(errno) == SW_WAIT) {
+                if (poll(SW_EVENT_READ)) {
+                    continue;
+                }
+            }
+            return false;
+        }
+        if (n_peek == 0) {
+            set_err(SW_ERROR_HTTP_PROXY_BAD_RESPONSE, "connection closed before the HTTP proxy response was complete");
+            return false;
+        }
 
-    swoole_trace_log(SW_TRACE_HTTP_CLIENT, "proxy response: <<EOF\n%.*sEOF", (int) n, recv_buffer->str);
+        size_t response_length = 0;
+        // Parse the consumed prefix with the queued bytes. Incomplete fragments are consumed so the next peek
+        // advances, while bytes after a complete proxy header remain queued.
+        recv_buffer.length += n_peek;
+        auto status = HttpProxy::parse_response(recv_buffer.str, recv_buffer.length, &response_length);
+        recv_buffer.length -= n_peek;
+        if (status == SW_HTTP_PROXY_RESPONSE_ERROR) {
+            set_err(SW_ERROR_HTTP_PROXY_BAD_RESPONSE, "invalid HTTP proxy response");
+            return false;
+        }
 
-    if (!http_proxy->handshake(recv_buffer)) {
-        set_err(SW_ERROR_HTTP_PROXY_BAD_RESPONSE,
-                std::string("wrong http_proxy response received, \n[Request]: ") + send_buffer->to_std_string() +
-                    "\n[Response]: " + send_buffer->to_std_string());
-        return false;
+        size_t consume_length = status == SW_HTTP_PROXY_RESPONSE_READY ? response_length - recv_buffer.length : n_peek;
+        ssize_t n_read = recv_all(recv_buffer.str + recv_buffer.length, consume_length);
+        if (n_read != (ssize_t) consume_length) {
+            return false;
+        }
+        recv_buffer.length += n_read;
+        if (status == SW_HTTP_PROXY_RESPONSE_READY) {
+            swoole_trace_log(
+                SW_TRACE_HTTP_CLIENT, "proxy response: <<EOF\n%.*sEOF", (int) recv_buffer.length, recv_buffer.str);
+            return true;
+        }
     }
 
-    return true;
+    set_err(SW_ERROR_HTTP_PROXY_BAD_RESPONSE, "HTTP proxy response header is too large");
+    return false;
 }
 
 void Socket::init_sock_type(SocketType _type) {
@@ -664,7 +685,9 @@ bool Socket::connect(const std::string &_host, int _port, int flags) {
     }
     // http proxy
     if (http_proxy && !http_proxy->dont_handshake && !http_proxy_handshake()) {
-        set_err(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+        if (errCode != SW_ERROR_HTTP_PROXY_BAD_RESPONSE) {
+            set_err(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+        }
         return false;
     }
 #ifdef SW_USE_OPENSSL

--- a/src/network/client.cc
+++ b/src/network/client.cc
@@ -436,9 +436,8 @@ static int Client_tcp_connect_sync(Client *cli, const char *host, int port, doub
     int ret = cli->socket->connect_sync(cli->server_addr);
     if (ret >= 0) {
         cli->active = true;
-        auto recv_buf = sw_tg_buffer();
-
         if (cli->socks5_proxy) {
+            auto recv_buf = sw_tg_buffer();
             const auto ctx = cli->socks5_proxy.get();
             const auto len = ctx->pack_negotiate_request();
             if (cli->send(ctx->buf, len) < 0) {
@@ -456,17 +455,67 @@ static int Client_tcp_connect_sync(Client *cli, const char *host, int port, doub
                 return SW_ERR;
             }
         } else if (cli->http_proxy) {
+            auto send_buf = sw_tg_buffer();
             auto target_host = cli->get_http_proxy_host_name();
-            const size_t n_write = cli->http_proxy->pack(recv_buf, target_host);
-            if (cli->send(recv_buf->str, n_write, 0) < 0) {
+            const size_t n_write = cli->http_proxy->pack(send_buf, target_host);
+            if (cli->send(send_buf->str, n_write, 0) < 0) {
                 return SW_ERR;
             }
-            const ssize_t n_read = cli->recv(recv_buf->str, recv_buf->size, 0);
-            if (n_read <= 0) {
-                return SW_ERR;
+
+            String recv_buf(cli->input_buffer_size);
+            bool response_complete = false;
+            const double read_timeout = cli->socket->read_timeout;
+            const double deadline = read_timeout > 0 ? microtime() + read_timeout : 0;
+            ON_SCOPE_EXIT {
+                cli->socket->read_timeout = read_timeout;
+            };
+            while (recv_buf.length < recv_buf.size) {
+                if (read_timeout > 0) {
+                    const double remaining = deadline - microtime();
+                    if (remaining <= 0) {
+                        swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+                        return SW_ERR;
+                    }
+                    cli->socket->read_timeout = remaining;
+                }
+
+                const ssize_t n_peek =
+                    cli->recv(recv_buf.str + recv_buf.length, recv_buf.size - recv_buf.length, MSG_PEEK);
+                if (n_peek < 0) {
+                    swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+                    return SW_ERR;
+                }
+                if (n_peek == 0) {
+                    swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
+                    return SW_ERR;
+                }
+
+                size_t response_length = 0;
+                // Parse the consumed prefix with the queued bytes. Incomplete fragments are consumed so the next peek
+                // advances, while bytes after a complete proxy header remain queued.
+                recv_buf.length += n_peek;
+                auto status = HttpProxy::parse_response(recv_buf.str, recv_buf.length, &response_length);
+                recv_buf.length -= n_peek;
+                if (status == SW_HTTP_PROXY_RESPONSE_ERROR) {
+                    swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
+                    return SW_ERR;
+                }
+
+                size_t consume_length =
+                    status == SW_HTTP_PROXY_RESPONSE_READY ? response_length - recv_buf.length : n_peek;
+                const ssize_t n_read = cli->recv(recv_buf.str + recv_buf.length, consume_length, MSG_WAITALL);
+                if (n_read != (ssize_t) consume_length) {
+                    swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+                    return SW_ERR;
+                }
+                recv_buf.length += n_read;
+                if (status == SW_HTTP_PROXY_RESPONSE_READY) {
+                    response_complete = true;
+                    break;
+                }
             }
-            recv_buf->length = n_read;
-            if (!cli->http_proxy->handshake(recv_buf)) {
+            if (!response_complete) {
+                swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
                 return SW_ERR;
             }
         }
@@ -728,6 +777,14 @@ static int Client_onPackage(const Protocol *proto, Socket *conn, const RecvData 
 static int Client_onStreamRead(Reactor *reactor, Event *event) {
     ssize_t n;
     auto *cli = (Client *) event->socket->object;
+    auto connect_fail = [cli]() {
+        cli->active = false;
+        cli->close();
+        if (cli->onError) {
+            cli->onError(cli);
+        }
+        return SW_OK;
+    };
     char *buf = cli->buffer->str + cli->buffer->length;
     ssize_t buf_size = cli->buffer->size - cli->buffer->length;
 #ifdef SW_USE_OPENSSL
@@ -737,22 +794,46 @@ static int Client_onStreamRead(Reactor *reactor, Event *event) {
 #endif
 
     if (cli->http_proxy && cli->http_proxy->state != SW_HTTP_PROXY_STATE_READY) {
-        n = event->socket->recv(buf, buf_size, 0);
-        if (n <= 0) {
-            swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR);
-        _connect_fail:
-            cli->active = false;
-            cli->close();
-            if (cli->onError) {
-                cli->onError(cli);
+        if (buf_size == 0) {
+            swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
+            return connect_fail();
+        }
+
+        n = event->socket->peek(buf, buf_size, 0);
+        if (n < 0) {
+            if (event->socket->catch_read_error(errno) == SW_WAIT) {
+                return SW_OK;
             }
-            return SW_OK;
+            swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR);
+            return connect_fail();
+        }
+        if (n == 0) {
+            swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
+            return connect_fail();
+        }
+
+        size_t response_length = 0;
+        // Parse the consumed prefix with the queued bytes. Incomplete fragments are consumed so the next peek
+        // advances, while bytes after a complete proxy header remain queued.
+        cli->buffer->length += n;
+        auto status = HttpProxy::parse_response(cli->buffer->str, cli->buffer->length, &response_length);
+        cli->buffer->length -= n;
+        if (status == SW_HTTP_PROXY_RESPONSE_ERROR) {
+            swoole_set_last_error(SW_ERROR_HTTP_PROXY_BAD_RESPONSE);
+            return connect_fail();
+        }
+
+        size_t consume_length = status == SW_HTTP_PROXY_RESPONSE_READY ? response_length - cli->buffer->length : n;
+        n = event->socket->recv(buf, consume_length, 0);
+        if (n != (ssize_t) consume_length) {
+            swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR);
+            return connect_fail();
         }
         cli->buffer->length += n;
-        if (!cli->http_proxy->handshake(cli->buffer)) {
-            swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_ERROR);
-            goto _connect_fail;
+        if (status == SW_HTTP_PROXY_RESPONSE_WAIT) {
+            return SW_OK;
         }
+
         cli->http_proxy->state = SW_HTTP_PROXY_STATE_READY;
         cli->buffer->clear();
         if (!do_ssl_handshake) {
@@ -765,12 +846,12 @@ static int Client_onStreamRead(Reactor *reactor, Event *event) {
         n = event->socket->recv(buf, buf_size, 0);
         if (n <= 0) {
             swoole_set_last_error(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
-            goto _connect_fail;
+            return connect_fail();
         }
         cli->buffer->length += n;
         if (!cli->socks5_handshake(buf, buf_size)) {
             swoole_set_last_error(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
-            goto _connect_fail;
+            return connect_fail();
         }
         if (cli->socks5_proxy->state != SW_SOCKS5_STATE_READY) {
             return SW_OK;
@@ -786,7 +867,7 @@ static int Client_onStreamRead(Reactor *reactor, Event *event) {
     if (cli->open_ssl && cli->socket->ssl_state != SW_SSL_STATE_READY) {
         if (cli->ssl_handshake() < 0) {
             swoole_set_last_error(SW_ERROR_SSL_HANDSHAKE_FAILED);
-            goto _connect_fail;
+            return connect_fail();
         }
         if (cli->socket->ssl_state != SW_SSL_STATE_READY) {
             return SW_OK;

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -91,59 +91,36 @@ size_t HttpProxy::pack(const String *send_buffer, const std::string &host_name) 
     }
 }
 
-bool HttpProxy::handshake(const String *recv_buffer) {
-    bool ret = false;
-    char *buf = recv_buffer->str;
-    size_t len = recv_buffer->length;
-    int state = 0;
-    char *p = buf;
-    char *pe = buf + len;
-
-    if (recv_buffer->length < sizeof(SW_HTTP_PROXY_HANDSHAKE_RESPONSE) - 1) {
-        return false;
+swHttpProxyResponseStatus HttpProxy::parse_response(const char *buf, size_t len, size_t *response_length) {
+    if (len < sizeof("HTTP/1.x") - 1) {
+        return SW_HTTP_PROXY_RESPONSE_WAIT;
+    }
+    // Check the version first so a non-HTTP peer fails without waiting for a complete status line.
+    if (!SW_STR_ISTARTS_WITH(buf, len, "HTTP/1.1") && !SW_STR_ISTARTS_WITH(buf, len, "HTTP/1.0")) {
+        return SW_HTTP_PROXY_RESPONSE_ERROR;
     }
 
-    for (; p < buf + len; p++) {
-        if (state == 0) {
-            if (SW_STR_ISTARTS_WITH(p, pe - p, "HTTP/1.1") || SW_STR_ISTARTS_WITH(p, pe - p, "HTTP/1.0")) {
-                state = 1;
-                p += sizeof("HTTP/1.x") - 1;
-            } else {
-                break;
-            }
-        } else if (state == 1) {
-            if (isspace(*p)) {
-                continue;
-            } else {
-                if (SW_STR_ISTARTS_WITH(p, pe - p, "200")) {
-                    state = 2;
-                    p += sizeof("200") - 1;
-                } else {
-                    swoole_set_last_error(SW_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
-                    break;
-                }
-            }
-        } else if (state == 2) {
-            ret = true;
-            break;
-            /**
-             * The response message is generally "Connection established,"
-             * although it is not specified in the RFC documents, and thus will not be checked for now.
-             */
-#if SW_HTTP_PROXY_CHECK_MESSAGE
-            if (isspace(*p)) {
-                continue;
-            } else {
-                if (SW_STR_ISTARTS_WITH(p, pe - p, "Connection established")) {
-                    ret = true;
-                }
-                break;
-            }
-#endif
-        }
+    const char *status_line_end = swoole_strnstr(buf, len, SW_STRL("\r\n"));
+    if (!status_line_end) {
+        return SW_HTTP_PROXY_RESPONSE_WAIT;
     }
 
-    return ret;
+    const char *p = buf + sizeof("HTTP/1.x") - 1;
+    while (p < status_line_end && isspace(static_cast<unsigned char>(*p))) {
+        p++;
+    }
+    if (status_line_end - p < 3 || memcmp(p, "200", 3) != 0 ||
+        (status_line_end - p > 3 && !isspace(static_cast<unsigned char>(p[3])))) {
+        return SW_HTTP_PROXY_RESPONSE_ERROR;
+    }
+
+    const char *response_end = swoole_strnstr(buf, len, SW_STRL("\r\n\r\n"));
+    if (!response_end) {
+        return SW_HTTP_PROXY_RESPONSE_WAIT;
+    }
+
+    *response_length = response_end - buf + sizeof("\r\n\r\n") - 1;
+    return SW_HTTP_PROXY_RESPONSE_READY;
 }
 
 namespace http_server {

--- a/tests/swoole_client_async/http_proxy_fragmented_response.phpt
+++ b/tests/swoole_client_async/http_proxy_fragmented_response.phpt
@@ -1,0 +1,76 @@
+--TEST--
+swoole_client_async: fragmented HTTP proxy response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $completed = 0;
+    $finish = function () use (&$completed, $pm) {
+        if (++$completed === 3) {
+            $pm->kill();
+            echo "DONE\n";
+        }
+    };
+    $connect = function (string $host, bool $shouldSucceed) use ($finish, $pm) {
+        $client = new Swoole\Async\Client(SWOOLE_SOCK_TCP);
+        $client->set([
+            'http_proxy_host' => '127.0.0.1',
+            'http_proxy_port' => $pm->getFreePort(),
+        ]);
+        $client->on('connect', function () use ($shouldSucceed) {
+            Assert::true($shouldSucceed);
+        });
+        $client->on('receive', function (Swoole\Async\Client $client, string $data) use ($finish, $shouldSucceed) {
+            Assert::true($shouldSucceed);
+            Assert::same($data, 'TUNNEL DATA');
+            $client->close();
+            $finish();
+        });
+        $client->on('error', function (Swoole\Async\Client $client) use ($finish, $shouldSucceed) {
+            Assert::false($shouldSucceed);
+            Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+            $finish();
+        });
+        $client->on('close', function () {});
+        Assert::true($client->connect($host, 22, 0.5));
+    };
+
+    $connect('success.example.com', true);
+    $connect('invalid.example.com', false);
+    $connect('eof.example.com', false);
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = stream_socket_server('tcp://127.0.0.1:' . $pm->getFreePort());
+    $pm->wakeup();
+    for ($i = 0; $i < 3; $i++) {
+        $connection = stream_socket_accept($server);
+        $request = '';
+        while (!str_contains($request, "\r\n\r\n")) {
+            $request .= fread($connection, 8192);
+        }
+        if (str_contains($request, 'success.example.com')) {
+            fwrite($connection, "HTTP/1.1 200 ");
+            usleep(20000);
+            fwrite($connection, "Connection established\r\n\r\nTUNNEL DATA");
+            usleep(100000);
+        } elseif (str_contains($request, 'invalid.example.com')) {
+            fwrite($connection, "HTTP/1.1 407 Proxy Authentication Required\r\n");
+        } else {
+            fwrite($connection, "HTTP/1.1 200 Connection");
+        }
+        fclose($connection);
+    }
+    fclose($server);
+};
+
+$pm->async = true;
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_coro/http_proxy_fragmented_response.phpt
+++ b/tests/swoole_client_coro/http_proxy_fragmented_response.phpt
@@ -1,0 +1,88 @@
+--TEST--
+swoole_client_coro: preserve data after the HTTP proxy response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Co\run(function () use ($pm) {
+        $createClient = function (float $timeout = 5) use ($pm) {
+            $client = new Swoole\Coroutine\Client(SWOOLE_SOCK_TCP);
+            $client->set([
+                'timeout' => $timeout,
+                'http_proxy_host' => '127.0.0.1',
+                'http_proxy_port' => $pm->getFreePort(),
+            ]);
+            return $client;
+        };
+
+        $client = $createClient();
+        Assert::true($client->connect('example.com', 22));
+        Assert::same($client->recv(), 'TUNNEL DATA');
+        $client->close();
+
+        $client = $createClient();
+        $started = microtime(true);
+        Assert::false($client->connect('example.com', 22));
+        Assert::lessThan(microtime(true) - $started, 1);
+        Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+
+        $client = $createClient();
+        Assert::false($client->connect('example.com', 22));
+        Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+
+        $client = $createClient(0.2);
+        $started = microtime(true);
+        Assert::false($client->connect('example.com', 22));
+        Assert::greaterThan(microtime(true) - $started, 0.1);
+        Assert::lessThan(microtime(true) - $started, 0.45);
+        Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+
+        $client = $createClient();
+        $started = microtime(true);
+        Assert::false($client->connect('example.com', 22));
+        Assert::lessThan(microtime(true) - $started, 1);
+        Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+
+        $pm->kill();
+        echo "DONE\n";
+    });
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = stream_socket_server('tcp://127.0.0.1:' . $pm->getFreePort());
+    $pm->wakeup();
+    $responses = [
+        [["HTTP/1.1 200 Connection established\r\n", "\r\nTUNNEL DATA"], 20000, 0],
+        [["HTTP/1.1 407 Proxy Authentication Required\r\n"], 20000, 1500000],
+        [["HTTP/1.1 200 Connection"], 20000, 0],
+        [["HTTP/1.1", " 200", " OK\r\n\r\n"], 150000, 0],
+        [["not-http"], 20000, 1500000],
+    ];
+
+    foreach ($responses as [$chunks, $delay, $closeDelay]) {
+        $connection = stream_socket_accept($server);
+        $request = '';
+        while (!str_contains($request, "\r\n\r\n")) {
+            $request .= fread($connection, 8192);
+        }
+        foreach ($chunks as $chunk) {
+            @fwrite($connection, $chunk);
+            usleep($delay);
+        }
+        if ($closeDelay > 0) {
+            usleep($closeDelay);
+        }
+        fclose($connection);
+    }
+    fclose($server);
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_sync/http_proxy_fragmented_response.phpt
+++ b/tests/swoole_client_sync/http_proxy_fragmented_response.phpt
@@ -1,0 +1,90 @@
+--TEST--
+swoole_client_sync: fragmented HTTP proxy response
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $createClient = function (float $timeout = 0.5) use ($pm) {
+        $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+        $client->set([
+            'timeout' => $timeout,
+            'http_proxy_host' => '127.0.0.1',
+            'http_proxy_port' => $pm->getFreePort(),
+        ]);
+        return $client;
+    };
+    $connect = function () use ($createClient) {
+        $client = $createClient();
+        Assert::true($client->connect('example.com', 22));
+        return $client;
+    };
+
+    $client = $connect();
+    Assert::same($client->recv(), 'FRAGMENTED');
+    $client->close();
+
+    $client = $connect();
+    Assert::same($client->recv(), 'SHORT');
+    $client->close();
+
+    $client = $connect();
+    Assert::same($client->recv(), 'COMPLETE');
+    $client->close();
+
+    $client = $createClient();
+    Assert::false(@$client->connect('example.com', 22));
+    Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+
+    $client = $createClient();
+    Assert::false(@$client->connect('example.com', 22));
+    Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_BAD_RESPONSE);
+
+    $client = $createClient(0.2);
+    $started = microtime(true);
+    Assert::false(@$client->connect('example.com', 22, 0.2));
+    Assert::greaterThan(microtime(true) - $started, 0.1);
+    Assert::lessThan(microtime(true) - $started, 0.45);
+    Assert::same($client->errCode, SWOOLE_ERROR_HTTP_PROXY_HANDSHAKE_FAILED);
+
+    $pm->kill();
+    echo "DONE\n";
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = stream_socket_server('tcp://127.0.0.1:' . $pm->getFreePort());
+    $pm->wakeup();
+
+    $responses = [
+        [["HTTP/1.1 200 ", "Connection established\r\nProxy-Agent: test\r\n\r\nFRAGMENTED"], 20000],
+        [["HTTP/1.1 200 OK\r\n\r\nSHORT"], 20000],
+        [["HTTP/1.1 200 Connection established\r\n", "\r\nCOMPLETE"], 20000],
+        [["HTTP/1.1 407 Proxy Authentication Required\r\n"], 20000],
+        [["HTTP/1.1 200 Connection"], 20000],
+        [["HTTP/1.1", " 200", " OK\r\n\r\n"], 150000],
+    ];
+
+    foreach ($responses as [$chunks, $delay]) {
+        $connection = stream_socket_accept($server);
+        $request = '';
+        while (!str_contains($request, "\r\n\r\n")) {
+            $request .= fread($connection, 8192);
+        }
+        foreach ($chunks as $chunk) {
+            @fwrite($connection, $chunk);
+            usleep($delay);
+        }
+        fclose($connection);
+    }
+
+    fclose($server);
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
HTTP proxy responses can be split across reads. The synchronous client reads once, and the async client treats an incomplete response as invalid.

The response parser also accepts status 200 before the headers end. If tunneled data arrives in the same read, the client discards it with the proxy response.

This change distinguishes incomplete and invalid responses, waits for the complete proxy header, and consumes only that header. Data from the tunneled connection remains available to the next receive.

Both async proxy failure tests previously asserted only inside `onError`, so they could pass without executing their error checks. Each now asserts after the event loop that the callback ran.

The proxy framing paths are covered across synchronous, async, and coroutine clients with local fixtures. The two existing async failure tests also pass on the updated branch.
