### PR TITLE
Fix reactor initialization and hook tests

### DIFF
--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -550,6 +550,8 @@ TEST(reactor, hook) {
         1);
 
     ON_SCOPE_EXIT {
+        delete static_cast<std::list<Callback> *>(SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_CREATE]);
+        delete static_cast<std::list<Callback> *>(SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY]);
         SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_CREATE] = nullptr;
         SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY] = nullptr;
     };

--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -31,9 +31,8 @@
 using namespace std;
 using namespace swoole;
 
-#ifdef HAVE_EPOLL
+static int reactor_create_count;
 static int reactor_destroy_count;
-#endif
 
 TEST(reactor, create) {
     swoole_event_init(0);
@@ -530,14 +529,15 @@ TEST(reactor, priority_idle_task) {
 }
 
 TEST(reactor, hook) {
-    Reactor *reactor = new Reactor(1024, Reactor::TYPE_POLL);
-    reactor->wait_exit = true;
+    reactor_create_count = 0;
+    reactor_destroy_count = 0;
 
     swoole_add_hook(
         SW_GLOBAL_HOOK_ON_REACTOR_CREATE,
         [](void *data) -> void {
             Reactor *reactor = (Reactor *) data;
             ASSERT_EQ(Reactor::TYPE_POLL, reactor->type_);
+            reactor_create_count++;
         },
         1);
 
@@ -546,6 +546,7 @@ TEST(reactor, hook) {
         [](void *data) -> void {
             Reactor *reactor = (Reactor *) data;
             ASSERT_EQ(Reactor::TYPE_POLL, reactor->type_);
+            reactor_destroy_count++;
         },
         1);
 
@@ -556,8 +557,13 @@ TEST(reactor, hook) {
         SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY] = nullptr;
     };
 
+    Reactor *reactor = new Reactor(1024, Reactor::TYPE_POLL);
+    reactor->wait_exit = true;
     reactor_test_func(reactor);
     delete reactor;
+
+    ASSERT_EQ(reactor_create_count, 1);
+    ASSERT_EQ(reactor_destroy_count, 1);
 }
 
 TEST(reactor, set_fd) {

--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -24,8 +24,16 @@
 #include "swoole_util.h"
 #include "swoole_api.h"
 
+#ifdef HAVE_EPOLL
+#include <sys/resource.h>
+#endif
+
 using namespace std;
 using namespace swoole;
+
+#ifdef HAVE_EPOLL
+static int reactor_destroy_count;
+#endif
 
 TEST(reactor, create) {
     swoole_event_init(0);
@@ -62,6 +70,46 @@ TEST(reactor, create) {
 
     swoole_event_free();
 }
+
+#ifdef HAVE_EPOLL
+TEST(reactor, create_failure) {
+    ASSERT_EQ(SwooleTG.reactor, nullptr);
+
+    void *previous_hook = SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY];
+    SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY] = nullptr;
+    ON_SCOPE_EXIT {
+        delete static_cast<std::list<Callback> *>(SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY]);
+        SwooleG.hooks[SW_GLOBAL_HOOK_ON_REACTOR_DESTROY] = previous_hook;
+    };
+
+    reactor_destroy_count = 0;
+    swoole_add_hook(SW_GLOBAL_HOOK_ON_REACTOR_DESTROY, [](void *) { reactor_destroy_count++; }, 1);
+
+    rlimit original_limit;
+    ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &original_limit), 0);
+    rlimit limit = original_limit;
+    limit.rlim_cur = 0;
+    ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &limit), 0);
+    ON_SCOPE_EXIT {
+        setrlimit(RLIMIT_NOFILE, &original_limit);
+    };
+
+    swoole_clear_last_error();
+    int retval = swoole_event_init(0);
+    int error = swoole_get_last_error();
+    int restore_result = setrlimit(RLIMIT_NOFILE, &original_limit);
+
+    ASSERT_EQ(restore_result, 0);
+    ASSERT_EQ(retval, SW_ERR);
+    ASSERT_EQ(error, EMFILE);
+    ASSERT_EQ(SwooleTG.reactor, nullptr);
+    ASSERT_EQ(reactor_destroy_count, 1);
+
+    ASSERT_EQ(swoole_event_init(0), SW_OK);
+    ASSERT_EQ(swoole_event_free(), SW_OK);
+    ASSERT_EQ(reactor_destroy_count, 2);
+}
+#endif
 
 TEST(reactor, set_handler) {
     Reactor reactor;

--- a/src/reactor/kqueue.cc
+++ b/src/reactor/kqueue.cc
@@ -35,7 +35,7 @@ using network::Socket;
 class ReactorKqueue : public ReactorImpl {
     int epfd_;
     int event_max_;
-    struct kevent *events_;
+    struct kevent *events_ = nullptr;
 
     bool fetch_event(Event *event, void *udata) {
         event->socket = (Socket *) udata;

--- a/src/wrapper/event.cc
+++ b/src/wrapper/event.cc
@@ -27,6 +27,7 @@ using swoole::network::Socket;
 int swoole_event_init(int flags) {
     auto *reactor = new Reactor(SW_REACTOR_MAXEVENTS);
     if (!reactor->ready()) {
+        delete reactor;
         return SW_ERR;
     }
 


### PR DESCRIPTION
When an event backend cannot initialize, `swoole_event_init()` returns an error without freeing the new reactor. This leaves both the reactor and its backend allocation unreachable.

Delete the failed reactor before returning. Initialize the kqueue event pointer to null because this cleanup makes its failure destructor reachable for the first time.

The reactor hook test also cleared both global hook pointers so its poll-only assertions could not affect later tests. That made its two hook lists unreachable before `swoole_clean()` could free them. Delete the lists before clearing the pointers. The same fixture registered its create hook after constructing the reactor, so that callback never ran; register both hooks first and assert each runs once.

The regression forces `epoll_create()` to fail with `EMFILE`, verifies the reactor is destroyed, and confirms normal initialization still works afterward. The full reactor test group reports 144 leaked bytes under ASAN before the hook cleanup and no leak afterward.
