### PR TITLE
Reject compressed WebSocket control frames

### DIFF
--- a/core-tests/src/server/http_server.cpp
+++ b/core-tests/src/server/http_server.cpp
@@ -741,6 +741,26 @@ TEST(http_server, websocket_encode) {
     unlink(log_file);
 }
 
+TEST(http_server, websocket_compressed_control_frame) {
+    auto buffer = sw_tg_buffer();
+    websocket::Frame frame;
+    const uint8_t control_opcodes[] = {
+        websocket::OPCODE_CLOSE,
+        websocket::OPCODE_PING,
+        websocket::OPCODE_PONG,
+    };
+
+    for (auto opcode : control_opcodes) {
+        buffer->clear();
+        ASSERT_TRUE(websocket::encode(buffer, "", 0, opcode, websocket::FLAG_FIN | websocket::FLAG_RSV1));
+        ASSERT_FALSE(websocket::decode(&frame, buffer->str, buffer->length));
+    }
+
+    buffer->clear();
+    ASSERT_TRUE(websocket::encode(buffer, "", 0, websocket::OPCODE_TEXT, websocket::FLAG_FIN | websocket::FLAG_RSV1));
+    ASSERT_TRUE(websocket::decode(&frame, buffer->str, buffer->length));
+}
+
 TEST(http_server, node_websocket_client_1) {
     unlink(TEST_LOG_FILE);
 

--- a/include/swoole_websocket.h
+++ b/include/swoole_websocket.h
@@ -132,6 +132,10 @@ enum CloseReason {
     CLOSE_TLS = 1015,
 };
 
+static inline bool is_control_frame(uchar opcode) {
+    return opcode == OPCODE_CLOSE || opcode == OPCODE_PING || opcode == OPCODE_PONG;
+}
+
 static inline uint16_t get_ext_flags(uchar opcode, uchar flags) {
     uint16_t ext_flags = opcode;
     ext_flags = ext_flags << 8;

--- a/src/protocol/websocket.cc
+++ b/src/protocol/websocket.cc
@@ -179,6 +179,11 @@ bool decode(Frame *frame, char *data, size_t length) {
     frame->payload_length = total_length - pl.header_len;
     frame->header_length = pl.header_len;
 
+    if (sw_unlikely(frame->header.RSV1 && is_control_frame(frame->header.OPCODE))) {
+        swoole_warning("invalid compressed websocket control frame received: opcode=%u", frame->header.OPCODE);
+        return false;
+    }
+
     swoole_trace_log(SW_TRACE_WEBSOCKET,
                      "decode frame, payload_length=%ld, mask=%d, opcode=%d",
                      frame->payload_length,


### PR DESCRIPTION
RFC 7692 does not allow per-message compression on WebSocket control frames. Swoole accepted CLOSE, PING, and PONG frames with RSV1 set, allowing invalid peer frames into every receive path.

Reject these frames in the shared decoder before payload unmasking, so failure does not modify the caller's buffer. Compressed data frames continue to work.

The regression covers each control opcode and confirms an RSV1 text frame remains accepted.