### PR TITLE
Reject repeated native-resource constructors

### DIFF
--- a/ext-src/swoole_http2_client_coro.cc
+++ b/ext-src/swoole_http2_client_coro.cc
@@ -804,6 +804,11 @@ static PHP_METHOD(swoole_http2_client_coro, __construct) {
     Z_PARAM_BOOL(ssl)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (http2_client_coro_get_client(ZEND_THIS)) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     if (host_len == 0) {
         zend_throw_exception(swoole_http2_client_coro_exception_ce, "host is empty", SW_ERROR_INVALID_PARAMS);
         RETURN_FALSE;

--- a/ext-src/swoole_http_client_coro.cc
+++ b/ext-src/swoole_http_client_coro.cc
@@ -1783,6 +1783,11 @@ static PHP_METHOD(swoole_http_client_coro, __construct) {
     Z_PARAM_BOOL(ssl)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    if (hcc->client) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     zend_update_property_stringl(swoole_http_client_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("host"), host, host_len);
     zend_update_property_long(swoole_http_client_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("port"), port);
     zend_update_property_bool(swoole_http_client_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("ssl"), ssl);

--- a/ext-src/swoole_http_cookie.cc
+++ b/ext-src/swoole_http_cookie.cc
@@ -346,6 +346,11 @@ static PHP_METHOD(swoole_http_cookie, __construct) {
     Z_PARAM_BOOL(encode)
     ZEND_PARSE_PARAMETERS_END();
 
+    if (php_swoole_http_get_cookie(ZEND_THIS)) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     php_swoole_http_response_set_cookie(ZEND_THIS, new HttpCookie(encode));
 }
 

--- a/ext-src/swoole_http_server_coro.cc
+++ b/ext-src/swoole_http_server_coro.cc
@@ -329,6 +329,12 @@ static PHP_METHOD(swoole_http_server_coro, __construct) {
     Z_PARAM_BOOL(reuse_port)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
+    HttpServerObject *hsc = http_server_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
+    if (hsc->server) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     zend_update_property_stringl(swoole_http_server_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("host"), host, l_host);
     zend_update_property_bool(swoole_http_server_coro_ce, SW_Z8_OBJ_P(ZEND_THIS), ZEND_STRL("ssl"), ssl);
 
@@ -338,7 +344,6 @@ static PHP_METHOD(swoole_http_server_coro, __construct) {
         RETURN_FALSE;
     }
 
-    HttpServerObject *hsc = http_server_coro_fetch_object(Z_OBJ_P(ZEND_THIS));
     std::string host_str(host, l_host);
     hsc->server = new HttpServer(swoole::network::Socket::convert_to_type(host_str));
     Socket *sock = hsc->server->socket;

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -376,6 +376,12 @@ static PHP_METHOD(swoole_process_pool, __construct) {
         RETURN_FALSE;
     }
 
+    auto pp = process_pool_fetch_object(ZEND_THIS);
+    if (pp->pool) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        RETURN_FALSE;
+    }
+
     if (worker_num <= 0) {
         zend_throw_exception_ex(swoole_exception_ce, errno, "the parameter $worker_num must be greater than 0");
         RETURN_FALSE;
@@ -398,7 +404,6 @@ static PHP_METHOD(swoole_process_pool, __construct) {
     pool->ptr = sw_zval_dup(zobject);
     pool->async = enable_coroutine;
 
-    auto pp = process_pool_fetch_object(ZEND_THIS);
     pp->enable_coroutine = enable_coroutine;
     pp->pool = pool;
 }

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -46,6 +46,7 @@ using swoole::Thread;
 
 struct PhpThread {
     std::shared_ptr<Thread> thread;
+    bool constructed = false;
 
     PhpThread() : thread(std::make_shared<Thread>()) {}
 
@@ -192,12 +193,17 @@ static PHP_METHOD(swoole_thread, __construct) {
     Z_PARAM_VARIADIC('+', args, argc)
     ZEND_PARSE_PARAMETERS_END();
 
+    auto pt = thread_get_php_thread(ZEND_THIS);
+    if (pt->constructed) {
+        zend_throw_error(nullptr, "Constructor of %s can only be called once", SW_Z_OBJCE_NAME_VAL_P(ZEND_THIS));
+        return;
+    }
+
     if (l_script_file < 1) {
         zend_throw_exception(swoole_exception_ce, "exec file name is empty", SW_ERROR_INVALID_PARAMS);
         return;
     }
 
-    auto pt = thread_get_php_thread(ZEND_THIS);
     zend_string *file = zend_string_init(script_file, l_script_file, true);
 
     if (argc > 0) {
@@ -214,6 +220,7 @@ static PHP_METHOD(swoole_thread, __construct) {
         return;
     }
 
+    pt->constructed = true;
     zend::object_set(ZEND_THIS, ZEND_STRL("id"), (zend_long) pt->thread->get_id());
 }
 

--- a/tests/swoole_http2_client_coro/construct_twice.phpt
+++ b/tests/swoole_http2_client_coro/construct_twice.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_http2_client_coro: construct twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http2\Client;
+
+$client = new Client('127.0.0.1', 80);
+
+try {
+    $client->__construct('localhost', 80);
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Constructor of Swoole\Coroutine\Http2\Client can only be called once

--- a/tests/swoole_http_client_coro/construct_twice.phpt
+++ b/tests/swoole_http_client_coro/construct_twice.phpt
@@ -1,0 +1,22 @@
+--TEST--
+swoole_http_client_coro: construct twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http\Client;
+
+$client = new Client('127.0.0.1', 80);
+
+try {
+    $client->__construct('localhost', 80);
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+Assert::same($client->host, '127.0.0.1');
+?>
+--EXPECT--
+Constructor of Swoole\Coroutine\Http\Client can only be called once

--- a/tests/swoole_http_server/cookie_construct_twice.phpt
+++ b/tests/swoole_http_server/cookie_construct_twice.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_http_server: construct cookie twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Http\Cookie;
+
+$cookie = new Cookie();
+
+try {
+    $cookie->__construct(false);
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Constructor of Swoole\Http\Cookie can only be called once

--- a/tests/swoole_http_server_coro/construct_twice.phpt
+++ b/tests/swoole_http_server_coro/construct_twice.phpt
@@ -1,0 +1,22 @@
+--TEST--
+swoole_http_server_coro: construct twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Http\Server;
+
+$server = new Server('127.0.0.1', 0);
+
+try {
+    $server->__construct('0.0.0.0', 0);
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+Assert::same($server->host, '127.0.0.1');
+?>
+--EXPECT--
+Constructor of Swoole\Coroutine\Http\Server can only be called once

--- a/tests/swoole_process_pool/construct_twice.phpt
+++ b/tests/swoole_process_pool/construct_twice.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_process_pool: construct twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process\Pool;
+
+$pool = new Pool(1);
+
+try {
+    $pool->__construct(1);
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Constructor of Swoole\Process\Pool can only be called once

--- a/tests/swoole_thread/construct_twice.phpt
+++ b/tests/swoole_thread/construct_twice.phpt
@@ -1,0 +1,25 @@
+--TEST--
+swoole_thread: construct twice
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_nts();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Thread;
+
+$thread = new Thread(TESTS_API_PATH . '/swoole_thread/sleep.php');
+
+try {
+    $thread->__construct(TESTS_API_PATH . '/swoole_thread/sleep.php');
+} catch (Error $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+$thread->join();
+?>
+--EXPECT--
+Constructor of Swoole\Thread can only be called once


### PR DESCRIPTION
Several public constructors replace native state when called more than once. This leaks clients, listeners, process-pool resources, or cookies. Calling `Thread::__construct()` twice terminates the process.

Reject repeated construction after parsing arguments, matching Swoole objects that already enforce one construction. Thread keeps a construction marker because its wrapper exists before `__construct()`.

Tests cover each affected class and verify that existing public state is not rewritten.