### PR TITLE
Fix Redis server receive buffer handling

### DIFF
--- a/core-tests/src/protocol/redis.cpp
+++ b/core-tests/src/protocol/redis.cpp
@@ -136,3 +136,31 @@ TEST(redis, parse) {
     auto rs = redis::parse(SW_STRL(":3\r\n"));
     ASSERT_EQ(rs[0], "3");
 }
+
+TEST(redis, recv_packet_with_partially_filled_buffer) {
+    int pairs[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, pairs), 0);
+    ASSERT_EQ(send(pairs[0], "*", 1, 0), 1);
+    close(pairs[0]);
+
+    network::Socket socket{};
+    socket.fd = pairs[1];
+    socket.socket_type = SW_SOCK_UNIX_STREAM;
+
+    Connection conn{};
+    conn.fd = pairs[1];
+    conn.socket = &socket;
+
+    Protocol protocol{};
+    protocol.package_max_length = SW_BUFFER_SIZE_BIG * 2;
+
+    String buffer(SW_BUFFER_SIZE_BIG);
+    size_t buffer_size = buffer.size;
+
+    ASSERT_EQ(redis::recv_packet(&protocol, &conn, &buffer), SW_ERR);
+    ASSERT_EQ(buffer.length, 1);
+    ASSERT_EQ(buffer.size, buffer_size);
+
+    sw_free(conn.object);
+    close(pairs[1]);
+}

--- a/src/protocol/redis.cc
+++ b/src/protocol/redis.cc
@@ -91,17 +91,25 @@ _recv_data:
     } else {
         buffer->length += n;
 
-        if (strncmp(buffer->str + buffer->length - SW_CRLF_LEN, SW_CRLF, SW_CRLF_LEN) != 0) {
-            if (buffer->size < protocol->package_max_length) {
-                uint32_t extend_size = swoole_size_align(buffer->size * 2, swoole_pagesize());
-                if (extend_size > protocol->package_max_length) {
-                    extend_size = protocol->package_max_length;
+        if (buffer->length < SW_CRLF_LEN ||
+            strncmp(buffer->str + buffer->length - SW_CRLF_LEN, SW_CRLF, SW_CRLF_LEN) != 0) {
+            if (buffer->length == buffer->size) {
+                if (buffer->size < protocol->package_max_length) {
+                    size_t extend_size;
+                    if (buffer->size >= protocol->package_max_length / 2) {
+                        extend_size = protocol->package_max_length;
+                    } else {
+                        extend_size = swoole_size_align(buffer->size * 2, swoole_pagesize());
+                        if (extend_size > protocol->package_max_length) {
+                            extend_size = protocol->package_max_length;
+                        }
+                    }
+                    buffer->extend(extend_size);
+                } else {
+                _package_too_big:
+                    swoole_warning("Package is too big. package_length=%zu", buffer->length);
+                    return SW_ERR;
                 }
-                buffer->extend(extend_size);
-            } else if (buffer->length == buffer->size) {
-            _package_too_big:
-                swoole_warning("Package is too big. package_length=%ld", buffer->length);
-                return SW_ERR;
             }
             goto _recv_data;
         }

--- a/tests/swoole_redis_server/fragmented_request.phpt
+++ b/tests/swoole_redis_server/fragmented_request.phpt
@@ -1,0 +1,40 @@
+--TEST--
+swoole_redis_server: fragmented request
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Redis\Server;
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP, SWOOLE_SOCK_SYNC);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::same($client->send('*'), 1);
+    usleep(100000);
+    Assert::same($client->send("2\r\n$3\r\nGET\r\n$3\r\nkey\r\n"), 21);
+    Assert::same($client->recv(), "$5\r\nvalue\r\n");
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->setHandler('GET', function ($fd) use ($server) {
+        $server->send($fd, Server::format(Server::STRING, 'value'));
+    });
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+echo "SUCCESS\n";
+?>
+--EXPECT--
+SUCCESS


### PR DESCRIPTION
Redis server request parsing checks for CRLF before ensuring that at least two bytes were received. A one-byte read can access memory before the request buffer. The same path also grows the buffer after every incomplete read, even while free space remains, and narrows large growth values.

This change handles short input before the CRLF comparison, grows only when the buffer is full, and keeps growth within the configured package limit.

The core regression fails on unchanged 6.1 when a one-byte request grows a mostly empty buffer. Under ASAN, the same input reports the invalid read. A PHPT covers a fragmented request through `Swoole\Redis\Server`, and the existing large-request test confirms that the buffer still grows when required.