### PR TITLE
Preserve HTTP request fields across parse calls

### DIFF
--- a/ext-src/php_swoole_http.h
+++ b/ext-src/php_swoole_http.h
@@ -90,6 +90,13 @@ class Session;
 }  // namespace http2
 
 namespace http {
+struct RequestParserState {
+    size_t url_length;
+    size_t header_name_offset;
+    size_t header_name_length;
+    size_t header_value_length;
+};
+
 struct Request {
     int version;
     char *path;
@@ -103,6 +110,7 @@ struct Request {
     size_t body_length;
     String *chunked_body;
     String *h2_data_buffer;
+    RequestParserState *parser_state;
 
     // Notice: Do not change the order
     zval *zobject;

--- a/ext-src/swoole_http_request.cc
+++ b/ext-src/swoole_http_request.cc
@@ -47,6 +47,9 @@ static int http_request_on_header_field(llhttp_t *parser, const char *at, size_t
 static int http_request_on_header_value(llhttp_t *parser, const char *at, size_t length);
 static int http_request_on_headers_complete(llhttp_t *parser);
 static int http_request_message_complete(llhttp_t *parser);
+static int http_request_parse_on_url(llhttp_t *parser, const char *at, size_t length);
+static int http_request_parse_on_header_field(llhttp_t *parser, const char *at, size_t length);
+static int http_request_parse_on_header_value(llhttp_t *parser, const char *at, size_t length);
 
 static int multipart_body_on_header_field(multipart_parser *p, const char *at, size_t length);
 static int multipart_body_on_header_value(multipart_parser *p, const char *at, size_t length);
@@ -117,6 +120,35 @@ static constexpr llhttp_settings_t http_parser_settings =
     nullptr,                                // on_chunk_header
     nullptr,                                // on_chunk_complete
     nullptr,                                // on_reset
+};
+
+static constexpr llhttp_settings_t http_request_parser_settings =
+{
+    nullptr,                                      // on_message_begin
+    nullptr,                                      // on_protocol
+    http_request_parse_on_url,                    // on_url
+    nullptr,                                      // on_status
+    nullptr,                                      // on_method
+    nullptr,                                      // on_version
+    http_request_parse_on_header_field,           // on_header_field
+    http_request_parse_on_header_value,           // on_header_value
+    nullptr,                                      // on_chunk_extension_name
+    nullptr,                                      // on_chunk_extension_value
+    http_request_on_headers_complete,             // on_headers_complete
+    http_request_on_body,                         // on_body
+    http_request_message_complete,                // on_message_complete
+    nullptr,                                      // on_protocol_complete
+    nullptr,                                      // on_url_complete
+    nullptr,                                      // on_status_complete
+    nullptr,                                      // on_method_complete
+    nullptr,                                      // on_version_complete
+    nullptr,                                      // on_header_field_complete
+    nullptr,                                      // on_header_value_complete
+    nullptr,                                      // on_chunk_extension_name_complete
+    nullptr,                                      // on_chunk_extension_value_complete
+    nullptr,                                      // on_chunk_header
+    nullptr,                                      // on_chunk_complete
+    nullptr,                                      // on_reset
 };
 
 static constexpr multipart_parser_settings mt_parser_settings =
@@ -286,6 +318,47 @@ static int http_request_on_header_field(llhttp_t *parser, const char *at, size_t
     ctx->current_header_name = at;
     ctx->current_header_name_len = length;
     return 0;
+}
+
+static int http_request_parse_on_url(llhttp_t *parser, const char *at, size_t length) {
+    auto *ctx = static_cast<HttpContext *>(parser->data);
+    auto *state = ctx->request.parser_state;
+    state->url_length += length;
+
+    // llhttp flushes unfinished spans at the end of each input buffer.
+    if (at + length == Z_STRVAL(ctx->request.zdata) + Z_STRLEN(ctx->request.zdata)) {
+        return 0;
+    }
+
+    return http_request_on_url(parser, at + length - state->url_length, state->url_length);
+}
+
+static int http_request_parse_on_header_field(llhttp_t *parser, const char *at, size_t length) {
+    auto *ctx = static_cast<HttpContext *>(parser->data);
+    auto *state = ctx->request.parser_state;
+    if (state->header_name_length == 0) {
+        state->header_name_offset = static_cast<size_t>(at - Z_STRVAL(ctx->request.zdata));
+    }
+    state->header_name_length += length;
+    return 0;
+}
+
+static int http_request_parse_on_header_value(llhttp_t *parser, const char *at, size_t length) {
+    auto *ctx = static_cast<HttpContext *>(parser->data);
+    auto *state = ctx->request.parser_state;
+    state->header_value_length += length;
+    if (at + length == Z_STRVAL(ctx->request.zdata) + Z_STRLEN(ctx->request.zdata)) {
+        return 0;
+    }
+
+    const char *header_name = Z_STRVAL(ctx->request.zdata) + state->header_name_offset;
+    http_request_on_header_field(parser, header_name, state->header_name_length);
+
+    int result =
+        http_request_on_header_value(parser, at + length - state->header_value_length, state->header_value_length);
+    state->header_name_length = 0;
+    state->header_value_length = 0;
+    return result;
 }
 
 bool HttpContext::init_multipart_parser(const char *boundary_str, int boundary_len) {
@@ -939,6 +1012,7 @@ static PHP_METHOD(swoole_http_request, create) {
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
     auto *ctx = new HttpContext();
+    ctx->request.parser_state = new swoole::http::RequestParserState();
     object_init_ex(return_value, swoole_http_request_ce);
     zval *zrequest_object = &ctx->request._zobject;
     ctx->request.zobject = zrequest_object;
@@ -1023,7 +1097,10 @@ static PHP_METHOD(swoole_http_request, parse) {
         ZVAL_STR(&ctx->request.zdata, new_str);
     }
 
-    RETURN_LONG(ctx->parse(str, l_str));
+    RETURN_LONG(swoole_llhttp_parser_execute(&ctx->parser,
+                                             &http_request_parser_settings,
+                                             Z_STRVAL(ctx->request.zdata) + Z_STRLEN(ctx->request.zdata) - l_str,
+                                             l_str));
 }
 
 static PHP_METHOD(swoole_http_request, getMethod) {

--- a/ext-src/swoole_http_server.cc
+++ b/ext-src/swoole_http_server.cc
@@ -324,6 +324,7 @@ void HttpContext::free() {
 
     delete req->chunked_body;
     delete req->h2_data_buffer;
+    delete req->parser_state;
 
     if (res->reason) {
         efree(res->reason);

--- a/tests/swoole_http_server/create_request.phpt
+++ b/tests/swoole_http_server/create_request.phpt
@@ -65,5 +65,25 @@ $req3 = Request::create();
 $req3->parse($data);
 Assert::eq("POST", $req3->getMethod());
 
+$body = 'first=one&second=two';
+$data .= "Content-Type: application/x-www-form-urlencoded\r\n";
+$data .= "Content-Length: " . strlen($body) . "\r\n\r\n";
+$data .= $body;
+
+$req4 = Request::create();
+$req4->parse($data);
+
+for ($offset = 1; $offset < strlen($data); ++$offset) {
+    $req = Request::create();
+    Assert::eq($req->parse(substr($data, 0, $offset)), $offset);
+    Assert::eq($req->parse(substr($data, $offset)), strlen($data) - $offset);
+    Assert::true($req->isCompleted());
+    Assert::eq($req->server['request_uri'], $req4->server['request_uri']);
+    Assert::eq($req->get, $req4->get);
+    Assert::eq($req->header, $req4->header);
+    Assert::eq($req->cookie, $req4->cookie);
+    Assert::eq($req->post, $req4->post);
+}
+
 ?>
 --EXPECT--


### PR DESCRIPTION
`Swoole\Http\Request::parse()` retained each chunk but passed the caller's temporary string to llhttp. A URL, header, or body split between calls could corrupt the parsed request; a header name could also be read after its string was released.

Parse each appended range from the request's retained buffer and rebuild spans only for the standalone parser. Normal server parsing remains unchanged.

The regression compares one-call parsing with every possible two-chunk split of a representative form request. The unchanged code fails those comparisons. To reproduce the released header-name read, build the unchanged `6.1` tree with ASAN, switch the source tree to this branch without rebuilding, and run:

```sh
LD_PRELOAD="$(cc -print-file-name=libasan.so)" \
ASAN_OPTIONS=detect_leaks=0 \
USE_ZEND_ALLOC=0 \
PHPT=1 \
TEST_PHP_ARGS="-n -d extension=sockets -d extension=$PWD/modules/swoole.so" \
php -n run-tests.php -q --show-diff tests/swoole_http_server/create_request.phpt
```

The unchanged build reports `heap-use-after-free` in `strncasecmp`; rebuilding this branch passes the same test.
