### PR TITLE
Validate SOCKS5 domain target lengths

### DIFF
--- a/core-tests/src/protocol/base.cpp
+++ b/core-tests/src/protocol/base.cpp
@@ -251,6 +251,27 @@ TEST(protocol, socks5_strerror) {
     }
 }
 
+TEST(protocol, socks5_dns_tunnel_target_host_max_length) {
+    auto proxy = Socks5Proxy::create(SW_SOCK_TCP, "127.0.0.1", 1080, "", "");
+    ASSERT_NE(proxy, nullptr);
+    proxy->dns_tunnel = 1;
+    proxy->target_host = std::string(UINT8_MAX, 'a');
+    proxy->target_port = 80;
+
+    ASSERT_EQ(proxy->pack_connect_request(), 262);
+    ASSERT_EQ(static_cast<uint8_t>(proxy->buf[3]), 0x03);
+    ASSERT_EQ(static_cast<uint8_t>(proxy->buf[4]), UINT8_MAX);
+    ASSERT_MEMEQ(proxy->buf + 5, proxy->target_host.data(), proxy->target_host.length());
+    uint16_t port;
+    memcpy(&port, proxy->buf + 5 + proxy->target_host.length(), sizeof(port));
+    ASSERT_EQ(ntohs(port), 80);
+
+    proxy->target_host = std::string(UINT8_MAX + 1, 'a');
+    ASSERT_EQ(proxy->pack_connect_request(), SW_ERR);
+    ASSERT_ERREQ(SW_ERROR_SOCKS5_HANDSHAKE_FAILED);
+    delete proxy;
+}
+
 TEST(protocol, swap_byte_order) {
     {
         EXPECT_EQ(swoole_swap_endian16(0x1234), 0x3412);

--- a/src/protocol/socks5.cc
+++ b/src/protocol/socks5.cc
@@ -174,10 +174,11 @@ ssize_t Socks5Proxy::pack_connect_request() {
     p += 3;
 
     if (dns_tunnel) {
-        if (host.length() > 480) {
-            swoole_error_log(
-                SW_LOG_NOTICE, SW_ERROR_SOCKS5_AUTH_FAILED, "SOCKS5 host is too long, max length is 480 bytes");
-            return -1;
+        if (target_host.length() > UINT8_MAX) {
+            swoole_error_log(SW_LOG_NOTICE,
+                             SW_ERROR_SOCKS5_HANDSHAKE_FAILED,
+                             "SOCKS5 target host is too long, max length is 255 bytes");
+            return SW_ERR;
         }
         p[0] = 0x03;
         p[1] = target_host.length();


### PR DESCRIPTION
SOCKS5 DNS tunnel requests store the destination host length in one byte. The current check uses the proxy host on the 6.1 branch and permits destination hosts that cannot be represented, producing a malformed connect request.

This change validates the destination host and rejects lengths above 255 before encoding the request. It also reports the failure as a SOCKS5 handshake error.

The regression verifies the complete 255-byte boundary encoding and rejection at 256 bytes.