### PR TITLE
Fix CPU affinity IDs

### DIFF
--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -960,8 +960,7 @@ bool php_swoole_array_to_cpu_set(const zval *array, cpu_set_t *cpu_set) {
         return false;
     }
 
-    const zend_long cpu_num = SW_MIN((zend_long) SW_CPU_NUM, (zend_long) CPU_SETSIZE);
-    if ((zend_long) php_swoole_array_length(array) > cpu_num) {
+    if (php_swoole_array_length(array) > CPU_SETSIZE) {
         php_swoole_fatal_error(E_WARNING, "More than the number of CPU");
         return false;
     }
@@ -971,7 +970,7 @@ bool php_swoole_array_to_cpu_set(const zval *array, cpu_set_t *cpu_set) {
 
     SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(array), value)
     const zend_long cpu_id = zval_get_long(value);
-    if (cpu_id < 0 || cpu_id >= cpu_num) {
+    if (cpu_id < 0 || cpu_id >= CPU_SETSIZE) {
         php_swoole_fatal_error(E_WARNING, "invalid cpu id [" ZEND_LONG_FMT "]", cpu_id);
         return false;
     }
@@ -984,7 +983,7 @@ bool php_swoole_array_to_cpu_set(const zval *array, cpu_set_t *cpu_set) {
 void php_swoole_cpu_set_to_array(zval *array, cpu_set_t *cpu_set) {
     array_init(array);
 
-    int cpu_n = SW_CPU_NUM;
+    int cpu_n = CPU_SETSIZE;
     SW_LOOP_N(cpu_n) {
         if (CPU_ISSET(i, cpu_set)) {
             add_next_index_long(array, i);

--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -960,7 +960,8 @@ bool php_swoole_array_to_cpu_set(const zval *array, cpu_set_t *cpu_set) {
         return false;
     }
 
-    if (php_swoole_array_length(array) > SW_CPU_NUM) {
+    const zend_long cpu_num = SW_MIN((zend_long) SW_CPU_NUM, (zend_long) CPU_SETSIZE);
+    if ((zend_long) php_swoole_array_length(array) > cpu_num) {
         php_swoole_fatal_error(E_WARNING, "More than the number of CPU");
         return false;
     }
@@ -969,11 +970,12 @@ bool php_swoole_array_to_cpu_set(const zval *array, cpu_set_t *cpu_set) {
     CPU_ZERO(cpu_set);
 
     SW_HASHTABLE_FOREACH_START(Z_ARRVAL_P(array), value)
-    if (zval_get_long(value) >= SW_CPU_NUM) {
-        php_swoole_fatal_error(E_WARNING, "invalid cpu id [%d]", (int) Z_LVAL_P(value));
+    const zend_long cpu_id = zval_get_long(value);
+    if (cpu_id < 0 || cpu_id >= cpu_num) {
+        php_swoole_fatal_error(E_WARNING, "invalid cpu id [" ZEND_LONG_FMT "]", cpu_id);
         return false;
     }
-    CPU_SET(Z_LVAL_P(value), cpu_set);
+    CPU_SET(cpu_id, cpu_set);
     SW_HASHTABLE_FOREACH_END();
 
     return true;

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -280,7 +280,7 @@ static PHP_METHOD(swoole_thread, setAffinity) {
         RETURN_FALSE;
     }
 
-    if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set), &cpu_set) < 0) {
+    if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set), &cpu_set) != 0) {
         php_swoole_error(E_WARNING, "pthread_setaffinity_np() failed");
         RETURN_FALSE;
     }

--- a/tests/swoole_process/affinity_cpu_id_range.phpt
+++ b/tests/swoole_process/affinity_cpu_id_range.phpt
@@ -1,0 +1,39 @@
+--TEST--
+swoole_process: affinity CPU ID range
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_linux();
+skip_if_no_process_affinity();
+
+$status = file_get_contents('/proc/self/status');
+preg_match('/^Cpus_allowed_list:\s*(.+)$/m', $status, $matches);
+skip('cannot read allowed CPU list', empty($matches[1]));
+
+$cpuRanges = explode(',', trim($matches[1]));
+$lastRange = explode('-', end($cpuRanges));
+$lastCpu = (int) end($lastRange);
+skip('requires an affinity CPU ID outside swoole_cpu_num range', $lastCpu < swoole_cpu_num());
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+
+$status = file_get_contents('/proc/self/status');
+preg_match('/^Cpus_allowed_list:\s*(.+)$/m', $status, $matches);
+
+$cpus = [];
+foreach (explode(',', trim($matches[1])) as $range) {
+    $bounds = array_map('intval', explode('-', $range, 2));
+    foreach (range($bounds[0], $bounds[1] ?? $bounds[0]) as $cpu) {
+        $cpus[] = $cpu;
+    }
+}
+
+Assert::same(Process::getAffinity(), $cpus);
+Assert::true(Process::setAffinity($cpus));
+Assert::same(Process::getAffinity(), $cpus);
+?>
+--EXPECT--

--- a/tests/swoole_process/setaffinity.phpt
+++ b/tests/swoole_process/setaffinity.phpt
@@ -4,24 +4,20 @@ swoole_process: setAffinity
 <?php
 require __DIR__ . '/../include/skipif.inc';
 skip_if_no_process_affinity();
-$cpus = Swoole\Process::getAffinity();
-$cpus = array_filter($cpus, fn ($cpu) => $cpu < swoole_cpu_num());
-skip('no usable cpu id', !$cpus);
 ?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';
 $original = Swoole\Process::getAffinity();
-$cpus = array_values(array_filter($original, fn ($cpu) => $cpu < swoole_cpu_num()));
-$cpu = $cpus[0];
+$cpu = $original[0];
 
 try {
     Assert::true(Swoole\Process::setAffinity([(string) $cpu]));
     Assert::same(Swoole\Process::getAffinity(), [$cpu]);
 
-    if (count($cpus) > 1) {
-        Assert::true(Swoole\Process::setAffinity([$cpus[0], $cpus[1]]));
-        Assert::same(Swoole\Process::getAffinity(), [$cpus[0], $cpus[1]]);
+    if (count($original) > 1) {
+        Assert::true(Swoole\Process::setAffinity([$original[0], $original[1]]));
+        Assert::same(Swoole\Process::getAffinity(), [$original[0], $original[1]]);
     }
 
     $warning = null;

--- a/tests/swoole_process/setaffinity.phpt
+++ b/tests/swoole_process/setaffinity.phpt
@@ -4,15 +4,39 @@ swoole_process: setAffinity
 <?php
 require __DIR__ . '/../include/skipif.inc';
 skip_if_no_process_affinity();
+$cpus = Swoole\Process::getAffinity();
+$cpus = array_filter($cpus, fn ($cpu) => $cpu < swoole_cpu_num());
+skip('no usable cpu id', !$cpus);
 ?>
 --FILE--
 <?php
 require __DIR__ . '/../include/bootstrap.php';
-$r = Swoole\Process::setaffinity([0]);
-Assert::assert($r);
-if (swoole_cpu_num() > 1) {
-    $r = Swoole\Process::setaffinity([0, 1]);
-    Assert::assert($r);
+$original = Swoole\Process::getAffinity();
+$cpus = array_values(array_filter($original, fn ($cpu) => $cpu < swoole_cpu_num()));
+$cpu = $cpus[0];
+
+try {
+    Assert::true(Swoole\Process::setAffinity([(string) $cpu]));
+    Assert::same(Swoole\Process::getAffinity(), [$cpu]);
+
+    if (count($cpus) > 1) {
+        Assert::true(Swoole\Process::setAffinity([$cpus[0], $cpus[1]]));
+        Assert::same(Swoole\Process::getAffinity(), [$cpus[0], $cpus[1]]);
+    }
+
+    $warning = null;
+    set_error_handler(function ($errno, $message) use (&$warning) {
+        $warning = $message;
+        return true;
+    });
+    try {
+        Assert::false(Swoole\Process::setAffinity([$cpu, -1]));
+    } finally {
+        restore_error_handler();
+    }
+    Assert::contains($warning, 'invalid cpu id [-1]');
+} finally {
+    @Swoole\Process::setAffinity($original);
 }
 echo "SUCCESS";
 ?>

--- a/tests/swoole_thread/affinity.phpt
+++ b/tests/swoole_thread/affinity.phpt
@@ -19,6 +19,7 @@ $tm->parentFunc = function () {
     $thread = new Thread(__FILE__, 'child');
     $r = Thread::getAffinity();
     Assert::eq(count($r), swoole_cpu_num());
+    Assert::false(@Thread::setAffinity([1023]));
     Assert::assert(Thread::setAffinity([1]));
     Assert::eq(Thread::getAffinity(), [1]);
     $thread->join();


### PR DESCRIPTION
`Swoole\Process::setAffinity()` validates converted CPU IDs but uses the original zval storage when building the affinity mask. Numeric-string IDs can therefore be omitted, and a mixed list can return success with the wrong mask. Negative IDs are also silently omitted on this branch.

The affinity helpers also treat `swoole_cpu_num()` as the CPU ID range, but that count does not bound IDs. On musl it counts the startup affinity mask, and on master it can be a cgroup CPU quota. A process limited to CPU 1 on Alpine gets an empty `getAffinity()` result, and `setAffinity([1])` fails.

This change converts each entry once and uses that value for validation, diagnostics, and the CPU mask. Input IDs and the output scan are limited by the platform CPU-set size; the kernel still rejects a mask with no usable CPU. `Thread::setAffinity()` also reports a rejected mask instead of returning true.

The existing affinity test uses the process's current CPUs directly. A Linux regression compares the affinity with `Cpus_allowed_list` when it includes an ID outside the `swoole_cpu_num()` range.
