### PR TITLE
Report multipart upload temporary file failures

### DIFF
--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -667,6 +667,7 @@ static int multipart_body_on_header_complete(multipart_parser *p) {
     sw_snprintf(file_path, SW_HTTP_UPLOAD_TMPDIR_SIZE, "%s/swoole.upfile.XXXXXX", ctx->upload_tmp_dir.c_str());
     int tmpfile = swoole_tmpfile(file_path);
     if (tmpfile < 0) {
+        add_assoc_long(z_multipart_header, "error", HTTP_UPLOAD_ERR_NO_TMP_DIR);
         return 0;
     }
 

--- a/tests/swoole_http_server/upload_file_no_tmp_dir.phpt
+++ b/tests/swoole_http_server/upload_file_no_tmp_dir.phpt
@@ -1,0 +1,64 @@
+--TEST--
+swoole_http_server: upload file without temporary directory
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$uploadTmpDir = sys_get_temp_dir() . '/swoole-upload-' . get_safe_random(8);
+
+$pm->parentFunc = function () use ($pm) {
+    $boundary = '------------------------d3f990cdce762596';
+    $body = implode("\r\n", [
+        "--$boundary",
+        'Content-Disposition: form-data; name="file"; filename="test.txt"',
+        'Content-Type: text/plain',
+        '',
+        'test',
+        "--$boundary--",
+        '',
+    ]);
+    $request = implode("\r\n", [
+        'POST / HTTP/1.1',
+        "Content-Type: multipart/form-data; boundary=$boundary",
+        'Content-Length: ' . strlen($body),
+        '',
+        $body,
+    ]);
+
+    $sock = stream_socket_client("tcp://127.0.0.1:{$pm->getFreePort()}");
+    fwrite($sock, $request);
+    stream_set_chunk_size($sock, 2 * 1024 * 1024);
+    $response = fread($sock, 2 * 1024 * 1024);
+    fclose($sock);
+
+    [, $body] = explode("\r\n\r\n", $response, 2);
+    $files = json_decode($body, true);
+    Assert::true(isset($files['file']));
+    assert_upload_file($files['file'], '', 'test.txt', 'text/plain', 0, UPLOAD_ERR_NO_TMP_DIR);
+
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm, $uploadTmpDir) {
+    $http = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $http->set([
+        'log_file' => '/dev/null',
+        'upload_tmp_dir' => $uploadTmpDir,
+    ]);
+    Assert::true(rmdir($uploadTmpDir));
+    $http->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $http->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        $response->end(json_encode($request->files));
+    });
+    $http->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
Multipart uploads currently retain `UPLOAD_ERR_OK` when Swoole cannot create the temporary file. The handler receives an empty path and zero size as a successful upload.

Set `UPLOAD_ERR_NO_TMP_DIR` when temporary-file creation fails, matching PHP's upload behavior. The regression removes a configured upload directory after validation and verifies the failed upload metadata.
