### PR TITLE
Preserve package limits across partial socket settings

### DIFF
--- a/ext-src/swoole_socket_coro.cc
+++ b/ext-src/swoole_socket_coro.cc
@@ -997,8 +997,6 @@ SW_API bool php_swoole_socket_set_protocol(Socket *sock, const zval *zset) {
     if (php_swoole_array_get_value(vht, "package_max_length", ztmp)) {
         zend_long v = php_swoole_parse_to_size(ztmp);
         sock->protocol.package_max_length = SW_MAX(0, SW_MIN(v, UINT32_MAX));
-    } else {
-        sock->protocol.package_max_length = SW_INPUT_BUFFER_SIZE;
     }
 
     return ret;

--- a/tests/swoole_client_coro/package_max_length_partial_setting.phpt
+++ b/tests/swoole_client_coro/package_max_length_partial_setting.phpt
@@ -1,0 +1,57 @@
+--TEST--
+swoole_client_coro: preserve package_max_length after partial settings
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+const PACKAGE_MAX_LENGTH = 1024;
+
+Co::set(['log_level' => SWOOLE_LOG_ERROR]);
+
+$pm = new SwooleTest\ProcessManager;
+
+$pm->parentFunc = function ($pid) use ($pm) {
+    go(function () use ($pm) {
+        $client = new Swoole\Coroutine\Client(SWOOLE_SOCK_TCP);
+        $client->set([
+            'open_length_check' => true,
+            'package_length_type' => 'N',
+            'package_length_offset' => 0,
+            'package_body_offset' => 4,
+            'package_max_length' => PACKAGE_MAX_LENGTH,
+        ]);
+        Assert::true($client->connect('127.0.0.1', $pm->getFreePort()));
+        $client->set(['timeout' => 1]);
+        Assert::false($client->recv());
+        Assert::same($client->errCode, SWOOLE_ERROR_PACKAGE_LENGTH_TOO_LARGE);
+    });
+    Swoole\Event::wait();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $server = new Swoole\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_BASE);
+    $server->set([
+        'worker_num' => 1,
+        'log_file' => '/dev/null',
+    ]);
+    $server->on('WorkerStart', function () use ($pm) {
+        $pm->wakeup();
+    });
+    $server->on('Connect', function (Swoole\Server $server, int $fd) {
+        $data = str_repeat('A', PACKAGE_MAX_LENGTH * 2);
+        $server->send($fd, pack('N', strlen($data)) . $data);
+    });
+    $server->on('Receive', function () {
+    });
+    $server->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
Coroutine socket protocol settings are partial updates, but omitting `package_max_length` reset it to the default. On a connected client, changing an unrelated setting could silently raise a lower packet limit or lower a larger one.

Keep the current limit unless `package_max_length` is supplied. Socket construction still initializes the existing default.

The regression configures a smaller limit, changes only the timeout on the live client, and verifies that an oversized packet is still rejected.
