### PR TITLE
Handle HTTP body boundaries and 100 Continue

### DIFF
--- a/include/swoole_http.h
+++ b/include/swoole_http.h
@@ -112,6 +112,18 @@ namespace swoole {
 class Server;
 namespace http_server {
 //-----------------------------------------------------------------
+enum ChunkState {
+    CHUNK_STATE_SIZE,
+    CHUNK_STATE_DATA,
+    CHUNK_STATE_TRAILER,
+};
+
+enum ChunkSizeResult {
+    CHUNK_SIZE_OK,
+    CHUNK_SIZE_MALFORMED,
+    CHUNK_SIZE_TOO_LARGE,
+};
+
 struct FormData {
     const char *multipart_boundary_buf;
     uint32_t multipart_boundary_len;
@@ -139,7 +151,6 @@ struct Request {
     uchar known_length : 1;
     uchar keep_alive : 1;
     uchar chunked : 1;
-    uchar nobody_chunked : 1;
 
     uint32_t url_offset_;
     uint32_t url_length_;
@@ -148,6 +159,10 @@ struct Request {
     uint32_t request_line_length_; /* without \r\n  */
     uint32_t header_length_;       /* include request_line_length + \r\n */
     uint64_t content_length_;
+    uint8_t chunk_state_;
+    size_t chunk_length_;
+    size_t chunk_offset_;
+    size_t chunk_scan_offset_;
 
     FormData *form_data_;
     String *buffer_;

--- a/src/protocol/http.cc
+++ b/src/protocol/http.cc
@@ -775,9 +775,6 @@ void Request::parse_header_info() {
     }
 
     header_parsed = 1;
-    if (chunked && known_length && content_length_ == 0) {
-        nobody_chunked = 1;
-    }
 }
 
 bool Request::init_multipart_parser(const Server *server) {
@@ -895,53 +892,231 @@ int Request::get_header_length() {
     return SW_ERR;
 }
 
-int Request::get_chunked_body_length() {
-    const char *p = buffer_->str + buffer_->offset;
-    const char *pe = buffer_->str + buffer_->length;
+static bool is_http_token_char(unsigned char c) {
+    if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+        return true;
+    }
+    switch (c) {
+    case '!':
+    case '#':
+    case '$':
+    case '%':
+    case '&':
+    case '\'':
+    case '*':
+    case '+':
+    case '-':
+    case '.':
+    case '^':
+    case '_':
+    case '`':
+    case '|':
+    case '~':
+        return true;
+    default:
+        return false;
+    }
+}
 
-    /**
-     * Ending with SW_HTTP_CHUNK_EOF indicates that the HTTP request may have been fully received,
-     * but this is not certain. It is still necessary to skip over the data sections based on
-     * the length of each chunk of the HTTP data until SW_HTTP_CHUNK_EOF (\0\r\n\r\n) is found.
-     */
-    if (static_cast<size_t>(pe - p) < sizeof(SW_HTTP_CHUNK_EOF) - 1 ||
-        memcmp(pe - sizeof(SW_HTTP_CHUNK_EOF) + 1, SW_STRL(SW_HTTP_CHUNK_EOF)) != 0) {
-        return SW_ERR;
+static bool is_http_quoted_char(unsigned char c) {
+    return c == '\t' || (c >= 0x20 && c != 0x7f && c != '"' && c != '\\');
+}
+
+static bool is_http_quoted_pair_char(unsigned char c) {
+    return c == '\t' || (c >= 0x20 && c != 0x7f);
+}
+
+static ChunkSizeResult parse_chunk_size(const char *p, const char *pe, size_t max_length, size_t *chunk_length) {
+    size_t length = 0;
+    const char *start = p;
+
+    while (p < pe) {
+        unsigned char c = *p;
+        uint8_t digit;
+        if (c >= '0' && c <= '9') {
+            digit = c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+            digit = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'F') {
+            digit = c - 'A' + 10;
+        } else {
+            break;
+        }
+        if (digit > max_length || length > (max_length - digit) / 16) {
+            return CHUNK_SIZE_TOO_LARGE;
+        }
+        length = length * 16 + digit;
+        p++;
+    }
+
+    if (p == start) {
+        return CHUNK_SIZE_MALFORMED;
+    }
+
+    while (p < pe) {
+        if (*p++ != ';') {
+            return CHUNK_SIZE_MALFORMED;
+        }
+
+        const char *name = p;
+        while (p < pe && is_http_token_char(*p)) {
+            p++;
+        }
+        if (p == name) {
+            return CHUNK_SIZE_MALFORMED;
+        }
+        if (p == pe) {
+            break;
+        }
+        if (*p != '=') {
+            continue;
+        }
+
+        p++;
+        if (p == pe) {
+            return CHUNK_SIZE_MALFORMED;
+        }
+        if (*p == '"') {
+            bool closed = false;
+            for (p++; p < pe; p++) {
+                unsigned char c = *p;
+                if (c == '"') {
+                    closed = true;
+                    p++;
+                    break;
+                }
+                if (c == '\\') {
+                    if (++p == pe || !is_http_quoted_pair_char(*p)) {
+                        return CHUNK_SIZE_MALFORMED;
+                    }
+                } else if (!is_http_quoted_char(c)) {
+                    return CHUNK_SIZE_MALFORMED;
+                }
+            }
+            if (!closed) {
+                return CHUNK_SIZE_MALFORMED;
+            }
+        } else {
+            const char *value = p;
+            while (p < pe && is_http_token_char(*p)) {
+                p++;
+            }
+            if (p == value) {
+                return CHUNK_SIZE_MALFORMED;
+            }
+        }
+    }
+
+    *chunk_length = length;
+    return CHUNK_SIZE_OK;
+}
+
+int Request::get_chunked_body_length() {
+    const char *buffer = buffer_->str;
+    const char *pe = buffer + buffer_->length;
+    const size_t chunk_data_end_length = sizeof("\r\n") - 1 + sizeof(SW_HTTP_CHUNK_EOF) - 1;
+    const size_t trailer_end_length = sizeof("\r\n") - 1;
+
+    if (chunk_offset_ == 0) {
+        // clean() leaves zero as the uninitialized offset, and the header has been parsed here.
+        chunk_offset_ = chunk_scan_offset_ = header_length_;
     }
 
     while (true) {
-        char *endptr;
-        size_t chunk_length = strtoul(p, &endptr, 16);
-        if (endptr == nullptr || *endptr != '\r') {
-            break;
+        if (chunk_state_ == CHUNK_STATE_DATA) {
+            if (chunk_offset_ > buffer_->length || chunk_length_ > buffer_->length - chunk_offset_) {
+                return SW_ERR;
+            }
+            size_t chunk_end = chunk_offset_ + chunk_length_;
+            if (chunk_end == buffer_->length) {
+                return SW_ERR;
+            }
+            if (buffer[chunk_end] != '\r') {
+                excepted = 1;
+                return SW_ERR;
+            }
+            if (chunk_end + 1 == buffer_->length) {
+                return SW_ERR;
+            }
+            if (buffer[chunk_end + 1] != '\n') {
+                excepted = 1;
+                return SW_ERR;
+            }
+            chunk_offset_ = chunk_scan_offset_ = chunk_end + 2;
+            chunk_length_ = 0;
+            chunk_state_ = CHUNK_STATE_SIZE;
+            continue;
         }
 
-        swoole_trace_log(SW_TRACE_HTTP, "chunk_length=%zu, chunk_len_str=%.*s\n", chunk_length, (int) (endptr - p), p);
-
-        // Found the HTTP Chunk EOF
-        if (chunk_length == 0) {
-            known_length = 1;
-            content_length_ = endptr - (buffer_->str + header_length_) + 4;
-            return SW_OK;
-        } else {
-            // chunk length [hex str] + CRLF + data + CRLF
-            p = endptr + 2 + chunk_length + 2;
-            // Continue to parse the next segment of HTTP CHUNK data.
-            if (p < pe) {
-                continue;
+        const char *p = buffer + chunk_scan_offset_;
+        const char *line_start = buffer + chunk_offset_;
+        while (p < pe && *p != '\r') {
+            if (*p == '\n') {
+                excepted = 1;
+                return SW_ERR;
             }
-            /**
-             * If the calculated data length exceeds the length of the currently received data,
-             * then SW_HTTP_CHUNK_EOF may be part of the data,
-             * necessitating the reception of additional data and recalculating the HTTP Chunk length.
-             */
+            p++;
+        }
+        if (p == pe) {
+            chunk_scan_offset_ = p - buffer;
             return SW_ERR;
         }
-        break;
-    }
+        if (p + 1 == pe) {
+            chunk_scan_offset_ = p - buffer;
+            return SW_ERR;
+        }
+        if (p[1] != '\n') {
+            excepted = 1;
+            return SW_ERR;
+        }
 
-    excepted = 1;
-    return SW_ERR;
+        const char *line_end = p;
+        p += 2;
+        chunk_offset_ = chunk_scan_offset_ = p - buffer;
+
+        if (chunk_state_ == CHUNK_STATE_TRAILER) {
+            if (chunk_offset_ > max_length_) {
+                too_large = 1;
+                return SW_ERR;
+            }
+            if (line_end == line_start) {
+                known_length = 1;
+                content_length_ = chunk_offset_ - header_length_;
+                return SW_OK;
+            }
+            continue;
+        }
+
+        ChunkSizeResult result = parse_chunk_size(line_start, line_end, max_length_, &chunk_length_);
+        if (result == CHUNK_SIZE_TOO_LARGE) {
+            too_large = 1;
+            return SW_ERR;
+        }
+        if (result != CHUNK_SIZE_OK) {
+            excepted = 1;
+            return SW_ERR;
+        }
+        swoole_trace_log(SW_TRACE_HTTP,
+                         "chunk_length=%zu, chunk_len_str=%.*s\n",
+                         chunk_length_,
+                         (int) (line_end - line_start),
+                         line_start);
+
+        if (chunk_length_ == 0) {
+            chunk_state_ = CHUNK_STATE_TRAILER;
+            if (chunk_offset_ > max_length_ || max_length_ - chunk_offset_ < trailer_end_length) {
+                too_large = 1;
+                return SW_ERR;
+            }
+        } else {
+            chunk_state_ = CHUNK_STATE_DATA;
+            if (chunk_offset_ > max_length_ || max_length_ - chunk_offset_ < chunk_data_end_length ||
+                chunk_length_ > max_length_ - chunk_offset_ - chunk_data_end_length) {
+                too_large = 1;
+                return SW_ERR;
+            }
+        }
+    }
 }
 
 std::string Request::get_header(const char *name) const {

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -598,16 +598,8 @@ _parse:
 
     // content length (equal to 0) or (field not found but not chunked)
     if (!request->tried_to_dispatch) {
-        // recv nobody_chunked eof
-        if (request->nobody_chunked) {
-            if (buffer->length < request->header_length_ + (sizeof(SW_HTTP_CHUNK_EOF) - 1)) {
-                goto _recv_data;
-            }
-            request->header_length_ += (sizeof(SW_HTTP_CHUNK_EOF) - 1);
-        }
         request->tried_to_dispatch = 1;
-        // (know content-length is equal to 0) or (no content-length field and no chunked)
-        if (request->content_length_ == 0 && (request->known_length || !request->chunked)) {
+        if (request->content_length_ == 0 && !request->chunked) {
             buffer->offset = request->header_length_;
             // send static file content directly in the reactor thread
             if (!serv->enable_static_handler || !serv->select_static_handler(request, conn)) {
@@ -638,6 +630,9 @@ _parse:
     if (request->chunked) {
         /* unknown length, should find chunked eof */
         if (request->get_chunked_body_length() < 0) {
+            if (request->too_large) {
+                goto _too_large;
+            }
             if (request->excepted) {
                 swoole_error_log(SW_LOG_TRACE,
                                  SW_ERROR_HTTP_INVALID_PROTOCOL,
@@ -666,8 +661,8 @@ _parse:
         swoole_trace_log(
             SW_TRACE_SERVER, "received chunked eof, real content-length=%" PRIu64, request->content_length_);
     } else {
-        request_length = request->header_length_ + request->content_length_;
-        if (request_length > protocol->package_max_length) {
+        // Header parsing is capped at the minimum package_max_length before this subtraction.
+        if (request->content_length_ > protocol->package_max_length - request->header_length_) {
             swoole_error_log(SW_LOG_WARNING,
                              SW_ERROR_HTTP_INVALID_PROTOCOL,
                              "Request Entity Too Large: header-length (%u) + content-length (%" PRIu64
@@ -679,6 +674,7 @@ _parse:
                              CLIENT_INFO_ARGS);
             goto _too_large;
         }
+        request_length = request->header_length_ + request->content_length_;
 
         if (request_length > buffer->size) {
             buffer->extend(request_length);
@@ -700,25 +696,20 @@ _parse:
         }
     }
 
-    // discard the redundant data
-    if (buffer->length > request_length) {
-        swoole_error_log(SW_LOG_TRACE,
-                         SW_ERROR_HTTP_INVALID_PROTOCOL,
-                         "Invalid Request: %zu bytes has been discard" CLIENT_INFO_FMT,
-                         buffer->length - request_length,
-                         CLIENT_INFO_ARGS);
-        buffer->length = request_length;
-    }
-
     buffer->offset = request_length;
     dispatch_data.data = buffer->str;
-    dispatch_data.info.len = buffer->length;
+    dispatch_data.info.len = request_length;
 
     if (http_server::dispatch_request(serv, protocol, _socket, &dispatch_data) < 0) {
         goto _close_fd;
     }
 
     if (conn->active && !_socket->removed) {
+        if (buffer->length > request_length) {
+            buffer->reduce(request_length);
+            request->clean();
+            goto _parse;
+        }
         port->destroy_http_request(conn);
         if (_socket->recv_buffer && _socket->recv_buffer->size > SW_BUFFER_SIZE_BIG * 2) {
             delete _socket->recv_buffer;

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -566,6 +566,9 @@ _parse:
         if (request->form_data_) {
             if (serv->upload_max_filesize > 0 &&
                 request->header_length_ + request->content_length_ > request->max_length_) {
+                if (buffer->length == request->header_length_ && request->has_expect_header()) {
+                    _socket->send(SW_STRL(SW_HTTP_100_CONTINUE_PACKET), 0);
+                }
                 request->init_multipart_parser(serv);
 
                 buffer = request->buffer_;
@@ -650,6 +653,9 @@ _parse:
                                  CLIENT_INFO_ARGS);
                 goto _too_large;
             }
+            if (buffer->length == request->header_length_ && request->has_expect_header()) {
+                _socket->send(SW_STRL(SW_HTTP_100_CONTINUE_PACKET), 0);
+            }
             if (buffer->length == buffer->size) {
                 // The limit check above guarantees that the new size is larger.
                 buffer->extend(SW_MIN(buffer->size + SW_BUFFER_SIZE_BIG, (size_t) protocol->package_max_length));
@@ -682,7 +688,7 @@ _parse:
 
         if (buffer->length < request_length) {
             // Expect: 100-continue
-            if (request->has_expect_header()) {
+            if (buffer->length == request->header_length_ && request->has_expect_header()) {
                 _socket->send(SW_STRL(SW_HTTP_100_CONTINUE_PACKET), 0);
             } else {
                 swoole_trace_log(

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -645,18 +645,19 @@ _parse:
                                  CLIENT_INFO_ARGS);
                 goto _bad_request;
             }
-            request_length = buffer->size + SW_BUFFER_SIZE_BIG;
-            if (request_length > protocol->package_max_length) {
+            if (buffer->length >= protocol->package_max_length) {
                 swoole_error_log(SW_LOG_WARNING,
                                  SW_ERROR_HTTP_INVALID_PROTOCOL,
-                                 "Request Entity Too Large: request length (chunked) has already been greater than the "
+                                 "Request Entity Too Large: the chunked request length (%zu) has reached the "
                                  "package_max_length(%u)" CLIENT_INFO_FMT,
+                                 buffer->length,
                                  protocol->package_max_length,
                                  CLIENT_INFO_ARGS);
                 goto _too_large;
             }
             if (buffer->length == buffer->size) {
-                buffer->extend(request_length);
+                // The limit check above guarantees that the new size is larger.
+                buffer->extend(SW_MIN(buffer->size + SW_BUFFER_SIZE_BIG, (size_t) protocol->package_max_length));
             }
             goto _recv_data;
         } else {

--- a/tests/swoole_http_server/100-continue.phpt
+++ b/tests/swoole_http_server/100-continue.phpt
@@ -9,6 +9,22 @@ skip_if_function_not_exist('curl_init');
 <?php
 require __DIR__ . '/../include/bootstrap.php';
 
+const CONTINUE_RESPONSE = "HTTP/1.1 100 Continue\r\n\r\n";
+
+function connectHttpServer(ProcessManager $pm): Swoole\Coroutine\Socket
+{
+    $socket = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $pm->getFreePort()));
+    return $socket;
+}
+
+function recvContinue(Swoole\Coroutine\Socket $socket): string
+{
+    $response = $socket->recv();
+    Assert::same($response, CONTINUE_RESPONSE);
+    return $response;
+}
+
 $pm = new ProcessManager;
 $pm->parentFunc = function () use ($pm) {
     $ch = curl_init();
@@ -33,6 +49,46 @@ $pm->parentFunc = function () use ($pm) {
     Assert::same($res, md5_file($file));
     curl_close($ch);
 
+    Swoole\Coroutine\run(function () use ($pm) {
+        $socket = connectHttpServer($pm);
+        $request =
+            "POST /length HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Length: 10\r\n" .
+            "Expect: 100-continue\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        $response = recvContinue($socket);
+
+        Assert::same($socket->sendAll('hello'), 5);
+        usleep(1000);
+        Assert::same($socket->sendAll('world'), 5);
+        while (!str_contains($response, 'helloworld')) {
+            $data = $socket->recv();
+            Assert::assert($data !== false && $data !== '');
+            $response .= $data;
+        }
+        Assert::same(substr_count($response, CONTINUE_RESPONSE), 1);
+
+        $socket = connectHttpServer($pm);
+        $request =
+            "POST /chunked HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Transfer-Encoding: chunked\r\n" .
+            "Expect: 100-continue\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        recvContinue($socket);
+
+        $socket = connectHttpServer($pm);
+        $request =
+            "POST /multipart HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Type: multipart/form-data; boundary=boundary\r\n" .
+            "Content-Length: " . (2 * 1024 * 1024) . "\r\n" .
+            "Expect: 100-continue\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        recvContinue($socket);
+    });
+
     $pm->kill();
 };
 
@@ -41,6 +97,7 @@ $pm->childFunc = function () use ($pm) {
 
     $http->set([
         'log_file' => '/dev/null',
+        'upload_max_filesize' => 1024 * 1024,
     ]);
 
     $http->on("WorkerStart", function () use ($pm) {
@@ -48,7 +105,11 @@ $pm->childFunc = function () use ($pm) {
     });
 
     $http->on("request", function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
-        $response->end(md5_file($request->files['file']['tmp_name']));
+        if ($request->server['request_uri'] === '/length') {
+            $response->end($request->rawContent());
+        } else {
+            $response->end(md5_file($request->files['file']['tmp_name']));
+        }
     });
 
     $http->start();

--- a/tests/swoole_http_server/body_pipeline_request_base.phpt
+++ b/tests/swoole_http_server/body_pipeline_request_base.phpt
@@ -1,0 +1,66 @@
+--TEST--
+swoole_http_server: body pipeline request in base mode
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Socket;
+
+const EOF = "EOF";
+
+function sendPipelineRequest(ProcessManager $pm, string $request, array $expected): void
+{
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::true($socket->setProtocol([
+        'open_eof_check' => true,
+        'package_eof' => EOF,
+    ]));
+    Assert::same($socket->sendAll($request), strlen($request));
+    foreach ($expected as $body) {
+        $response = $socket->recvPacket();
+        Assert::notEmpty($response);
+        Assert::same(explode("\r\n\r\n", $response, 2)[1], $body . EOF);
+    }
+}
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Swoole\Coroutine\run(function () use ($pm) {
+        $next = "GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        $request =
+            "POST /chunk HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Transfer-Encoding: chunked\r\n\r\n" .
+            "5\r\nhello\r\n0\r\n\r\n" . $next;
+        sendPipelineRequest($pm, $request, ['chunk:hello', 'next']);
+
+        $request =
+            "POST /length HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Length: 5\r\n\r\nhello" . $next;
+        sendPipelineRequest($pm, $request, ['length:hello', 'next']);
+    });
+    $pm->kill();
+    echo "SUCCESS\n";
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $uri = $request->server['request_uri'];
+        $body = $uri === '/next' ? 'next' : substr($uri, 1) . ':' . $request->rawContent();
+        $response->end($body . EOF);
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+SUCCESS

--- a/tests/swoole_http_server/chunked_package_max_length.phpt
+++ b/tests/swoole_http_server/chunked_package_max_length.phpt
@@ -8,7 +8,7 @@ require __DIR__ . '/../include/bootstrap.php';
 
 use Swoole\Coroutine\Socket;
 
-const PACKAGE_MAX_LENGTH = 100000;
+const PACKAGE_MAX_LENGTH = 100001;
 
 function make_chunked_request(string $path, string $body): string
 {
@@ -53,9 +53,12 @@ $pm->parentFunc = function () use ($pm) {
         Assert::contains($response, 'HTTP/1.1 200 OK');
         Assert::same(explode("\r\n\r\n", $response, 2)[1], strlen($exactBody) . ':' . md5($exactBody));
 
-        $request = make_chunked_request('/above', str_repeat('X', PACKAGE_MAX_LENGTH));
-        Assert::greaterThan(strlen($request), PACKAGE_MAX_LENGTH);
+        $overhead = strlen(make_chunked_request('/above', $exactBody)) - strlen($exactBody);
+        $aboveBody = str_repeat('X', PACKAGE_MAX_LENGTH + 1 - $overhead);
+        $request = make_chunked_request('/above', $aboveBody);
+        Assert::same(strlen($request), PACKAGE_MAX_LENGTH + 1);
 
+        // Preserve rejection while ensuring the declared chunk cannot consume allocator padding.
         $response = send_chunked_request($pm, $request);
         Assert::contains($response, 'HTTP/1.1 413 Request Entity Too Large');
     });

--- a/tests/swoole_http_server/chunked_package_max_length.phpt
+++ b/tests/swoole_http_server/chunked_package_max_length.phpt
@@ -1,0 +1,84 @@
+--TEST--
+swoole_http_server: chunked package max length
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Socket;
+
+const PACKAGE_MAX_LENGTH = 100000;
+
+function make_chunked_request(string $path, string $body): string
+{
+    return "POST {$path} HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Transfer-Encoding: chunked\r\n" .
+        "Connection: close\r\n\r\n" .
+        dechex(strlen($body)) . "\r\n{$body}\r\n0\r\n\r\n";
+}
+
+function send_chunked_request(ProcessManager $pm, string $request): string
+{
+    $socket = new Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::same($socket->sendAll($request), strlen($request));
+
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    Swoole\Coroutine\run(function () use ($pm) {
+        $body = str_repeat('0123456789abcdef', 5625);
+        $request = make_chunked_request('/below', $body);
+        Assert::lessThan(strlen($request), PACKAGE_MAX_LENGTH);
+
+        $response = send_chunked_request($pm, $request);
+        Assert::contains($response, 'HTTP/1.1 200 OK');
+        Assert::same(explode("\r\n\r\n", $response, 2)[1], strlen($body) . ':' . md5($body));
+
+        $exactBody = str_repeat('E', PACKAGE_MAX_LENGTH);
+        $overhead = strlen(make_chunked_request('/exact', $exactBody)) - strlen($exactBody);
+        $exactBody = str_repeat('E', PACKAGE_MAX_LENGTH - $overhead);
+        $request = make_chunked_request('/exact', $exactBody);
+        Assert::same(strlen($request), PACKAGE_MAX_LENGTH);
+
+        $response = send_chunked_request($pm, $request);
+        Assert::contains($response, 'HTTP/1.1 200 OK');
+        Assert::same(explode("\r\n\r\n", $response, 2)[1], strlen($exactBody) . ':' . md5($exactBody));
+
+        $request = make_chunked_request('/above', str_repeat('X', PACKAGE_MAX_LENGTH));
+        Assert::greaterThan(strlen($request), PACKAGE_MAX_LENGTH);
+
+        $response = send_chunked_request($pm, $request);
+        Assert::contains($response, 'HTTP/1.1 413 Request Entity Too Large');
+    });
+    echo "SUCCESS";
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'log_file' => '/dev/null',
+        'package_max_length' => PACKAGE_MAX_LENGTH,
+    ]);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $body = $request->rawContent();
+        $response->end(strlen($body) . ':' . md5($body));
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+SUCCESS

--- a/tests/swoole_http_server/chunked_pipeline_request.phpt
+++ b/tests/swoole_http_server/chunked_pipeline_request.phpt
@@ -9,9 +9,128 @@ require __DIR__ . '/../include/api/http_test_cases.php';
 
 const EOF = "EOF";
 
+function connectHttpSocket(ProcessManager $pm, bool $eof = true): Swoole\Coroutine\Socket
+{
+    $socket = new Swoole\Coroutine\Socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    Assert::true($socket->connect('127.0.0.1', $pm->getFreePort()));
+    if ($eof) {
+        Assert::true($socket->setProtocol([
+            'open_eof_check' => true,
+            'package_eof' => EOF,
+        ]));
+    }
+    return $socket;
+}
+
+function sendAndClose(ProcessManager $pm, string $request): string
+{
+    $socket = connectHttpSocket($pm, false);
+    Assert::same($socket->sendAll($request), strlen($request));
+
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
+function sendMalformedChunkedRequest(ProcessManager $pm, string $body): string
+{
+    $request =
+        "POST / HTTP/1.1\r\n" .
+        "Host: localhost\r\n" .
+        "Transfer-Encoding: chunked\r\n" .
+        "Connection: close\r\n\r\n" . $body;
+    $socket = connectHttpSocket($pm, false);
+    Assert::same($socket->sendAll($request), strlen($request));
+    Assert::true($socket->shutdown(STREAM_SHUT_WR));
+
+    $response = '';
+    while (($data = $socket->recv()) !== '' && $data !== false) {
+        $response .= $data;
+    }
+    return $response;
+}
+
 $pm = new ProcessManager;
 $pm->initRandomData(1);
 $pm->parentFunc = function () use ($pm) {
+    Swoole\Coroutine\run(function () use ($pm) {
+        $socket = connectHttpSocket($pm);
+        $request =
+            "POST /chunk HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Transfer-Encoding: chunked\r\n\r\n" .
+            "5;foo=token;bar=\"a\\\"b\"\r\nhello\r\n" .
+            "0\r\nX-Trailer: yes\r\n\r\n" .
+            "GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        Assert::same(getHttpBody($socket->recvPacket()), 'chunk:hello');
+        Assert::same(getHttpBody($socket->recvPacket()), 'next');
+
+        $socket = connectHttpSocket($pm);
+        $request =
+            "POST /chunk HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Transfer-Encoding: chunked\r\n\r\n" .
+            "5\r\nhello\r\n0\r\nX-Split";
+        Assert::same($socket->sendAll($request), strlen($request));
+        usleep(1000);
+        $request = "-Trailer: yes\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        Assert::same(getHttpBody($socket->recvPacket()), 'chunk:hello');
+
+        $socket = connectHttpSocket($pm);
+        $request =
+            "POST /chunk HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Transfer-Encoding: chunked\r\n\r\n" .
+            "5;foo=\"a\\";
+        Assert::same($socket->sendAll($request), strlen($request));
+        usleep(1000);
+        $request = "b\"\r\nhello\r";
+        Assert::same($socket->sendAll($request), strlen($request));
+        usleep(1000);
+        $request = "\n0\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        Assert::same(getHttpBody($socket->recvPacket()), 'chunk:hello');
+
+        $socket = connectHttpSocket($pm);
+        $request =
+            "POST /length HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Length: 5\r\n\r\nhello" .
+            "GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        Assert::same($socket->sendAll($request), strlen($request));
+        Assert::same(getHttpBody($socket->recvPacket()), 'length:hello');
+        Assert::same(getHttpBody($socket->recvPacket()), 'next');
+
+        $request =
+            "POST / HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Length: 0\r\n" .
+            "Transfer-Encoding: chunked\r\n" .
+            "Connection: close\r\n\r\n0\r\n\r\n";
+        $response = sendAndClose($pm, $request);
+        Assert::same(substr_count($response, 'HTTP/1.1 400 Bad Request'), 1);
+
+        $request =
+            "POST / HTTP/1.1\r\n" .
+            "Host: localhost\r\n" .
+            "Content-Length: 18446744073709551615\r\n" .
+            "Connection: close\r\n\r\n";
+        $response = sendAndClose($pm, $request);
+        Assert::contains($response, 'HTTP/1.1 413 Request Entity Too Large');
+
+        // Preserve strict framing for malformed data terminators and chunk-size whitespace.
+        foreach (["5\r\nhelloXX\r\n0\r\n\r\n", "5 \r\nhello\r\n0\r\n\r\n"] as $body) {
+            $response = sendMalformedChunkedRequest($pm, $body);
+            Assert::same(substr_count($response, 'HTTP/1.1 400 Bad Request'), 1);
+        }
+
+        $response = sendMalformedChunkedRequest($pm, "5\nhello\n0\n\n");
+        Assert::same(substr_count($response, 'HTTP/1.1 400 Bad Request'), 1);
+    });
     chunked_request($pm);
 };
 $pm->childFunc = function () use ($pm) {
@@ -25,8 +144,21 @@ $pm->childFunc = function () use ($pm) {
     $http->on('workerStart', function () use ($pm) {
         $pm->wakeup();
     });
-    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) use ($pm) {
-        $response->end($request->rawContent() . EOF);
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        switch ($request->server['request_uri']) {
+        case '/chunk':
+            $body = 'chunk:' . $request->rawContent();
+            break;
+        case '/length':
+            $body = 'length:' . $request->rawContent();
+            break;
+        case '/next':
+            $body = 'next';
+            break;
+        default:
+            $body = $request->rawContent();
+        }
+        $response->end($body . EOF);
     });
     $http->start();
 };


### PR DESCRIPTION
The ordinary HTTP server only recognized the end of a chunked request when the receive buffer ended with `0\r\n\r\n`. Requests with trailers or another pipelined request could therefore remain incomplete. Valid chunk extensions were rejected, bytes after body requests were discarded, and large declared lengths could overflow the size calculation. The server also omitted `100 Continue` before chunked and streaming multipart bodies and repeated it as fixed-length body fragments arrived.\n\nThis change parses chunk framing incrementally through extensions and trailers, preserves bytes for the next request after both chunked and `Content-Length` bodies, and checks request sizes without overflowing or growing past `package_max_length`. It sends `100 Continue` while only the request headers are buffered, before waiting for the body.\n\nThe tests cover split framing, extensions, trailers, body request pipelines, malformed chunks, impossible declared lengths, non-aligned package limits, and `100 Continue` across the supported body forms.