### PR TITLE
Reject oversized HTTP Upgrade values

### DIFF
--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -327,7 +327,7 @@ static void http_request_add_upload_file(HttpContext *ctx, const char *file, siz
 }
 
 bool swoole_http_token_list_contains_value(const char *at, size_t length, const char *value) {
-    if (0 == length) {
+    if (0 == length || length >= sw_tg_buffer()->size) {
         return false;
     }
     if (SW_STRCASEEQ(at, length, value)) {

--- a/tests/swoole_http_server/create_request_large_upgrade.phpt
+++ b/tests/swoole_http_server/create_request_large_upgrade.phpt
@@ -1,0 +1,25 @@
+--TEST--
+swoole_http_server: handle an oversized Upgrade value safely
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Http\Request;
+
+$upgrade = str_repeat('x', 128 * 1024) . ', websocket';
+$data = "GET / HTTP/1.1\r\n" .
+    "Host: localhost\r\n" .
+    "Upgrade: {$upgrade}\r\n" .
+    "Connection: Upgrade\r\n\r\n";
+$request = Request::create();
+
+Assert::same($request->parse($data), strlen($data));
+Assert::true($request->isCompleted());
+Assert::same($request->header['upgrade'], $upgrade);
+
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
`Request::parse()` accepts caller-provided HTTP data without the server header-size check. Upgrade parsing copied the complete value into the current thread buffer and then appended a null byte. A value at least as large as that buffer wrote past its end and corrupted heap state.

This change returns false before copying a value that cannot fit together with the terminating byte. Parsing for valid Upgrade values is unchanged.

The regression passes a 128 KiB Upgrade value through `Request::parse()`. On unchanged 6.1 it prints `DONE`, then aborts with `double free or corruption (!prev)`; Valgrind also reports the invalid writes. The guarded implementation completes normally and under Valgrind while retaining the original header value.