### PR TITLE
Keep uploaded file paths valid through request shutdown

### DIFF
--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -321,9 +321,12 @@ void swoole_http_parse_cookie(zval *zcookies, const char *at, size_t length) {
 static void http_request_add_upload_file(HttpContext *ctx, const char *file, size_t l_file) {
     zval *zfiles = swoole_http_init_and_read_property(
         swoole_http_request_ce, ctx->request.zobject, &ctx->request.ztmpfiles, SW_ZSTR_KNOWN(SW_ZEND_STR_TMPFILES));
-    add_next_index_stringl(zfiles, file, l_file);
-    // support is_upload_file
-    zend_hash_str_add_ptr(SG(rfc1867_uploaded_files), file, l_file, (char *) file);
+    zend_string *path = zend_string_init(file, l_file, 0);
+    add_next_index_str(zfiles, zend_string_copy(path));
+    // Registers the path for is_uploaded_file() and move_uploaded_file(). The hash key holds the reference that
+    // keeps the value pointer valid for PHP's request-shutdown cleanup.
+    zend_hash_add_ptr(SG(rfc1867_uploaded_files), path, path);
+    zend_string_release(path);
 }
 
 bool swoole_http_token_list_contains_value(const char *at, size_t length, const char *value) {

--- a/tests/swoole_http_server/upload_file_request_shutdown.phpt
+++ b/tests/swoole_http_server/upload_file_request_shutdown.phpt
@@ -1,0 +1,72 @@
+--TEST--
+swoole_http_server: retain uploaded file until request shutdown
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+class RequestHolder
+{
+    public static ?Swoole\Http\Request $request = null;
+}
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $boundary = '------------------------d3f990cdce762596';
+    $body = implode("\r\n", [
+        '--' . $boundary,
+        'Content-Disposition: form-data; name="file"; filename="test.jpg"',
+        'Content-Type: image/jpeg',
+        '',
+        file_get_contents(TEST_IMAGE),
+        '--' . $boundary . '--',
+        '',
+    ]);
+    $request = implode("\r\n", [
+        'POST / HTTP/1.1',
+        'Host: 127.0.0.1',
+        'Connection: close',
+        'Content-Type: multipart/form-data; boundary=' . $boundary,
+        'Content-Length: ' . strlen($body),
+        '',
+        $body,
+    ]);
+
+    $socket = stream_socket_client("tcp://127.0.0.1:{$pm->getFreePort()}");
+    fwrite($socket, $request);
+    $response = stream_get_contents($socket);
+    fclose($socket);
+    $parts = explode("\r\n\r\n", $response, 2);
+    Assert::count($parts, 2);
+    Assert::same($parts[1], md5_file(TEST_IMAGE));
+
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $http->set([
+        'log_file' => '/dev/null',
+        'worker_num' => 1,
+        'package_max_length' => 64 * 1024,
+        'upload_max_filesize' => 8 * 1024 * 1024,
+    ]);
+    $http->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $tmpName = $request->files['file']['tmp_name'];
+        Assert::true(is_file($tmpName));
+        Assert::same(md5_file($tmpName), md5_file(TEST_IMAGE));
+        RequestHolder::$request = $request;
+        $response->end(md5_file($tmpName));
+    });
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+$pm->expectExitCode(0);
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

- keep uploaded file paths alive while PHP's uploaded-file table references them
- share the same path string with the request temporary-file list
- cover a preprocessed upload retained until request shutdown

## Why

Swoole stored a pointer to temporary stack or heap storage as each uploaded-file table value. Normal
`is_uploaded_file()` and `move_uploaded_file()` calls only inspect the table keys, so they did not expose the lifetime
error. When an upload request survives until extension shutdown, PHP reads the value while removing the temporary file
and can access storage that has already been released.

This can occur through public `Request::create()` and `parse()` usage, a single-worker base-mode server, or thread
mode. The change stores the path in one `zend_string` shared by the request and the uploaded-file table. The table key
then keeps its value valid until PHP finishes cleanup.

The regression uses the real large-upload preprocessor in single-worker base mode and retains the request through
shutdown. It passes normally because ordinary assertions cannot observe the stale native pointer.

## Reproduction

After building and installing Swoole, run the regression under Valgrind:

```sh
cd tests
PHPT=1 php run-tests -m swoole_http_server/upload_file_request_shutdown.phpt
```

On unchanged 6.1, Valgrind reports `unlink(pathname) points to unaddressable byte(s)` from
`destroy_uploaded_files_hash()`. With this change, the test passes cleanly.
