### PR TITLE
Restrict Server task IPC access

### DIFF
--- a/core-tests/src/os/msg_queue.cpp
+++ b/core-tests/src/os/msg_queue.cpp
@@ -19,6 +19,13 @@
 
 #include "test_core.h"
 #include "swoole_msg_queue.h"
+#include "swoole_util.h"
+
+#ifdef HAVE_MSGQUEUE
+#include <pwd.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#endif
 
 using swoole::MsgQueue;
 using swoole::QueueNode;
@@ -70,3 +77,144 @@ TEST(msg_queue, rbac) {
     ASSERT_FALSE(q.set_capacity(8192));
     ASSERT_ERREQ(EINVAL);
 }
+
+#ifdef HAVE_MSGQUEUE
+static key_t make_queue_key(int line) {
+    return 0x69000000 + ((getpid() + line) & 0xfffff);
+}
+
+TEST(msg_queue, set_access_preserves_trusted_backlog) {
+    MsgQueue q(make_queue_key(__LINE__), true, 0644);
+    ASSERT_TRUE(q.ready());
+    ON_SCOPE_EXIT {
+        q.destroy();
+    };
+
+    QueueNode in{};
+    in.mtype = 1;
+    strcpy(in.mdata, "pending");
+    ASSERT_TRUE(q.push(&in, strlen(in.mdata)));
+    ASSERT_TRUE(q.set_access(geteuid(), getegid(), 0600));
+
+    msqid_ds status;
+    ASSERT_EQ(msgctl(q.get_id(), IPC_STAT, &status), 0);
+    ASSERT_EQ(status.msg_perm.uid, geteuid());
+    ASSERT_EQ(status.msg_perm.gid, getegid());
+    ASSERT_EQ(status.msg_perm.mode & 0777, 0600);
+    ASSERT_EQ(status.msg_qnum, 1);
+
+    QueueNode out{};
+    out.mtype = 1;
+    ASSERT_GT(q.pop(&out, sizeof(out.mdata)), 0);
+    ASSERT_STREQ(out.mdata, in.mdata);
+}
+
+TEST(msg_queue, set_access_replaces_writable_backlog) {
+    MsgQueue q(make_queue_key(__LINE__), true, 0666);
+    ASSERT_TRUE(q.ready());
+    ON_SCOPE_EXIT {
+        q.destroy();
+    };
+
+    QueueNode in{};
+    in.mtype = 1;
+    strcpy(in.mdata, "pending");
+    ASSERT_TRUE(q.push(&in, strlen(in.mdata)));
+    ASSERT_TRUE(q.set_access(geteuid(), getegid(), 0600));
+
+    msqid_ds status;
+    ASSERT_EQ(msgctl(q.get_id(), IPC_STAT, &status), 0);
+    ASSERT_EQ(status.msg_perm.mode & 0777, 0600);
+    ASSERT_EQ(status.msg_qnum, 0);
+
+    q.set_blocking(false);
+    QueueNode out{};
+    out.mtype = 1;
+    ASSERT_EQ(q.pop(&out, sizeof(out.mdata)), -1);
+    ASSERT_ERREQ(ENOMSG);
+}
+
+TEST(msg_queue, set_access_changes_private_queue_owner) {
+    if (geteuid() != 0) {
+        GTEST_SKIP();
+    }
+    auto *passwd = getpwnam("nobody");
+    if (passwd == nullptr) {
+        GTEST_SKIP();
+    }
+
+    MsgQueue q(IPC_PRIVATE, true, 0600);
+    ASSERT_TRUE(q.ready());
+    ON_SCOPE_EXIT {
+        q.destroy();
+    };
+    ASSERT_TRUE(q.set_access(passwd->pw_uid, passwd->pw_gid, 0600));
+
+    msqid_ds status;
+    ASSERT_EQ(msgctl(q.get_id(), IPC_STAT, &status), 0);
+    ASSERT_EQ(status.msg_perm.uid, passwd->pw_uid);
+    ASSERT_EQ(status.msg_perm.gid, passwd->pw_gid);
+    ASSERT_EQ(status.msg_perm.mode & 0777, 0600);
+}
+
+TEST(msg_queue, set_access_rejects_forged_owner) {
+    key_t key = make_queue_key(__LINE__);
+    uid_t target_uid = geteuid() == 0 ? 0 : geteuid() + 1;
+    ON_SCOPE_EXIT {
+        int msg_id = msgget(key, 0);
+        if (msg_id >= 0) {
+            msgctl(msg_id, IPC_RMID, nullptr);
+        }
+    };
+
+    if (geteuid() == 0) {
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            if (setgid(65534) < 0 || setuid(65534) < 0) {
+                _exit(1);
+            }
+            MsgQueue q(key, true, 0666);
+            QueueNode in{};
+            in.mtype = 1;
+            strcpy(in.mdata, "pending");
+            if (!q.ready() || !q.push(&in, strlen(in.mdata))) {
+                _exit(2);
+            }
+            msqid_ds status;
+            if (msgctl(q.get_id(), IPC_STAT, &status) < 0) {
+                _exit(3);
+            }
+            status.msg_perm.uid = target_uid;
+            status.msg_perm.mode = 0600;
+            _exit(msgctl(q.get_id(), IPC_SET, &status) < 0 ? 4 : 0);
+        }
+        int status;
+        ASSERT_EQ(waitpid(pid, &status, 0), pid);
+        ASSERT_TRUE(WIFEXITED(status));
+        ASSERT_EQ(WEXITSTATUS(status), 0);
+    } else {
+        MsgQueue attacker(key, true, 0666);
+        ASSERT_TRUE(attacker.ready());
+        QueueNode in{};
+        in.mtype = 1;
+        strcpy(in.mdata, "pending");
+        ASSERT_TRUE(attacker.push(&in, strlen(in.mdata)));
+        msqid_ds status;
+        ASSERT_EQ(msgctl(attacker.get_id(), IPC_STAT, &status), 0);
+        status.msg_perm.uid = target_uid;
+        status.msg_perm.mode = 0600;
+        ASSERT_EQ(msgctl(attacker.get_id(), IPC_SET, &status), 0);
+    }
+
+    MsgQueue q(key, true, 0600);
+    ASSERT_TRUE(q.ready());
+    ASSERT_TRUE(q.set_access(target_uid, getegid(), 0600));
+
+    msqid_ds status;
+    ASSERT_EQ(msgctl(q.get_id(), IPC_STAT, &status), 0);
+    ASSERT_EQ(status.msg_perm.uid, target_uid);
+    ASSERT_EQ(status.msg_perm.mode & 0777, 0600);
+    ASSERT_EQ(status.msg_qnum, 0);
+}
+#endif

--- a/core-tests/src/os/process_pool.cpp
+++ b/core-tests/src/os/process_pool.cpp
@@ -1,5 +1,6 @@
 #include "test_core.h"
 #include "swoole_process_pool.h"
+#include "swoole_util.h"
 
 #include <csignal>
 
@@ -85,6 +86,23 @@ TEST(process_pool, tcp) {
     ASSERT_EQ(pool.listen(TEST_HOST, svr_port, 128), SW_OK);
 
     test_func_task_protocol(pool);
+}
+
+TEST(process_pool, tcp_destroy_does_not_unlink_host_name) {
+    int fd = open(TEST_HOST, O_CREAT | O_EXCL | O_WRONLY, 0600);
+    ASSERT_GE(fd, 0);
+    close(fd);
+    ON_SCOPE_EXIT {
+        unlink(TEST_HOST);
+    };
+
+    ProcessPool pool{};
+    int svr_port = TEST_PORT + __LINE__;
+    ASSERT_EQ(pool.create(1, 0, SW_IPC_SOCKET), SW_OK);
+    ASSERT_EQ(pool.listen(TEST_HOST, svr_port, 128), SW_OK);
+    pool.destroy();
+
+    ASSERT_EQ(access(TEST_HOST, F_OK), 0);
 }
 
 TEST(process_pool, unix_sock) {

--- a/core-tests/src/server/server.cpp
+++ b/core-tests/src/server/server.cpp
@@ -412,6 +412,19 @@ TEST(server, base) {
     test_base();
 }
 
+TEST(server, task_finish_rejects_task_worker_source) {
+    Server serv(Server::MODE_BASE);
+    serv.worker_num = 1;
+    serv.task_worker_num = 1;
+    ASSERT_NE(serv.add_port(SW_SOCK_TCP, TEST_HOST, 0), nullptr);
+    ASSERT_EQ(serv.create(), SW_OK);
+
+    EventData task{};
+    task.info.type = SW_SERVER_EVENT_TASK;
+    task.info.reactor_id = serv.worker_num;
+    EXPECT_FALSE(serv.finish("result", sizeof("result") - 1, 0, &task));
+}
+
 static void test_process(bool single_thread = false) {
     Server serv(Server::MODE_PROCESS);
     serv.worker_num = 1;

--- a/include/swoole_msg_queue.h
+++ b/include/swoole_msg_queue.h
@@ -54,6 +54,7 @@ class MsgQueue {
     }
 
     void set_blocking(bool blocking);
+    bool set_access(uid_t uid, gid_t gid, mode_t mode);
     bool set_capacity(size_t queue_bytes) const;
     bool push(const QueueNode *in, size_t mdata_length) const;
     ssize_t pop(QueueNode *out, size_t mdata_size) const;

--- a/include/swoole_process_pool.h
+++ b/include/swoole_process_pool.h
@@ -417,7 +417,7 @@ struct ProcessPool {
     bool del_worker(const Worker *worker) const;
     Worker *get_worker_by_pid(pid_t pid) const;
     void destroy();
-    int create(uint32_t worker_num, key_t msgqueue_key = 0, swIPCMode ipc_mode = SW_IPC_NONE);
+    int create(uint32_t worker_num, key_t msgqueue_key = 0, swIPCMode ipc_mode = SW_IPC_NONE, int msgqueue_perms = 0);
     int create_message_box(size_t memory_size);
     int create_message_bus();
     int push_message(uint8_t _type, const void *data, size_t length) const;

--- a/src/os/msg_queue.cc
+++ b/src/os/msg_queue.cc
@@ -48,7 +48,7 @@ MsgQueue::MsgQueue(key_t msg_key, bool blocking, int perms) {
     blocking_ = blocking;
     msg_id_ = msgget(msg_key, IPC_CREAT | perms);
     if (msg_id_ < 0) {
-        swoole_sys_warning("msgget() failed");
+        swoole_sys_warning("msgget(key=%ld, uid=%d) failed", (long) msg_key, (int) geteuid());
     } else {
         set_blocking(blocking);
     }
@@ -59,6 +59,63 @@ MsgQueue::~MsgQueue() {
     if (msg_key_ == IPC_PRIVATE && msg_id_ >= 0) {
         destroy();
     }
+}
+
+bool MsgQueue::set_access(uid_t uid, gid_t gid, mode_t mode) {
+    msqid_ds status;
+    if (msgctl(msg_id_, IPC_STAT, &status) < 0) {
+        swoole_sys_warning("msgctl(%d, IPC_STAT) failed", msg_id_);
+        return false;
+    }
+
+    bool root = geteuid() == 0;
+    bool trusted_uid = status.msg_perm.uid == uid || (root && status.msg_perm.uid == 0);
+    // The creator keeps owner-class access even after ownership changes.
+    bool trusted_cuid = status.msg_perm.cuid == uid || (root && status.msg_perm.cuid == 0);
+    bool replace = !trusted_uid || !trusted_cuid || (status.msg_perm.mode & 0022);
+    size_t pending = 0;
+
+    if (replace) {
+        if (msg_key_ == IPC_PRIVATE) {
+            // Server initialization cannot reach this, but replacing a private queue would silently orphan it.
+            swoole_warning("cannot replace a private message queue");
+            return false;
+        }
+
+        pending = status.msg_qnum;
+        if (msgctl(msg_id_, IPC_RMID, nullptr) < 0) {
+            swoole_sys_warning("msgctl(%d, IPC_RMID) failed", msg_id_);
+            return false;
+        }
+        msg_id_ = msgget(msg_key_, IPC_CREAT | IPC_EXCL | (mode & 0777));
+        if (msg_id_ < 0) {
+            swoole_sys_warning("msgget(key=%ld) failed", (long) msg_key_);
+            return false;
+        }
+        if (msgctl(msg_id_, IPC_STAT, &status) < 0) {
+            swoole_sys_warning("msgctl(%d, IPC_STAT) failed", msg_id_);
+            destroy();
+            return false;
+        }
+    }
+
+    status.msg_perm.uid = uid;
+    status.msg_perm.gid = gid;
+    status.msg_perm.mode = (status.msg_perm.mode & ~0777) | (mode & 0777);
+    if (msgctl(msg_id_, IPC_SET, &status) < 0) {
+        swoole_sys_warning("msgctl(%d, IPC_SET) failed", msg_id_);
+        if (replace) {
+            destroy();
+        }
+        return false;
+    }
+    if (replace) {
+        swoole_warning("message queue[key=%ld] was replaced; discarded %zu pending message%s",
+                       (long) msg_key_,
+                       pending,
+                       pending == 1 ? "" : "s");
+    }
+    return true;
 }
 
 ssize_t MsgQueue::pop(QueueNode *data, size_t mdata_size) const {
@@ -121,6 +178,10 @@ MsgQueue::MsgQueue(key_t msg_key, bool blocking, int perms) {
 }
 
 void MsgQueue::set_blocking(bool blocking) {}
+
+bool MsgQueue::set_access(uid_t uid, gid_t gid, mode_t mode) {
+    return false;
+}
 
 bool MsgQueue::set_capacity(size_t queue_bytes) const {
     return false;

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -50,7 +50,7 @@ static inline void worker_end_callback() {
 /**
  * Process manager
  */
-int ProcessPool::create(uint32_t _worker_num, key_t _msgqueue_key, swIPCMode _ipc_mode) {
+int ProcessPool::create(uint32_t _worker_num, key_t _msgqueue_key, swIPCMode _ipc_mode, int _msgqueue_perms) {
 #ifndef HAVE_MSGQUEUE
     if (_ipc_mode == SW_IPC_MSGQUEUE) {
         swoole_warning("current platform does not support `sysvmsg`");
@@ -74,7 +74,7 @@ int ProcessPool::create(uint32_t _worker_num, key_t _msgqueue_key, swIPCMode _ip
     if (_ipc_mode == SW_IPC_MSGQUEUE) {
         use_msgqueue = 1;
         msgqueue_key = _msgqueue_key;
-        queue = new MsgQueue(msgqueue_key);
+        queue = new MsgQueue(msgqueue_key, true, _msgqueue_perms);
         if (!queue->ready()) {
             delete queue;
             queue = nullptr;
@@ -1020,10 +1020,10 @@ void ProcessPool::destroy() {
     }
 
     if (stream_info_) {
-        if (stream_info_->socket) {
+        if (stream_info_->socket && stream_info_->socket->is_local()) {
             unlink(stream_info_->socket_file);
-            sw_free(stream_info_->socket_file);
         }
+        sw_free(stream_info_->socket_file);
         if (stream_info_->socket) {
             stream_info_->socket->free();
             stream_info_->socket = nullptr;

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -24,6 +24,8 @@
 #include "swoole_api.h"
 
 #include <cassert>
+#include <grp.h>
+#include <pwd.h>
 
 using swoole::network::Address;
 using swoole::network::SendfileTask;
@@ -535,8 +537,33 @@ bool Server::create_task_workers() {
 
     ProcessPool *pool = get_task_worker_pool();
     *pool = {};
-    if (pool->create(task_worker_num, key, ipc_mode) < 0) {
+
+    uid_t worker_uid = geteuid();
+    gid_t worker_gid = getegid();
+    if (swoole_is_root_user()) {
+        if (!user_.empty()) {
+            auto *passwd = getpwnam(user_.c_str());
+            if (passwd) {
+                worker_uid = passwd->pw_uid;
+            }
+        }
+        if (!group_.empty()) {
+            auto *group = getgrnam(group_.c_str());
+            if (group) {
+                worker_gid = group->gr_gid;
+            }
+        }
+    }
+
+    int msgqueue_perms = ipc_mode == SW_IPC_MSGQUEUE ? 0600 : 0;
+    if (pool->create(task_worker_num, key, ipc_mode, msgqueue_perms) < 0) {
         swoole_warning("[Master] create task_workers failed");
+        return false;
+    }
+    if (ipc_mode == SW_IPC_MSGQUEUE && !pool->queue->set_access(worker_uid, worker_gid, 0600)) {
+        swoole_warning("[Master] configure task message queue[key=%ld, uid=%d] failed", (long) key, (int) geteuid());
+        pool->destroy();
+        *pool = {};
         return false;
     }
 
@@ -546,8 +573,23 @@ bool Server::create_task_workers() {
 
     if (ipc_mode == SW_IPC_SOCKET) {
         char sockfile[sizeof(struct sockaddr_un)];
-        snprintf(sockfile, sizeof(sockfile), "/tmp/swoole.task.%d.sock", gs->master_pid);
-        if (get_task_worker_pool()->listen(sockfile, 2048) < 0) {
+        // Task workers are initialized before daemonization, so use the creating process ID here.
+        snprintf(sockfile, sizeof(sockfile), "/tmp/swoole.task.%d.sock", getpid());
+        {
+            mode_t old_umask = umask(0177);
+            ON_SCOPE_EXIT {
+                umask(old_umask);
+            };
+            if (pool->listen(sockfile, 2048) < 0) {
+                pool->destroy();
+                *pool = {};
+                return false;
+            }
+        }
+        if ((worker_uid != geteuid() || worker_gid != getegid()) && chown(sockfile, worker_uid, worker_gid) < 0) {
+            swoole_sys_warning("chown(%s, %d, %d) failed", sockfile, (int) worker_uid, (int) worker_gid);
+            pool->destroy();
+            *pool = {};
             return false;
         }
     }

--- a/src/server/task_worker.cc
+++ b/src/server/task_worker.cc
@@ -450,12 +450,11 @@ bool Server::finish(const char *data, size_t data_len, int flags, const EventDat
     }
 
     uint16_t source_worker_id = current_task->info.reactor_id;
-    Worker *worker = get_worker(source_worker_id);
-
-    if (worker == nullptr) {
+    if (source_worker_id >= worker_num) {
         swoole_warning("invalid worker_id[%d]", source_worker_id);
         return false;
     }
+    Worker *worker = get_worker(source_worker_id);
 
     ssize_t retval;
     // for swoole_server_task

--- a/tests/swoole_server/task/task_queue_access.phpt
+++ b/tests/swoole_server/task/task_queue_access.phpt
@@ -1,0 +1,79 @@
+--TEST--
+swoole_server/task: restrict task queue access and accept external packets
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc';
+skip_if_function_not_exist('msg_get_queue');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Server;
+use Swoole\Server\Task;
+use SwooleTest\ProcessManager;
+
+$key = 0x71000000 + (getmypid() & 0xffff);
+$logFile = sys_get_temp_dir() . '/swoole-task-queue-access-' . getmypid() . '.log';
+@unlink($logFile);
+
+if (msg_queue_exists($key)) {
+    msg_remove_queue(msg_get_queue($key));
+}
+$queue = msg_get_queue($key, 0666);
+msg_set_queue($queue, ['msg_perm.mode' => 0666]);
+
+$small = 'small task';
+$large = str_repeat('L', 32 * 1024);
+$processed = new Atomic(0);
+$mode = null;
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(5);
+$pm->parentFunc = function () use ($key, $small, $large, &$mode) {
+    $queue = msg_get_queue($key, 0600);
+    $mode = msg_stat_queue($queue)['msg_perm.mode'] & 0777;
+    Assert::true(msg_send($queue, 1, Task::pack($small), false));
+    Assert::true(msg_send($queue, 1, Task::pack($large), false));
+};
+$pm->childFunc = function () use ($pm, $key, $logFile, $small, $large, $processed) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'task_worker_num' => 1,
+        'task_ipc_mode' => 3,
+        'message_queue_key' => $key,
+        'log_file' => $logFile,
+    ]);
+    $server->on('WorkerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('Receive', function () {});
+    $server->on('Task', function (Server $server, int $taskId, int $workerId, string $data) use (
+        $small,
+        $large,
+        $processed
+    ) {
+        Assert::true($data === $small || $data === $large);
+        if ($processed->add(1) === 2) {
+            $server->shutdown();
+        }
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+
+$queue = msg_get_queue($key, 0600);
+msg_remove_queue($queue);
+$log = @file_get_contents($logFile) ?: '';
+@unlink($logFile);
+
+Assert::eq($mode, 0600);
+Assert::eq($processed->get(), 2);
+Assert::true(str_contains($log, 'discarded 0 pending messages'));
+?>
+--EXPECT--

--- a/tests/swoole_server/task/task_queue_preserve_backlog.phpt
+++ b/tests/swoole_server/task/task_queue_preserve_backlog.phpt
@@ -1,0 +1,74 @@
+--TEST--
+swoole_server/task: preserve trusted task queue backlog
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc';
+skip_if_function_not_exist('msg_get_queue');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Server;
+use Swoole\Server\Task;
+use SwooleTest\ProcessManager;
+
+$key = 0x73000000 + (getmypid() & 0xffff);
+$logFile = sys_get_temp_dir() . '/swoole-task-queue-preserve-' . getmypid() . '.log';
+@unlink($logFile);
+
+if (msg_queue_exists($key)) {
+    msg_remove_queue(msg_get_queue($key));
+}
+$queue = msg_get_queue($key, 0644);
+msg_set_queue($queue, ['msg_perm.mode' => 0644]);
+Assert::true(msg_send($queue, 1, Task::pack('pending'), false));
+
+$processed = new Atomic(0);
+$mode = null;
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(5);
+$pm->parentFunc = function ($pid) use ($pm, $key, $processed, &$mode) {
+    for ($i = 0; $i < 200 && $processed->get() === 0; $i++) {
+        usleep(10000);
+    }
+    $queue = msg_get_queue($key, 0600);
+    $mode = msg_stat_queue($queue)['msg_perm.mode'] & 0777;
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm, $key, $logFile, $processed) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'task_worker_num' => 1,
+        'task_ipc_mode' => 3,
+        'message_queue_key' => $key,
+        'log_file' => $logFile,
+    ]);
+    $server->on('WorkerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('Receive', function () {});
+    $server->on('Task', function (Server $server, int $taskId, int $workerId, string $data) use ($processed) {
+        Assert::eq($data, 'pending');
+        $processed->add(1);
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+
+$queue = msg_get_queue($key, 0600);
+msg_remove_queue($queue);
+$log = @file_get_contents($logFile) ?: '';
+@unlink($logFile);
+
+Assert::eq($mode, 0600);
+Assert::eq($processed->get(), 1);
+Assert::false(str_contains($log, 'was replaced'));
+?>
+--EXPECT--

--- a/tests/swoole_server/task/task_queue_replace_backlog.phpt
+++ b/tests/swoole_server/task/task_queue_replace_backlog.phpt
@@ -1,0 +1,77 @@
+--TEST--
+swoole_server/task: replace writable task queue backlog
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc';
+skip_if_function_not_exist('msg_get_queue');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Atomic;
+use Swoole\Server;
+use Swoole\Server\Task;
+use SwooleTest\ProcessManager;
+
+$key = 0x72000000 + (getmypid() & 0xffff);
+$logFile = sys_get_temp_dir() . '/swoole-task-queue-replace-' . getmypid() . '.log';
+@unlink($logFile);
+
+if (msg_queue_exists($key)) {
+    msg_remove_queue(msg_get_queue($key));
+}
+$queue = msg_get_queue($key, 0666);
+msg_set_queue($queue, ['msg_perm.mode' => 0666]);
+Assert::true(msg_send($queue, 1, Task::pack('stale'), false));
+
+$stale = new Atomic(0);
+$fresh = new Atomic(0);
+$mode = null;
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(5);
+$pm->parentFunc = function () use ($key, &$mode) {
+    $queue = msg_get_queue($key, 0600);
+    $mode = msg_stat_queue($queue)['msg_perm.mode'] & 0777;
+    Assert::true(msg_send($queue, 1, Task::pack('fresh'), false));
+};
+$pm->childFunc = function () use ($pm, $key, $logFile, $stale, $fresh) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'task_worker_num' => 1,
+        'task_ipc_mode' => 3,
+        'message_queue_key' => $key,
+        'log_file' => $logFile,
+    ]);
+    $server->on('WorkerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('Receive', function () {});
+    $server->on('Task', function (Server $server, int $taskId, int $workerId, string $data) use ($stale, $fresh) {
+        if ($data === 'stale') {
+            $stale->add(1);
+        } elseif ($data === 'fresh') {
+            $fresh->add(1);
+            $server->shutdown();
+        }
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+
+$queue = msg_get_queue($key, 0600);
+msg_remove_queue($queue);
+$log = @file_get_contents($logFile) ?: '';
+@unlink($logFile);
+
+Assert::eq($mode, 0600);
+Assert::eq($stale->get(), 0);
+Assert::eq($fresh->get(), 1);
+Assert::true(str_contains($log, 'discarded 1 pending message'));
+?>
+--EXPECT--

--- a/tests/swoole_server/task/task_socket_access.phpt
+++ b/tests/swoole_server/task/task_socket_access.phpt
@@ -1,0 +1,73 @@
+--TEST--
+swoole_server/task: restrict task stream socket access
+--SKIPIF--
+<?php require __DIR__ . '/../../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Server;
+use SwooleTest\ProcessManager;
+
+$worker = function_exists('posix_geteuid') && posix_geteuid() === 0 ? posix_getpwnam('nobody') : false;
+$mode = null;
+$owner = null;
+$processed = new Swoole\Atomic(0);
+$creatorPid = new Swoole\Atomic(0);
+$logFile = sys_get_temp_dir() . '/swoole-task-socket-access-' . getmypid() . '.log';
+@unlink($logFile);
+
+$pm = new ProcessManager();
+$pm->setWaitTimeout(5);
+$pm->parentFunc = function () use ($pm, $processed, $creatorPid, &$mode, &$owner) {
+    $socketFile = "/tmp/swoole.task.{$creatorPid->get()}.sock";
+    clearstatcache(true, $socketFile);
+    $mode = fileperms($socketFile) & 0777;
+    $owner = fileowner($socketFile);
+
+    $client = new Swoole\Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::eq($client->send('task'), 4);
+    $client->close();
+    Assert::true($processed->wait(5));
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm, $processed, $creatorPid, $worker, $logFile) {
+    umask(0000);
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $settings = [
+        'worker_num' => 1,
+        'task_worker_num' => 1,
+        'task_ipc_mode' => 4,
+        'log_file' => $logFile,
+    ];
+    if ($worker !== false) {
+        $settings['user'] = $worker['name'];
+    }
+    $server->set($settings);
+    $server->on('WorkerStart', function (Server $server, int $workerId) use ($pm) {
+        if ($workerId === 0) {
+            $pm->wakeup();
+        }
+    });
+    $server->on('Receive', function (Server $server, int $fd, int $reactorId, string $data) {
+        Assert::integer($server->task($data));
+    });
+    $server->on('Task', function (Server $server, int $taskId, int $workerId, string $data) use ($processed) {
+        Assert::eq($data, 'task');
+        $processed->wakeup();
+    });
+    $creatorPid->set(getmypid());
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+@unlink($logFile);
+
+Assert::eq($mode, 0600);
+if ($worker !== false) {
+    Assert::eq($owner, $worker['uid']);
+}
+?>
+--EXPECT--


### PR DESCRIPTION
Server task message queues currently use mode 0666, and task stream sockets inherit the process umask. This allows unrelated local processes to send or receive internal task packets.

This change limits Server task queues and stream sockets to the configured worker account. An existing keyed queue is preserved only when both its current owner and original creator are trusted and it has no group or other write access. Otherwise, it is replaced before workers start. Linux grants owner permissions when the effective user matches either the current owner or the original creator, so checking only the current owner would leave the creator with access after the owner and mode change. The public ProcessPool queue default is unchanged.

Mode-4 task sockets now use the creating process ID instead of the uninitialized master PID, so concurrent servers no longer all try to bind `/tmp/swoole.task.0.sock`. This changes the observable socket name. A PID-based name can still collide after PID reuse or deliberate path pre-creation; changing the naming scheme is outside this fix.

The task reply path now validates the event-worker index before accessing worker and result storage. ProcessPool cleanup also unlinks only Unix socket paths, rather than treating a TCP host name as a path.

The tests cover queue replacement and restart preservation, external packed tasks from the worker account, stream socket permissions and ownership, concurrent mode-4 servers, TCP pool cleanup, and invalid task reply sources.

`task_pack.phpt` hangs on the unchanged 6.1 commit `07606e522` with no stale `0x70001001` queue present, and also hangs on this branch. That existing behavior is unrelated to these changes.