### PR TITLE
Enforce EOF packet size limits

### DIFF
--- a/core-tests/src/coroutine/socket.cpp
+++ b/core-tests/src/coroutine/socket.cpp
@@ -519,6 +519,94 @@ TEST(coroutine_socket, eof_6) {
                     }});
 }
 
+TEST(coroutine_socket, eof_package_max_length_complete) {
+    coroutine::run([](void *arg) {
+        int pairs[2];
+        ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pairs), 0);
+
+        Coroutine::create([fd = pairs[1]](void *arg) {
+            Socket peer(fd, SW_SOCK_UNIX_STREAM);
+            std::string packet(1023, 'A');
+            ASSERT_EQ(peer.send_all(packet.data(), packet.length()), packet.length());
+            System::sleep(0.01);
+            ASSERT_EQ(peer.send_all(SW_STRL(CRLF)), strlen(CRLF));
+            peer.close();
+        });
+
+        Socket sock(pairs[0], SW_SOCK_UNIX_STREAM);
+        socket_set_eof_protocol(sock);
+        sock.protocol.package_max_length = 1024;
+
+        EXPECT_EQ(sock.recv_packet(RECV_TIMEOUT), -1);
+        EXPECT_EQ(sock.errCode, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+        sock.close();
+    });
+
+    coroutine::run([](void *arg) {
+        int pairs[2];
+        ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pairs), 0);
+
+        std::string packets(1022, 'A');
+        packets.append(CRLF "B" CRLF);
+        Coroutine::create([fd = pairs[1], packets](void *arg) {
+            Socket peer(fd, SW_SOCK_UNIX_STREAM);
+            ASSERT_EQ(peer.send_all(packets.data(), packets.length()), packets.length());
+            peer.close();
+        });
+
+        Socket sock(pairs[0], SW_SOCK_UNIX_STREAM);
+        socket_set_eof_protocol(sock);
+        sock.protocol.package_max_length = 1024;
+
+        EXPECT_EQ(sock.recv_packet(RECV_TIMEOUT), 1024);
+        EXPECT_EQ(sock.get_read_buffer()->length, packets.length());
+        EXPECT_EQ(sock.recv_packet(RECV_TIMEOUT), 3);
+        sock.close();
+    });
+}
+
+TEST(coroutine_socket, eof_package_max_length_unterminated) {
+    coroutine::run([](void *arg) {
+        int pairs[2];
+        ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pairs), 0);
+
+        std::string packet(100008, 'A');
+        Coroutine::create([fd = pairs[1], packet](void *arg) {
+            Socket peer(fd, SW_SOCK_UNIX_STREAM);
+            ASSERT_EQ(peer.send_all(packet.data(), packet.length()), packet.length());
+            peer.close();
+        });
+
+        Socket sock(pairs[0], SW_SOCK_UNIX_STREAM);
+        socket_set_eof_protocol(sock);
+        sock.protocol.package_max_length = 100001;
+
+        EXPECT_EQ(sock.recv_packet(RECV_TIMEOUT), -1);
+        EXPECT_EQ(sock.errCode, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+        sock.close();
+    });
+
+    coroutine::run([](void *arg) {
+        int pairs[2];
+        ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pairs), 0);
+
+        std::string packet(2048, 'A');
+        Coroutine::create([fd = pairs[1], packet](void *arg) {
+            Socket peer(fd, SW_SOCK_UNIX_STREAM);
+            ASSERT_EQ(peer.send_all(packet.data(), packet.length()), packet.length());
+            peer.close();
+        });
+
+        Socket sock(pairs[0], SW_SOCK_UNIX_STREAM);
+        socket_set_eof_protocol(sock);
+        sock.protocol.package_max_length = 1024;
+
+        EXPECT_EQ(sock.recv_packet(RECV_TIMEOUT), -1);
+        EXPECT_EQ(sock.errCode, SW_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+        sock.close();
+    });
+}
+
 static void socket_set_length_protocol_1(Socket &sock) {
     sock.protocol = {};
 

--- a/ext-src/swoole_client.cc
+++ b/ext-src/swoole_client.cc
@@ -881,6 +881,16 @@ static PHP_METHOD(swoole_client, recv) {
             eof = swoole_strnpos(buffer->str, buffer->length, protocol->package_eof, protocol->package_eof_len);
             if (eof >= 0) {
                 eof += protocol->package_eof_len;
+                if ((size_t) eof > protocol->package_max_length) {
+                    php_swoole_error_ex(E_WARNING,
+                                        SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                                        "package length exceeds package_max_length, length=%zu, "
+                                        "package_max_length=%u",
+                                        (size_t) eof,
+                                        protocol->package_max_length);
+                    buffer->length = 0;
+                    RETURN_FALSE;
+                }
 
                 if ((ssize_t) buffer->length > eof) {
                     cli->buffer = swoole::make_string(SW_BUFFER_SIZE_BIG, sw_zend_string_allocator());
@@ -897,18 +907,20 @@ static PHP_METHOD(swoole_client, recv) {
 
                 return;
             } else {
-                if (buffer->length == protocol->package_max_length) {
-                    php_swoole_error(E_WARNING, "no package eof");
+                if (buffer->length >= protocol->package_max_length) {
+                    php_swoole_error_ex(E_WARNING,
+                                        SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                                        "no package eof, length=%zu, package_max_length=%u",
+                                        buffer->length,
+                                        protocol->package_max_length);
                     buffer->length = 0;
                     RETURN_FALSE;
                 } else if (buffer->length == buffer->size) {
-                    if (buffer->size < protocol->package_max_length) {
-                        uint32_t new_size = buffer->size * 2;
-                        if (new_size > protocol->package_max_length) {
-                            new_size = protocol->package_max_length;
-                        }
-                        buffer->extend(new_size);
+                    size_t new_size = buffer->size * 2;
+                    if (new_size > protocol->package_max_length) {
+                        new_size = protocol->package_max_length;
                     }
+                    buffer->extend(new_size);
                 }
             }
         }

--- a/src/coroutine/socket.cc
+++ b/src/coroutine/socket.cc
@@ -1470,14 +1470,28 @@ ssize_t Socket::recv_packet_with_eof_protocol() {
     _find_eof:
         eof = swoole_strnpos(read_buffer->str, read_buffer->length, protocol.package_eof, protocol.package_eof_len);
         if (eof >= 0) {
-            return (read_buffer->offset = eof + protocol.package_eof_len);
+            size_t packet_length = eof + protocol.package_eof_len;
+            if (packet_length > protocol.package_max_length) {
+                read_buffer->clear();
+                set_err(SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                        std_string::format("package length exceeds package_max_length, length=%zu, "
+                                           "package_max_length=%u",
+                                           packet_length,
+                                           protocol.package_max_length));
+                return -1;
+            }
+            return (read_buffer->offset = packet_length);
         }
-        if (read_buffer->length == protocol.package_max_length) {
+        if (read_buffer->length >= protocol.package_max_length) {
+            size_t buffered_length = read_buffer->length;
             read_buffer->clear();
-            set_err(SW_ERROR_PACKAGE_LENGTH_TOO_LARGE, "no package eof, package_max_length exceeded");
+            set_err(
+                SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                std_string::format(
+                    "no package eof, length=%zu, package_max_length=%u", buffered_length, protocol.package_max_length));
             return -1;
         }
-        if (read_buffer->length == read_buffer->size && read_buffer->size < protocol.package_max_length) {
+        if (read_buffer->length == read_buffer->size) {
             size_t new_size = read_buffer->size * 2;
             if (new_size > protocol.package_max_length) {
                 new_size = protocol.package_max_length;

--- a/src/protocol/base.cc
+++ b/src/protocol/base.cc
@@ -69,6 +69,13 @@ int Protocol::recv_split_by_eof(network::Socket *socket, String *buffer) const {
     }
 
     ssize_t n = buffer->split(package_eof, package_eof_len, [&](const char *data, size_t length) -> int {
+        if (length > package_max_length) {
+            proto_error(socket,
+                        SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                        "The received data packet is too large, length=%lu",
+                        (ulong_t) length);
+            return false;
+        }
         rdata.info.len = length;
         rdata.data = data;
         if (onPackage(this, socket, &rdata) < 0) {
@@ -274,7 +281,8 @@ _recv_data:
             } else {
                 return SW_OK;
             }
-        } else if (memcmp(buffer->str + buffer->length - package_eof_len, package_eof, package_eof_len) == 0) {
+        } else if (memcmp(buffer->str + buffer->length - package_eof_len, package_eof, package_eof_len) == 0 &&
+                   buffer->length <= package_max_length) {
             buffer->offset = buffer->length;
             rdata.info.len = buffer->length;
             rdata.data = buffer->str;
@@ -294,7 +302,7 @@ _recv_data:
         }
 
         // over max length, will discard
-        if (buffer->length == package_max_length) {
+        if (buffer->length >= package_max_length) {
             proto_error(socket,
                         SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
                         "The received data packet is too large, length=%lu",
@@ -305,13 +313,11 @@ _recv_data:
         // buffer is full, may have not read data
         if (buffer->length == buffer->size) {
             recv_again = true;
-            if (buffer->size < package_max_length) {
-                uint32_t extend_size = swoole_size_align(buffer->size * 2, swoole_pagesize());
-                if (extend_size > package_max_length) {
-                    extend_size = package_max_length;
-                }
-                buffer->extend(extend_size);
+            size_t extend_size = swoole_size_align(buffer->size * 2, swoole_pagesize());
+            if (extend_size > package_max_length) {
+                extend_size = package_max_length;
             }
+            buffer->extend(extend_size);
         }
         // no eof
         if (recv_again) {

--- a/tests/swoole_client_async/eof_package_max_length.phpt
+++ b/tests/swoole_client_async/eof_package_max_length.phpt
@@ -1,0 +1,98 @@
+--TEST--
+swoole_client_async: enforce package_max_length with eof protocol
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+swoole_async_set(['log_level' => SWOOLE_LOG_NONE]);
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    $cases = [
+        ['complete', false],
+        ['unterminated', false],
+        ['split', true],
+    ];
+    $outcomes = [];
+
+    $start = function (string $command, bool $split) use (&$outcomes, $cases, $pm) {
+        $received = false;
+        $timedOut = false;
+        $timer = null;
+
+        $client = new Swoole\Async\Client(SWOOLE_SOCK_TCP);
+        $client->set([
+            'open_eof_check' => true,
+            'open_eof_split' => $split,
+            'package_eof' => "\r\n",
+            'package_max_length' => 1024,
+        ]);
+        $client->on('connect', function (Swoole\Async\Client $client) use ($command) {
+            $client->send($command);
+        });
+        $client->on('receive', function (Swoole\Async\Client $client) use (&$received) {
+            $received = true;
+            $client->close();
+        });
+        $client->on('error', function () {
+            Assert::true(false);
+        });
+        $client->on('close', function () use (
+            &$outcomes, &$received, &$timedOut, &$timer, $command, $cases, $pm
+        ) {
+            if (!$timedOut) {
+                Swoole\Timer::clear($timer);
+            }
+            $outcomes[$command] = [$received, swoole_last_error(), $timedOut];
+            if (count($outcomes) === count($cases)) {
+                $pm->kill();
+                Swoole\Event::exit();
+            }
+        });
+        Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+        $timer = Swoole\Timer::after(2000, function () use (&$timedOut, $client) {
+            $timedOut = true;
+            $client->close();
+        });
+    };
+
+    foreach ($cases as [$command, $split]) {
+        $start($command, $split);
+    }
+    Swoole\Event::wait();
+
+    foreach ($cases as [$command]) {
+        Assert::false($outcomes[$command][0]);
+        Assert::same($outcomes[$command][1], SWOOLE_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+        Assert::false($outcomes[$command][2]);
+    }
+    echo "DONE\n";
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('Receive', function (Swoole\Server $server, int $fd, int $reactorId, string $command) {
+        if ($command === 'unterminated') {
+            $server->send($fd, str_repeat('A', 2000));
+        } else {
+            $server->send($fd, str_repeat('A', 1023));
+            Swoole\Timer::after(50, function () use ($server, $fd) {
+                $server->send($fd, "\r\n");
+            });
+        }
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_client_sync/eof_package_max_length.phpt
+++ b/tests/swoole_client_sync/eof_package_max_length.phpt
@@ -1,0 +1,80 @@
+--TEST--
+swoole_client_sync: enforce package_max_length with eof protocol
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+
+$recv = function (string $command) use ($pm): array {
+    $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+    $client->set([
+        'open_eof_check' => true,
+        'package_eof' => "\r\n",
+        'package_max_length' => 1024,
+    ]);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 5));
+    Assert::same($client->send($command), strlen($command));
+    $warning = null;
+    set_error_handler(function (int $errno, string $message) use (&$warning) {
+        $warning = $message;
+        return true;
+    });
+    $data = $client->recv();
+    restore_error_handler();
+    $error = swoole_last_error();
+    $client->close();
+    return [$data, $error, $warning];
+};
+
+$pm->parentFunc = function () use ($pm, $recv) {
+    [$data, $error, $warning] = $recv('complete');
+    Assert::false($data);
+    Assert::same($error, SWOOLE_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+    Assert::contains(
+        (string) $warning,
+        'package length exceeds package_max_length, length=1025, package_max_length=1024'
+    );
+
+    [$data, $error, $warning] = $recv('unterminated');
+    Assert::false($data);
+    Assert::same($error, SWOOLE_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+    Assert::contains((string) $warning, 'no package eof, length=');
+    Assert::contains((string) $warning, 'package_max_length=1024');
+
+    [$data] = $recv('exact');
+    Assert::same(strlen($data), 1024);
+    Assert::true(str_ends_with($data, "\r\n"));
+
+    $pm->kill();
+    echo "DONE\n";
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('Receive', function (Swoole\Server $server, int $fd, int $reactorId, string $command) {
+        if ($command === 'complete') {
+            $server->send($fd, str_repeat('A', 1023));
+            Swoole\Timer::after(50, function () use ($server, $fd) {
+                $server->send($fd, "\r\n");
+            });
+        } elseif ($command === 'unterminated') {
+            $server->send($fd, str_repeat('A', 65536));
+        } else {
+            $server->send($fd, str_repeat('A', 1022) . "\r\n");
+        }
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_server/eof_package_max_length.phpt
+++ b/tests/swoole_server/eof_package_max_length.phpt
@@ -1,0 +1,60 @@
+--TEST--
+swoole_server: enforce non-aligned package_max_length with eof protocol
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$logFile = TEST_LOG_FILE . '.eof_package_max_length';
+@unlink($logFile);
+
+$pm = new ProcessManager;
+
+$pm->parentFunc = function () use ($pm, $logFile) {
+    $send = function (string $data, string $tail = '') use ($pm) {
+        $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+        Assert::true($client->connect('127.0.0.1', $pm->getFreePort(), 1));
+        Assert::same($client->send($data), strlen($data));
+        if ($tail !== '') {
+            usleep(50000);
+            Assert::same($client->send($tail), strlen($tail));
+        }
+        @$client->recv();
+        $client->close();
+    };
+
+    $send(str_repeat('A', 100000), "A\r\n");
+    $send(str_repeat('A', 100008));
+
+    $log = is_file($logFile) ? file_get_contents($logFile) : '';
+    Assert::same(substr_count($log, 'The received data packet is too large'), 2);
+    @unlink($logFile);
+    $pm->kill();
+    echo "DONE\n";
+};
+
+$pm->childFunc = function () use ($pm, $logFile) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'open_eof_check' => true,
+        'package_eof' => "\r\n",
+        'package_max_length' => 100001,
+        'log_file' => $logFile,
+        'log_level' => SWOOLE_LOG_WARNING,
+    ]);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('Receive', function (Swoole\Server $server, int $fd) {
+        echo "RECEIVED\n";
+        $server->close($fd);
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
EOF protocol receive paths only rejected an incomplete buffer when its size exactly matched package_max_length. A read could step past the limit, and a complete packet beyond the limit could still be delivered. An asynchronous client could also remain waiting after an oversized unterminated response.

This rejects complete EOF-delimited packets above the limit and incomplete buffers at or above it across the supported socket, client, split, and server paths. Exact-limit packets and valid first packets from coalesced reads remain accepted.

Focused PHP and C++ regressions fail before the fix and pass after it.