### PR TITLE
Preserve HTTP pipelined response order and receive pauses

### DIFF
--- a/ext-src/php_swoole_http.h
+++ b/ext-src/php_swoole_http.h
@@ -162,6 +162,7 @@ struct Context {
     uchar parse_body : 1;
     uchar parse_files : 1;
     uchar http2 : 1;
+    uint16_t send_ext_flags;
 
     zval zsocket;
     uint32_t stream_id;
@@ -225,6 +226,13 @@ struct Context {
     HTTP_API void end(zval *zdata, zval *return_value);
     HTTP_API void write(zval *zdata, zval *return_value);
     HTTP_API bool send_file(const char *file, uint32_t l_file, off_t offset, size_t length);
+
+    bool send_with_flags(const char *data, size_t length, uint16_t ext_flags) {
+        send_ext_flags = ext_flags;
+        bool retval = send(this, data, length);
+        send_ext_flags = 0;
+        return retval;
+    }
 
     String *get_write_buffer();
 

--- a/ext-src/php_swoole_server.h
+++ b/ext-src/php_swoole_server.h
@@ -147,7 +147,8 @@ zend::Callable *php_swoole_server_get_callback(swServer *serv, int server_fd, in
 int php_swoole_create_dir(const char *path, size_t length);
 void php_swoole_server_before_start(swServer *serv, zval *zobject);
 bool php_swoole_server_isset_callback(swServer *serv, swoole::ListenPort *port, int event_type);
-void php_swoole_server_send_yield(swServer *serv, swoole::SessionId sesion_id, zval *zdata, zval *return_value);
+void php_swoole_server_send_yield(
+    swServer *serv, swoole::SessionId sesion_id, zval *zdata, zval *return_value, uint16_t ext_flags = 0);
 void php_swoole_get_recv_data(swServer *serv, zval *zdata, swoole::RecvData *req);
 void php_swoole_server_onConnect(swServer *, swoole::DataHead *);
 int php_swoole_server_onReceive(swServer *, swoole::RecvData *);

--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -720,7 +720,7 @@ bool HttpContext::send_file(const char *file, uint32_t l_file, off_t offset, siz
 
         build_header(http_buffer, nullptr, length);
 
-        if (!send(this, http_buffer->str, http_buffer->length)) {
+        if (!send_with_flags(http_buffer->str, http_buffer->length, length > 0 ? SW_SERVER_SEND_MORE_DATA : 0)) {
             send_header_ = 0;
             return false;
         }
@@ -749,7 +749,7 @@ void HttpContext::write(zval *zdata, zval *return_value) {
         send_chunked = 1;
         http_buffer->clear();
         build_header(http_buffer, nullptr, 0);
-        if (!send(this, http_buffer->str, http_buffer->length)) {
+        if (!send_with_flags(http_buffer->str, http_buffer->length, SW_SERVER_SEND_MORE_DATA)) {
             send_chunked = 0;
             send_header_ = 0;
             RETURN_FALSE;
@@ -774,7 +774,7 @@ void HttpContext::write(zval *zdata, zval *return_value) {
     http_buffer->append(ZEND_STRL("\r\n"));
     sw_free(hex_string);
 
-    RETURN_BOOL(send(this, http_buffer->str, http_buffer->length));
+    RETURN_BOOL(send_with_flags(http_buffer->str, http_buffer->length, SW_SERVER_SEND_MORE_DATA));
 }
 
 void HttpContext::end(zval *zdata, zval *return_value) {
@@ -791,7 +791,7 @@ void HttpContext::end(zval *zdata, zval *return_value) {
             }
         }
         if (send_trailer_) {
-            if (!send(this, ZEND_STRL("0\r\n"))) {
+            if (!send_with_flags(ZEND_STRL("0\r\n"), SW_SERVER_SEND_MORE_DATA)) {
                 RETURN_FALSE;
             }
             send_trailer(return_value);
@@ -848,7 +848,7 @@ void HttpContext::end(zval *zdata, zval *return_value) {
 #endif
             // send twice to reduce memory copy
             if (length > SW_HTTP_MAX_APPEND_DATA) {
-                if (!send(this, http_buffer->str, http_buffer->length)) {
+                if (!send_with_flags(http_buffer->str, http_buffer->length, SW_SERVER_SEND_MORE_DATA)) {
                     send_header_ = 0;
                     RETURN_FALSE;
                 }

--- a/ext-src/swoole_http_server.cc
+++ b/ext-src/swoole_http_server.cc
@@ -347,11 +347,11 @@ void HttpContext::free() {
 
 bool http_context_send_data(HttpContext *ctx, const char *data, size_t length) {
     auto *serv = ctx->get_async_server();
-    bool retval = serv->send(ctx->fd, data, length);
+    bool retval = serv->send(ctx->fd, data, length, ctx->send_ext_flags);
     if (!retval && swoole_get_last_error() == SW_ERROR_OUTPUT_SEND_YIELD) {
         zval yield_data, return_value;
         ZVAL_STRINGL(&yield_data, data, length);
-        php_swoole_server_send_yield(serv, ctx->fd, &yield_data, &return_value);
+        php_swoole_server_send_yield(serv, ctx->fd, &yield_data, &return_value, ctx->send_ext_flags);
         zval_ptr_dtor(&yield_data);
         return Z_BVAL_P(&return_value);
     }

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -1788,7 +1788,8 @@ void php_swoole_server_check_kernel_nobufs(Server *serv, SessionId session_id) {
     }
 }
 
-void php_swoole_server_send_yield(Server *serv, SessionId session_id, zval *zdata, zval *return_value) {
+void php_swoole_server_send_yield(
+    Server *serv, SessionId session_id, zval *zdata, zval *return_value, uint16_t ext_flags) {
     ServerObject *server_object = server_fetch_object(Z_OBJ_P(php_swoole_server_zval_ptr(serv)));
     Coroutine *co = Coroutine::get_current_safe();
     char *data;
@@ -1813,7 +1814,7 @@ void php_swoole_server_send_yield(Server *serv, SessionId session_id, zval *zdat
             co_list->erase(iter);
             RETURN_FALSE;
         }
-        bool ret = serv->send(session_id, data, length);
+        bool ret = serv->send(session_id, data, length, ext_flags);
         if (!ret && swoole_get_last_error() == SW_ERROR_OUTPUT_SEND_YIELD && serv->send_yield) {
             continue;
         } else {

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -84,6 +84,9 @@ struct Connection {
     uint8_t high_watermark;
     uint8_t http_upgrade;
     uint8_t http2_stream;
+    uint8_t http_request_in_flight;
+    uint8_t http_request_waiting;
+    uint8_t recv_paused;
     uint8_t websocket_compression;
     // If it is equal to 1, it means server actively closed the connection
     uint8_t close_actively;
@@ -639,6 +642,10 @@ enum ServerEventType {
     SW_SERVER_EVENT_SHUTDOWN,
     SW_SERVER_EVENT_COMMAND_REQUEST,
     SW_SERVER_EVENT_COMMAND_RESPONSE,
+};
+
+enum ServerSendFlag {
+    SW_SERVER_SEND_MORE_DATA = 1u << 0,
 };
 
 class Server {
@@ -1523,6 +1530,7 @@ class Server {
     static int dispatch_task(const Protocol *proto, network::Socket *_socket, const RecvData *rdata);
 
     int send_to_connection(const SendData *) const;
+    void resume_http_request(Connection *) const;
     ssize_t send_to_worker_from_worker(const Worker *dst_worker, const void *buf, size_t len, int flags);
     bool has_kernel_nobufs_error(SessionId session_id) const;
 
@@ -1537,7 +1545,7 @@ class Server {
      * This function is used for sending data to the client in the server.
      * @return true on success, false on failure.
      */
-    bool send(SessionId session_id, const void *data, uint32_t length) const;
+    bool send(SessionId session_id, const void *data, uint32_t length, uint16_t ext_flags = 0) const;
     /**
      * Send file to session.
      * This function is used for sending files in the HTTP server.

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -1309,10 +1309,11 @@ void Server::store_pipe_fd(UnixSocket *p) {
 /**
  * @process Worker
  */
-bool Server::send(SessionId session_id, const void *data, uint32_t length) const {
+bool Server::send(SessionId session_id, const void *data, uint32_t length, uint16_t ext_flags) const {
     SendData _send{};
     _send.info.fd = session_id;
     _send.info.type = SW_SERVER_EVENT_SEND_DATA;
+    _send.info.ext_flags = ext_flags;
     _send.data = (char *) data;
     _send.info.len = length;
     if (factory_->finish(&_send)) {
@@ -1467,6 +1468,7 @@ int Server::send_to_connection(const SendData *_send) const {
      * pause recv data
      */
     else if (_send->info.type == SW_SERVER_EVENT_PAUSE_RECV) {
+        conn->recv_paused = 1;
         if (_socket->removed || !(_socket->events & SW_EVENT_READ)) {
             return SW_OK;
         }
@@ -1480,6 +1482,11 @@ int Server::send_to_connection(const SendData *_send) const {
      * resume recv data
      */
     else if (_send->info.type == SW_SERVER_EVENT_RESUME_RECV) {
+        conn->recv_paused = 0;
+        if (conn->http_request_waiting) {
+            resume_http_request(conn);
+            return SW_OK;
+        }
         if (!_socket->removed || (_socket->events & SW_EVENT_READ)) {
             return SW_OK;
         }
@@ -1509,7 +1516,7 @@ int Server::send_to_connection(const SendData *_send) const {
             ssize_t n = _socket->send(_send_data, _send_length, 0);
             if (n == _send_length) {
                 conn->last_send_time = microtime();
-                return SW_OK;
+                goto _send_complete;
             } else if (n > 0) {
                 _send_data += n;
                 _send_length -= n;
@@ -1580,6 +1587,13 @@ int Server::send_to_connection(const SendData *_send) const {
 
     if (!_socket->isset_writable_event()) {
         reactor->add_write_event(_socket);
+    }
+
+_send_complete:
+    if (sw_unlikely(conn->http_request_in_flight && _send->info.type != SW_SERVER_EVENT_CLOSE &&
+                    !(_send->info.ext_flags & SW_SERVER_SEND_MORE_DATA))) {
+        conn->http_request_in_flight = 0;
+        resume_http_request(conn);
     }
 
     return SW_OK;

--- a/src/server/port.cc
+++ b/src/server/port.cc
@@ -464,9 +464,15 @@ int ListenPort::readable_callback_http(Reactor *reactor, ListenPort *port, Event
     }
 
     String *buffer = request->buffer_;
+    ssize_t n;
+
+    if (_socket->skip_recv) {
+        _socket->skip_recv = 0;
+        goto _parse;
+    }
 
 _recv_data:
-    ssize_t n = _socket->recv(buffer->str + buffer->length, buffer->size - buffer->length, 0);
+    n = _socket->recv(buffer->str + buffer->length, buffer->size - buffer->length, 0);
     if (n < 0) {
         switch (_socket->catch_read_error(errno)) {
         case SW_ERROR:
@@ -500,6 +506,14 @@ _recv_data:
     }
 
     buffer->length += n;
+    if (conn->http_request_in_flight) {
+        conn->http_request_waiting = 1;
+        if (_socket->events & SW_EVENT_READ) {
+            reactor->remove_read_event(_socket);
+        }
+        return SW_OK;
+    }
+    conn->http_request_waiting = 0;
 
 _parse:
     if (request->method == 0 && request->get_protocol() < 0) {
@@ -614,6 +628,7 @@ _parse:
                 // dynamic request, dispatch to worker
                 dispatch_data.info.len = request->header_length_;
                 dispatch_data.data = buffer->str;
+                conn->http_request_in_flight = 1;
                 if (http_server::dispatch_request(serv, protocol, _socket, &dispatch_data) < 0) {
                     goto _close_fd;
                 }
@@ -625,6 +640,13 @@ _parse:
                 // http pipeline, multi requests, parse the next one
                 buffer->reduce(request->header_length_);
                 request->clean();
+                if (conn->http_request_in_flight) {
+                    conn->http_request_waiting = 1;
+                    if (_socket->events & SW_EVENT_READ) {
+                        reactor->remove_read_event(_socket);
+                    }
+                    return SW_OK;
+                }
                 goto _parse;
             } else {
                 port->destroy_http_request(conn);
@@ -686,7 +708,12 @@ _parse:
         if (buffer->length < request_length) {
             // Expect: 100-continue
             if (request->has_expect_header()) {
-                _socket->send(SW_STRL(SW_HTTP_100_CONTINUE_PACKET), 0);
+                SendData send_data{};
+                send_data.info.fd = conn->session_id;
+                send_data.info.type = SW_SERVER_EVENT_SEND_DATA;
+                send_data.info.len = sizeof(SW_HTTP_100_CONTINUE_PACKET) - 1;
+                send_data.data = SW_HTTP_100_CONTINUE_PACKET;
+                serv->send_to_connection(&send_data);
             } else {
                 swoole_trace_log(
                     SW_TRACE_SERVER,
@@ -713,6 +740,7 @@ _parse:
     dispatch_data.data = buffer->str;
     dispatch_data.info.len = buffer->length;
 
+    conn->http_request_in_flight = 1;
     if (http_server::dispatch_request(serv, protocol, _socket, &dispatch_data) < 0) {
         goto _close_fd;
     }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -697,7 +697,11 @@ static int ReactorThread_onWrite(Reactor *reactor, Event *ev) {
 
     // remove EPOLLOUT event
     if (!conn->peer_closed && !socket->removed && Buffer::empty(socket->out_buffer)) {
-        reactor->set(socket, SW_EVENT_READ);
+        if (conn->recv_paused) {
+            reactor->del(socket);
+        } else {
+            reactor->set(socket, SW_EVENT_READ);
+        }
     }
     return SW_OK;
 }
@@ -920,7 +924,7 @@ static void ReactorThread_resume_data_receiving(Timer *timer, TimerNode *tnode) 
     conn->timer = nullptr;
     if (conn->http_request_waiting) {
         sw_server()->resume_http_request(conn);
-    } else {
+    } else if (!conn->recv_paused) {
         timer->get_reactor()->add_read_event(_socket);
     }
 }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -577,11 +577,42 @@ static int ReactorThread_onRead(Reactor *reactor, Event *event) {
         conn->waiting_time = 1;
         conn->timer =
             swoole_timer_add((long) conn->waiting_time, false, ReactorThread_resume_data_receiving, event->socket);
-        if (conn->timer) {
+        if (conn->timer && (event->socket->events & SW_EVENT_READ)) {
             reactor->remove_read_event(event->socket);
         }
     }
     return retval;
+}
+
+void Server::resume_http_request(Connection *conn) const {
+    if (!conn->http_request_waiting || conn->http_request_in_flight || conn->recv_paused || conn->timer) {
+        return;
+    }
+
+    Reactor *reactor = SwooleTG.reactor;
+    SessionId session_id = conn->session_id;
+    reactor->defer([this, reactor, session_id](void *) {
+        Connection *conn = get_connection_verify(session_id);
+        if (!conn || !conn->http_request_waiting || conn->http_request_in_flight || conn->recv_paused || conn->timer) {
+            return;
+        }
+
+        Socket *socket = conn->socket;
+        // The HTTP parser checks the registration after dispatch and must see reading restored.
+        if (!(socket->events & SW_EVENT_READ)) {
+            reactor->add_read_event(socket);
+        }
+        conn->http_request_waiting = 0;
+        socket->skip_recv = 1;
+
+        Event event{};
+        event.fd = conn->fd;
+        event.reactor_id = reactor->id;
+        event.type = SW_FD_SESSION;
+        event.socket = socket;
+        ListenPort *port = get_port_by_server_fd(conn->server_fd);
+        port->onRead(reactor, port, &event);
+    });
 }
 
 static int ReactorThread_onWrite(Reactor *reactor, Event *ev) {
@@ -886,8 +917,12 @@ static void ReactorThread_resume_data_receiving(Timer *timer, TimerNode *tnode) 
         }
     }
 
-    timer->get_reactor()->add_read_event(_socket);
     conn->timer = nullptr;
+    if (conn->http_request_waiting) {
+        sw_server()->resume_http_request(conn);
+    } else {
+        timer->get_reactor()->add_read_event(_socket);
+    }
 }
 
 /**

--- a/tests/swoole_http_server/pipeline_response_order.phpt
+++ b/tests/swoole_http_server/pipeline_response_order.phpt
@@ -1,0 +1,64 @@
+--TEST--
+swoole_http_server: preserve pipelined response order
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+foreach ([SWOOLE_BASE, SWOOLE_PROCESS] as $mode) {
+    $pm = new ProcessManager;
+    $pm->parentFunc = function () use ($pm) {
+        $client = stream_socket_client('tcp://127.0.0.1:' . $pm->getFreePort());
+        stream_set_timeout($client, 2);
+        fwrite(
+            $client,
+            "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" .
+            "GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        );
+
+        $response = '';
+        while ((substr_count($response, 'HTTP/1.1 200 OK') < 2 || !str_contains($response, "0\r\n\r\n")) &&
+               !feof($client)) {
+            $data = fread($client, 8192);
+            if (!$data) {
+                break;
+            }
+            $response .= $data;
+        }
+
+        $firstResponseEnd = strpos($response, "0\r\n\r\n");
+        $secondResponseStart = strpos($response, 'HTTP/1.1 200 OK', strlen('HTTP/1.1 200 OK'));
+        Assert::true($firstResponseEnd !== false && $secondResponseStart !== false);
+        Assert::true($firstResponseEnd < $secondResponseStart);
+        fclose($client);
+        $pm->kill();
+        echo "DONE\n";
+    };
+    $pm->childFunc = function () use ($pm, $mode) {
+        $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), $mode);
+        $server->set([
+            'worker_num' => 1,
+            'log_file' => '/dev/null',
+        ]);
+        $server->on('workerStart', function () use ($pm) {
+            $pm->wakeup();
+        });
+        $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+            if ($request->server['request_uri'] === '/first') {
+                $response->write('first');
+                Swoole\Coroutine::sleep(0.05);
+                $response->end();
+            } else {
+                $response->end('second');
+            }
+        });
+        $server->start();
+    };
+    $pm->childFirst();
+    $pm->run();
+}
+?>
+--EXPECT--
+DONE
+DONE

--- a/tests/swoole_server/pause_with_max_queued_bytes.phpt
+++ b/tests/swoole_server/pause_with_max_queued_bytes.phpt
@@ -1,0 +1,63 @@
+--TEST--
+swoole_server: queued input does not resume a paused connection
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Server;
+use Swoole\Timer;
+
+$pm = new SwooleTest\ProcessManager;
+
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::eq($client->send('first'), 5);
+    $pm->wait();
+    Assert::eq($client->send('second'), 6);
+    $pm->wait();
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $first = true;
+    $resumed = false;
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $server->set([
+        'worker_num' => 1,
+        'max_queued_bytes' => 1,
+        'log_file' => '/dev/null',
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+        usleep(100000);
+    });
+    $server->on('receive', function (Server $server, $fd) use ($pm, &$first, &$resumed) {
+        if ($first) {
+            $first = false;
+            Assert::true($server->pause($fd));
+            Timer::after(1000, function () use ($server, $fd, &$resumed) {
+                $resumed = true;
+                $server->resume($fd);
+            });
+            Timer::after(200, function () use ($pm) {
+                $pm->wakeup();
+            });
+            return;
+        }
+
+        echo $resumed ? "RESUMED\n" : "EARLY\n";
+        $pm->wakeup();
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+RESUMED

--- a/tests/swoole_server/pause_with_pending_output.phpt
+++ b/tests/swoole_server/pause_with_pending_output.phpt
@@ -1,0 +1,75 @@
+--TEST--
+swoole_server: pending output does not resume a paused connection
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Client;
+use Swoole\Server;
+use Swoole\Timer;
+
+const OUTPUT_SIZE = 2 * 1024 * 1024;
+
+$pm = new SwooleTest\ProcessManager;
+$pm->setWaitTimeout(5);
+
+$pm->parentFunc = function () use ($pm) {
+    $client = new Client(SWOOLE_SOCK_TCP);
+    Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+    Assert::eq($client->send('first'), 5);
+    $pm->wait();
+
+    $data = '';
+    while (strlen($data) < OUTPUT_SIZE) {
+        $chunk = $client->recv();
+        if (!$chunk) {
+            break;
+        }
+        $data .= $chunk;
+    }
+    Assert::eq(strlen($data), OUTPUT_SIZE);
+
+    Assert::eq($client->send('second'), 6);
+    $pm->wait();
+    $client->close();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $first = true;
+    $resumed = false;
+    $server = new Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $server->set([
+        'worker_num' => 1,
+        'kernel_socket_send_buffer_size' => 128 * 1024,
+        'log_file' => '/dev/null',
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('receive', function (Server $server, $fd) use ($pm, &$first, &$resumed) {
+        if ($first) {
+            $first = false;
+            Assert::true($server->pause($fd));
+            Timer::after(1000, function () use ($server, $fd, &$resumed) {
+                $resumed = true;
+                $server->resume($fd);
+            });
+            Assert::true($server->send($fd, str_repeat('A', OUTPUT_SIZE)));
+            $pm->wakeup();
+            return;
+        }
+
+        echo $resumed ? "RESUMED\n" : "EARLY\n";
+        $pm->wakeup();
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+RESUMED


### PR DESCRIPTION
A pipelined HTTP/1 connection can dispatch a later request while an earlier handler is suspended. Both handlers send directly to the same connection, so the later response can arrive first.

This dispatches one dynamic HTTP/1 request at a time on each connection and resumes parsing buffered requests after the final response output is accepted. Completion uses the existing send metadata, without buffering or copying whole responses. It also sends `100 Continue` through the normal connection output path so it cannot overtake an earlier response.

`Server::pause()` could also be undone when pending output drained or queued-input backpressure cleared. Both transitions now leave reading disabled until `Server::resume()`.

The HTTP regression fails on unchanged 6.1 in both server modes. Two process-mode regressions cover both ways an application pause could be lost.