### PR TITLE
Fix server SSL context initialization

### DIFF
--- a/core-tests/src/protocol/ssl.cpp
+++ b/core-tests/src/protocol/ssl.cpp
@@ -67,9 +67,16 @@ TEST(ssl, get_error) {
 }
 
 TEST(ssl, password) {
-    SSLContext ctx;
+    SSLContext ctx{};
     ctx.key_file = swoole::test::get_ssl_dir() + "/passwd_key.pem";
     ctx.passphrase = "swoole";
     ctx.cert_file = swoole::test::get_ssl_dir() + "/passwd.crt";
     ASSERT_TRUE(ctx.create());
+}
+
+TEST(ssl, failed_create) {
+    SSLContext ctx{};
+    ctx.cert_file = swoole::test::get_ssl_dir() + "/server.key";
+    ASSERT_FALSE(ctx.create());
+    ASSERT_FALSE(ctx.ready());
 }

--- a/core-tests/src/server/port.cpp
+++ b/core-tests/src/server/port.cpp
@@ -50,8 +50,12 @@ TEST(server_port, create) {
     ASSERT_EQ(port->protocol.package_eof_len, SW_DATA_EOF_MAXLEN);
 
     ASSERT_TRUE(port->ssl_context_init());
-    ASSERT_FALSE(port->ssl_context_create(port->ssl_context.get()));
+    ASSERT_FALSE(port->ssl_context_create(port->ssl_context.get(), false));
     ASSERT_ERREQ(SW_ERROR_WRONG_OPERATION);
+    port->ssl_context->cert_file = "server.crt";
+    ASSERT_FALSE(port->ssl_context_create(port->ssl_context.get(), true));
+    port->ssl_context->cert_file.clear();
+    ASSERT_TRUE(port->ssl_context_create(port->ssl_context.get(), true));
 }
 
 TEST(server_port, dgram) {

--- a/ext-src/swoole_server_port.cc
+++ b/ext-src/swoole_server_port.cc
@@ -535,11 +535,9 @@ static PHP_METHOD(swoole_server_port, set) {
             ZEND_HASH_FOREACH_END();
         }
 
-        if (!port->get_ssl_cert_file().empty() || !port->has_sni_contexts()) {
-            if (!port->ssl_init()) {
-                php_swoole_fatal_error(E_ERROR, "ssl_init() failed");
-                RETURN_FALSE;
-            }
+        if (!port->ssl_init()) {
+            php_swoole_fatal_error(E_ERROR, "ssl_init() failed");
+            RETURN_FALSE;
         }
     }
 #endif

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -334,7 +334,7 @@ struct ListenPort {
 
 #ifdef SW_USE_OPENSSL
     bool ssl_context_init();
-    bool ssl_context_create(SSLContext *context) const;
+    bool ssl_context_create(SSLContext *context, bool allow_empty_cert) const;
     bool ssl_create(network::Socket *sock);
     bool ssl_add_sni_cert(const std::string &name, const std::shared_ptr<SSLContext> &ctx);
     static bool ssl_matches_wildcard_name(const char *subject_name, const char *cert_name);

--- a/src/protocol/ssl.cc
+++ b/src/protocol/ssl.cc
@@ -208,6 +208,13 @@ bool SSLContext::create() {
         ssl_error("SSL_CTX_new() failed");
         return false;
     }
+    bool created = false;
+    ON_SCOPE_EXIT {
+        if (!created) {
+            SSL_CTX_free(context);
+            context = nullptr;
+        }
+    };
 
 #ifdef SSL_OP_MICROSOFT_SESS_ID_BUG
     SSL_CTX_set_options(context, SSL_OP_MICROSOFT_SESS_ID_BUG);
@@ -314,7 +321,7 @@ bool SSLContext::create() {
          */
         if (SSL_CTX_use_certificate_file(context, cert_file.c_str(), SSL_FILETYPE_PEM) <= 0) {
             ssl_error("SSL_CTX_use_certificate_file(%s) failed", cert_file.c_str());
-            return true;
+            return false;
         }
         /*
          * if the crt file have many certificate entry ,means certificate chain
@@ -394,6 +401,7 @@ bool SSLContext::create() {
         return false;
     }
 
+    created = true;
     return true;
 }
 

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -45,7 +45,7 @@ ListenPort::ListenPort(Server *server) {
 #ifdef SW_USE_OPENSSL
 
 bool ListenPort::ssl_add_sni_cert(const std::string &name, const std::shared_ptr<SSLContext> &ctx) {
-    if (!ssl_context_create(ctx.get())) {
+    if (!ssl_context_create(ctx.get(), false)) {
         return false;
     }
     sni_contexts.emplace(name, ctx);
@@ -139,7 +139,7 @@ bool ListenPort::ssl_context_init() {
 }
 
 bool ListenPort::ssl_init() const {
-    if (!ssl_context_create(ssl_context.get())) {
+    if (!ssl_context_create(ssl_context.get(), has_sni_contexts())) {
         return false;
     }
     if (!sni_contexts.empty()) {
@@ -160,8 +160,8 @@ bool ListenPort::ssl_create(Socket *sock) {
     return true;
 }
 
-bool ListenPort::ssl_context_create(SSLContext *context) const {
-    if (context->cert_file.empty() || context->key_file.empty()) {
+bool ListenPort::ssl_context_create(SSLContext *context, bool allow_empty_cert) const {
+    if (context->cert_file.empty() != context->key_file.empty() || (context->cert_file.empty() && !allow_empty_cert)) {
         swoole_error_log(SW_LOG_ERROR, SW_ERROR_WRONG_OPERATION, "require `ssl_cert_file` and `ssl_key_file` options");
         return false;
     }

--- a/tests/swoole_http_server/invalid_certificate.phpt
+++ b/tests/swoole_http_server/invalid_certificate.phpt
@@ -1,0 +1,25 @@
+--TEST--
+swoole_http_server: reject an invalid default certificate
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Http\Server;
+
+$server = new Server('127.0.0.1', get_one_free_port(), SWOOLE_BASE, SWOOLE_SOCK_TCP | SWOOLE_SSL);
+$server->set([
+    'ssl_cert_file' => __FILE__,
+    'ssl_key_file' => SSL_FILE_DIR . '/server.key',
+]);
+echo "UNEXPECTED\n";
+?>
+--EXPECTF--
+[%s]	WARNING	SSLContext::create(): SSL_CTX_use_certificate_file(%s) failed, Error: %s[%d]
+[%s]	WARNING	ListenPort::ssl_context_create(): failed to create ssl content
+
+Fatal error: Swoole\Server\Port::set(): ssl_init() failed in %s on line %d

--- a/tests/swoole_http_server/sni/sni_only.phpt
+++ b/tests/swoole_http_server/sni/sni_only.phpt
@@ -1,0 +1,89 @@
+--TEST--
+swoole_http_server/sni: SNI certificates without a default certificate
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_no_ssl();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+use Swoole\Http\Server;
+
+$pm = new ProcessManager;
+$pm->setWaitTimeout(10);
+
+$pm->parentFunc = function () use ($pm) {
+    $port = $pm->getFreePort();
+    $context = stream_context_create([
+        'ssl' => [
+            'capture_peer_cert' => true,
+            'peer_name' => 'cs.php.net',
+            'verify_peer' => false,
+            'verify_peer_name' => false,
+        ],
+    ]);
+    $client = stream_socket_client(
+        "tls://127.0.0.1:$port",
+        $errno,
+        $errstr,
+        1,
+        STREAM_CLIENT_CONNECT,
+        $context
+    );
+    Assert::resource($client);
+    $certificate = stream_context_get_options($context)['ssl']['peer_certificate'];
+    Assert::same(openssl_x509_parse($certificate)['subject']['CN'], 'cs.php.net');
+    fwrite($client, "GET / HTTP/1.1\r\nHost: cs.php.net\r\nConnection: close\r\n\r\n");
+    Assert::contains(stream_get_contents($client), 'HTTP/1.1 200 OK');
+    fclose($client);
+
+    $context = stream_context_create([
+        'ssl' => [
+            'SNI_enabled' => false,
+            'verify_peer' => false,
+            'verify_peer_name' => false,
+        ],
+    ]);
+    Assert::false(@stream_socket_client(
+        "tls://127.0.0.1:$port",
+        $errno,
+        $errstr,
+        1,
+        STREAM_CLIENT_CONNECT,
+        $context
+    ));
+
+    $pm->kill();
+    echo "DONE\n";
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE, SWOOLE_SOCK_TCP | SWOOLE_SSL);
+    $server->set([
+        'log_file' => '/dev/null',
+        'worker_num' => 1,
+        'ssl_sni_certs' => [
+            'cs.php.net' => [
+                'ssl_cert_file' => SSL_FILE_DIR . '/sni_server_cs_cert.pem',
+                'ssl_key_file' => SSL_FILE_DIR . '/sni_server_cs_key.pem',
+            ],
+        ],
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Request $request, Response $response) {
+        $response->end();
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
SNI-only server configuration skipped creation of the primary SSL context, so connections failed before SNI could select a certificate. Invalid default certificates were also reported as successfully initialized, and other creation failures left an incomplete context marked ready.

This always creates the primary context, allowing it to omit a certificate only when valid SNI certificates exist. Invalid or incomplete certificate configuration is rejected. Failed context creation now frees and clears the incomplete context so later attempts start cleanly.

The SNI-only and invalid-certificate regressions fail on unchanged 6.1 and pass with this change. Existing SNI and HTTPS server tests continue to pass.