### PR TITLE
Validate ProcessPool packet bounds

### DIFF
--- a/core-tests/src/os/process_pool.cpp
+++ b/core-tests/src/os/process_pool.cpp
@@ -30,6 +30,7 @@ static void test_func(ProcessPool &pool) {
     int worker_id = -1;
     ASSERT_EQ(pool.dispatch_sync(&data, &worker_id), SW_OK);
 
+    pool.get_worker(0)->init();
     pool.running = true;
     pool.ptr = &rmem;
     if (pool.onWorkerStart) {
@@ -99,6 +100,114 @@ TEST(process_pool, unix_sock) {
     test_func_task_protocol(pool);
 }
 
+TEST(process_pool, task_protocol_rejects_malformed_packets) {
+    ProcessPool pool{};
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_UNIXSOCK), SW_OK);
+    pool.set_protocol(SW_PROTOCOL_TASK);
+    pool.get_worker(0)->init();
+    pool.running = true;
+    size_t dispatched = 0;
+    pool.ptr = &dispatched;
+    pool.onTask = [](ProcessPool *pool, Worker *worker, EventData *task) -> int {
+        (*static_cast<size_t *>(pool->ptr))++;
+        if (task->info.len == 1 && task->data[0] == 'x') {
+            pool->running = false;
+        }
+        return SW_OK;
+    };
+
+    EventData task{};
+    task.info.len = UINT32_MAX;
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message(&task, sizeof(task.info) - 1, SW_PIPE_MASTER),
+              sizeof(task.info) - 1);
+
+    task.info.len = 5000;
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message(&task, 100, SW_PIPE_MASTER), 100);
+
+    task.info.ext_flags = SW_TASK_TMPFILE;
+    task.info.len = 1;
+    task.data[0] = 't';
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message(&task, sizeof(task.info) + 1, SW_PIPE_MASTER),
+              sizeof(task.info) + 1);
+
+    task.info.ext_flags = 0;
+    task.info.len = sizeof(task.data);
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message(&task, sizeof(task), SW_PIPE_MASTER), sizeof(task));
+
+    task.info.len = 1;
+    task.data[0] = 'x';
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message(&task, sizeof(task.info) + 1, SW_PIPE_MASTER),
+              sizeof(task.info) + 1);
+
+    pool.main_loop(&pool, pool.get_worker(0));
+
+    EXPECT_EQ(dispatched, 2);
+    EXPECT_ERREQ(SW_ERROR_PROTOCOL_ERROR);
+    pool.destroy();
+}
+
+TEST(process_pool, task_protocol_rejects_malformed_socket_packet) {
+    signal(SIGPIPE, SIG_IGN);
+    const char *socket_file = "/tmp/swoole_process_pool_task.sock";
+    ProcessPool pool{};
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen(socket_file, 128), SW_OK);
+    pool.set_protocol(SW_PROTOCOL_TASK);
+    pool.get_worker(0)->init();
+    pool.running = true;
+    size_t dispatched = 0;
+    pool.ptr = &dispatched;
+    pool.onTask = [](ProcessPool *pool, Worker *worker, EventData *task) -> int {
+        (*static_cast<size_t *>(pool->ptr))++;
+        if (task->info.len == 1 && task->data[0] == 'x') {
+            pool->running = false;
+        }
+        return SW_OK;
+    };
+
+    bool connected = false;
+    ssize_t acknowledgment_received = SW_ERR;
+    int acknowledgment = -1;
+    swResultCode valid_packet_sent = SW_ERR;
+    std::thread sender([&]() {
+        swoole_thread_init(false);
+        network::SyncClient client(SW_SOCK_UNIX_STREAM);
+        connected = client.connect(socket_file, 0);
+        EXPECT_TRUE(connected);
+        if (connected) {
+            client.get_client()->set_timeout(1, SW_TIMEOUT_READ);
+            EventData invalid_task{};
+            invalid_task.info.len = UINT32_MAX;
+            uint32_t packet_length = htonl(sizeof(invalid_task.info) - 1);
+            EXPECT_EQ(client.send(reinterpret_cast<char *>(&packet_length), sizeof(packet_length)), sizeof(uint32_t));
+            EXPECT_EQ(client.send(reinterpret_cast<char *>(&invalid_task), sizeof(invalid_task.info) - 1),
+                      sizeof(DataHead) - 1);
+            acknowledgment_received =
+                client.recv(reinterpret_cast<char *>(&acknowledgment), sizeof(acknowledgment), MSG_WAITALL);
+            client.close();
+        }
+
+        EventData valid_task{};
+        valid_task.info.len = 1;
+        valid_task.data[0] = 'x';
+        int worker_id = -1;
+        valid_packet_sent = pool.dispatch_sync(&valid_task, &worker_id);
+        if (valid_packet_sent != SW_OK) {
+            pool.stream_info_->socket->shutdown(SHUT_RDWR);
+        }
+        swoole_thread_clean(false);
+    });
+
+    pool.main_loop(&pool, pool.get_worker(0));
+    sender.join();
+
+    EXPECT_EQ(acknowledgment_received, sizeof(int));
+    EXPECT_EQ(acknowledgment, 0);
+    EXPECT_EQ(valid_packet_sent, SW_OK);
+    EXPECT_EQ(dispatched, 1);
+    pool.destroy();
+}
+
 TEST(process_pool, tcp_raw) {
     constexpr uint32_t size = 2 * 1024 * 1024;
     String data(size);
@@ -131,6 +240,7 @@ TEST(process_pool, tcp_raw) {
         swoole_thread_clean(false);
     });
 
+    pool.get_worker(0)->init();
     pool.main_loop(&pool, pool.get_worker(0));
     sender.join();
 
@@ -205,6 +315,59 @@ TEST(process_pool, stream_protocol) {
 
     test_func_stream_protocol(pool);
 }
+
+TEST(process_pool, stream_protocol_small_packet) {
+    // The one-byte allocation exposes the former QueueNode write under ASAN.
+    ProcessPool pool{};
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_UNIXSOCK), SW_OK);
+    pool.set_max_packet_size(1);
+    pool.set_protocol(SW_PROTOCOL_STREAM);
+    pool.get_worker(0)->init();
+    pool.running = true;
+    pool.onMessage = [](ProcessPool *pool, RecvData *rdata) {
+        EXPECT_EQ(rdata->info.len, 1);
+        EXPECT_EQ(rdata->data[0], 'x');
+        pool->running = false;
+    };
+
+    ASSERT_EQ(pool.get_worker(0)->send_pipe_message("x", 1, SW_PIPE_MASTER), 1);
+    pool.main_loop(&pool, pool.get_worker(0));
+    EXPECT_FALSE(pool.running);
+    pool.destroy();
+}
+
+#ifdef HAVE_MSGQUEUE
+TEST(process_pool, stream_protocol_msgqueue_package_limit) {
+    constexpr size_t max_packet_size = 1024;
+    std::vector<char> oversized_message(offsetof(QueueNode, mdata) + max_packet_size + 1);
+    std::vector<char> valid_message(offsetof(QueueNode, mdata) + max_packet_size);
+    auto *oversized_node = reinterpret_cast<QueueNode *>(oversized_message.data());
+    auto *valid_node = reinterpret_cast<QueueNode *>(valid_message.data());
+    oversized_node->mtype = 1;
+    valid_node->mtype = 1;
+
+    ProcessPool pool{};
+    ASSERT_EQ(pool.create(1, IPC_PRIVATE, SW_IPC_MSGQUEUE), SW_OK);
+    pool.set_max_packet_size(max_packet_size);
+    pool.set_protocol(SW_PROTOCOL_STREAM);
+    pool.get_worker(0)->init();
+    pool.running = true;
+    size_t received = 0;
+    pool.ptr = &received;
+    pool.onMessage = [](ProcessPool *pool, RecvData *rdata) {
+        *static_cast<size_t *>(pool->ptr) = rdata->info.len;
+        pool->running = false;
+    };
+
+    ASSERT_TRUE(pool.queue->push(oversized_node, max_packet_size + 1));
+    ASSERT_TRUE(pool.queue->push(valid_node, max_packet_size));
+    pool.main_loop(&pool, pool.get_worker(0));
+
+    EXPECT_EQ(received, max_packet_size);
+    EXPECT_ERREQ(SW_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+    pool.destroy();
+}
+#endif
 
 TEST(process_pool, stream_protocol_with_msgq) {
     ProcessPool pool{};

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -428,7 +428,8 @@ static PHP_METHOD(swoole_process_pool, set) {
         pp->enable_message_bus = zval_is_true(ztmp);
     }
     if (php_swoole_array_get_value(vht, "max_package_size", ztmp)) {
-        pool->set_max_packet_size(php_swoole_parse_to_size(ztmp));
+        zend_long v = php_swoole_parse_to_size(ztmp);
+        pool->set_max_packet_size(v < 1 ? 1 : (v > UINT32_MAX ? UINT32_MAX : v));
     }
     if (php_swoole_array_get_value(vht, "max_wait_time", ztmp)) {
         zend_long v = zval_get_long(ztmp);

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -592,15 +592,20 @@ int ProcessPool::run_with_task_protocol(ProcessPool *pool, Worker *worker) {
         if (n < 0) {
             goto _end;
         }
-        if (n != (ssize_t) out.buf.size()) {
-            swoole_warning("[Worker#%d] bad task packet, The received data-length[%ld] is inconsistent with the "
-                           "packet-length[%ld]",
-                           worker->id,
-                           n,
-                           out.buf.info.len + sizeof(out.buf.info));
-        }
-        if (pool->onTask(pool, worker, &out.buf) < 0) {
-            swoole_warning("[Worker#%d] the execution of task#%ld has failed", worker->id, pool->get_task_id(&out.buf));
+        {
+            uint64_t packet_size = sizeof(out.buf.info) + (uint64_t) out.buf.info.len;
+            if ((uint64_t) n != packet_size ||
+                ((out.buf.info.ext_flags & SW_TASK_TMPFILE) && out.buf.info.len != sizeof(PacketTask))) {
+                swoole_error_log(SW_LOG_WARNING,
+                                 SW_ERROR_PROTOCOL_ERROR,
+                                 "[Worker#%d] bad task packet, received data length[%zd], packet length[%" PRIu64 "]",
+                                 worker->id,
+                                 n,
+                                 packet_size);
+            } else if (pool->onTask(pool, worker, &out.buf) < 0) {
+                swoole_warning(
+                    "[Worker#%d] the execution of task#%ld has failed", worker->id, pool->get_task_id(&out.buf));
+            }
         }
         if (pool->use_socket && pool->stream_info_->last_connection) {
             int _end = 0;
@@ -668,13 +673,19 @@ int ProcessPool::run_with_stream_protocol(ProcessPool *pool, Worker *worker) {
     RecvData msg{};
     msg.info.reactor_id = -1;
 
-    pool->packet_buffer = new char[pool->max_packet_size_];
+    QueueNode *outbuf = nullptr;
+    if (pool->use_msgqueue) {
+        // MsgQueue::pop() does not truncate oversized messages. Receive the protocol maximum, including the message
+        // type prefix written by msgrcv(), then enforce max_packet_size_ after receipt.
+        pool->packet_buffer = new char[offsetof(QueueNode, mdata) + SW_MSGMAX];
+        outbuf = reinterpret_cast<QueueNode *>(pool->packet_buffer);
+        outbuf->mtype = 0;
+    } else {
+        pool->packet_buffer = new char[pool->max_packet_size_];
+    }
     if (pool->stream_info_) {
         pool->stream_info_->response_buffer = new String(SW_BUFFER_SIZE_STD);
     }
-
-    auto *outbuf = reinterpret_cast<QueueNode *>(pool->packet_buffer);
-    outbuf->mtype = 0;
 
     pool->at_worker_enter(worker);
     while (pool->is_worker_running(worker)) {
@@ -686,14 +697,25 @@ int ProcessPool::run_with_stream_protocol(ProcessPool *pool, Worker *worker) {
             /**
              * A fatal error has occurred; the message queue is no longer available, and the loop must be exited.
              */
-            if (n < 0 && catch_system_error(errno) == SW_ERROR) {
-                swoole_sys_warning("[Worker#%d] msgrcv(%d) failed", worker->id, pool->queue->get_id());
-                break;
+            if (n < 0) {
+                if (catch_system_error(errno) == SW_ERROR) {
+                    swoole_sys_warning("[Worker#%d] msgrcv(%d) failed", worker->id, pool->queue->get_id());
+                    break;
+                }
+                goto _end;
             }
             swoole_trace_log(SW_TRACE_WORKER, "pop from MsgQ#%d %lu bytes", pool->queue->get_id(), (ulong_t) n);
-            msg.info.len = n - sizeof(msg.info);
-            msg.data = outbuf->mdata;
             outbuf->mtype = 0;
+            if ((size_t) n > pool->max_packet_size_) {
+                swoole_error_log(SW_LOG_WARNING,
+                                 SW_ERROR_PACKAGE_LENGTH_TOO_LARGE,
+                                 "[Worker#%d] message is too large, length=%zd, max_package_size=%u",
+                                 worker->id,
+                                 n,
+                                 pool->max_packet_size_);
+                goto _end;
+            }
+            msg.data = outbuf->mdata;
         } else if (pool->use_socket) {
             Socket *conn = pool->stream_info_->socket->accept();
             if (conn == nullptr) {


### PR DESCRIPTION
ProcessPool stream workers use the configured package limit as their receive allocation. SysV message queues can write beyond that allocation, while direct stream workers also wrote queue metadata into buffers that may be smaller than the metadata itself. Task workers warn about inconsistent frame lengths but still dispatch those frames.

This change gives SysV queue reads enough space for the queue protocol, rejects drained messages above the configured limit, and keeps queue metadata out of other stream modes. It also rejects malformed task frames before onTask while preserving socket acknowledgement and cleanup.

The focused tests cover oversized and boundary-sized queue messages, malformed task frames, socket cleanup, and the largest valid inline task. A separate ASAN regression covers the one-byte direct stream allocation because the original overwrite is not observable with a normal allocator.