### PR TITLE
Fix HTTP/1 trailer completion

### DIFF
--- a/ext-src/swoole_http_response.cc
+++ b/ext-src/swoole_http_response.cc
@@ -690,7 +690,8 @@ void HttpContext::send_trailer(zval *return_value) {
     String *http_buffer = get_write_buffer();
 
     http_buffer->clear();
-    if (build_trailer(http_buffer) == 0) {
+    build_trailer(http_buffer);
+    if (http_buffer->length == 0) {
         return;
     }
     if (!send(this, http_buffer->str, http_buffer->length)) {
@@ -796,6 +797,9 @@ void HttpContext::end(zval *zdata, zval *return_value) {
             }
             send_trailer(return_value);
             send_trailer_ = 0;
+            if (end_) {
+                RETURN_FALSE;
+            }
         } else {
             if (!send(this, ZEND_STRL("0\r\n\r\n"))) {
                 RETURN_FALSE;

--- a/tests/swoole_http_server/trailer_null.phpt
+++ b/tests/swoole_http_server/trailer_null.phpt
@@ -1,0 +1,35 @@
+--TEST--
+swoole_http_server: null-only trailer
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $client = stream_socket_client('tcp://127.0.0.1:' . $pm->getFreePort());
+    fwrite($client, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    $response = stream_get_contents($client);
+    Assert::endsWith($response, "0\r\n\r\n");
+    $pm->kill();
+    echo "DONE\n";
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set(['log_file' => '/dev/null']);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        Assert::true($response->trailer('x-test', null));
+        Assert::true($response->write('body'));
+        Assert::true($response->end());
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+DONE

--- a/tests/swoole_http_server/trailer_send_failure.phpt
+++ b/tests/swoole_http_server/trailer_send_failure.phpt
@@ -1,0 +1,36 @@
+--TEST--
+swoole_http_server: trailer send failure
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$pm = new ProcessManager;
+$pm->parentFunc = function () use ($pm) {
+    $client = stream_socket_client('tcp://127.0.0.1:' . $pm->getFreePort());
+    fwrite($client, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream_get_contents($client);
+    $pm->kill();
+};
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $server->set([
+        'log_file' => '/dev/null',
+        'output_buffer_size' => 256,
+    ]);
+    $server->on('workerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('request', function (Swoole\Http\Request $request, Swoole\Http\Response $response) {
+        Assert::true($response->trailer('x-test', str_repeat('a', 256)));
+        Assert::true($response->write('body'));
+        var_dump($response->end());
+    });
+    $server->start();
+};
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
A response with only null trailer values ends with `0\r\n` instead of `0\r\n\r\n`, so clients wait for the missing message terminator. If the final trailer block cannot be sent, `Response::end()` returns true even though the response was closed before completion.

Use the built trailer buffer length when deciding whether to send it, and return false from `Response::end()` when the trailer block is not sent.

The regressions check the raw null-only terminator and a trailer block rejected by `output_buffer_size`. Both fail on unchanged 6.1 and pass with this change.