### PR TITLE
Report fatal Coroutine Server accept failures

### DIFF
--- a/ext-src/php_swoole_library.h
+++ b/ext-src/php_swoole_library.h
@@ -14,7 +14,7 @@
   +----------------------------------------------------------------------+
  */
 
-/* $Id: 6b77c9c11ca791c77fa13aad72117300071c32ca */
+/* $Id: bb1b7cb692944bca64f4893f7c360fc6ba791486 */
 
 #ifndef SWOOLE_LIBRARY_H
 #define SWOOLE_LIBRARY_H
@@ -1873,8 +1873,9 @@ static const char* swoole_library_source_core_coroutine_server =
     "                if ($socket->errCode == SOCKET_ECANCELED) {\n"
     "                    break;\n"
     "                }\n"
+    "                $this->errCode = $socket->errCode;\n"
     "                trigger_error(\"accept failed, Error: {$socket->errMsg}[{$socket->errCode}]\", E_USER_WARNING);\n"
-    "                break;\n"
+    "                return false;\n"
     "            }\n"
     "        }\n"
     "\n"

--- a/tests/swoole_server_coro/fatal_accept.phpt
+++ b/tests/swoole_server_coro/fatal_accept.phpt
@@ -1,0 +1,41 @@
+--TEST--
+swoole_server_coro: report fatal accept failure
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+go(function () {
+    $socket = new class {
+        public int $errCode = SOCKET_ECONNRESET;
+
+        public string $errMsg = 'Connection reset by peer';
+
+        public function setProtocol(array $setting): bool
+        {
+            return true;
+        }
+
+        public function accept(): false
+        {
+            return false;
+        }
+    };
+
+    $server = new class($socket) extends Swoole\Coroutine\Server {
+        public function __construct(object $socket)
+        {
+            $this->socket = $socket;
+        }
+    };
+    $server->handle(static function (): void {});
+
+    Assert::false($server->start());
+    Assert::same($server->errCode, SOCKET_ECONNRESET);
+    echo "DONE\n";
+});
+?>
+--EXPECTF--
+Warning: accept failed, Error: Connection reset by peer[%d] in %s on line %d
+DONE


### PR DESCRIPTION
The embedded Coroutine\Server::start() warns and stops accepting connections after a fatal socket error, but then returns true and leaves errCode unchanged.

This regenerates the embedded library with the reviewed source fix from [swoole/library#192](https://github.com/swoole/library/pull/192). The generated source is [the currently embedded library revision plus that fix](https://github.com/binaryfire/library/commit/bb1b7cb692944bca64f4893f7c360fc6ba791486), keeping the update isolated from unrelated library changes.

Fatal accept failures now copy the socket error and return false. Retryable failures, cancellation, and clean shutdown are unchanged.

The regression drives a non-retryable accept failure through the embedded public start() result and errCode.