### PR TITLE
Wait for SSH2 shell exit status before EOF

### DIFF
--- a/tests/swoole_ssh2/ssh2_shell_completion.phpt
+++ b/tests/swoole_ssh2/ssh2_shell_completion.phpt
@@ -1,0 +1,33 @@
+--TEST--
+ssh2_shell() waits for the remote exit status
+--SKIPIF--
+<?php require_once 'ssh2_skip.inc';
+ssh2t_needs_auth(); ?>
+--FILE--
+<?php
+require_once 'ssh2_test.inc';
+
+Co\run(function () {
+    $session = ssh2_connect(TEST_SSH2_HOSTNAME, TEST_SSH2_PORT);
+
+    if ($session === false || !ssh2t_auth($session)) {
+        throw new RuntimeException('Failed to connect to the SSH fixture.');
+    }
+
+    $shell = ssh2_shell($session);
+
+    if ($shell === false) {
+        throw new RuntimeException('Failed to open the shell channel.');
+    }
+
+    fwrite($shell, "exec sh -c 'exec 0<&- 1>&- 2>&-; sleep 1; exit 23'\n");
+    stream_get_contents($shell);
+
+    var_dump(stream_get_meta_data($shell)['exit_status']);
+
+    fclose($shell);
+    ssh2_disconnect($session);
+});
+?>
+--EXPECT--
+int(23)

--- a/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
+++ b/thirdparty/php/ssh2/ssh2_fopen_wrappers.cc
@@ -678,7 +678,7 @@ static php_stream *php_ssh2_shell_open(LIBSSH2_SESSION *session,
     }
 
     /* Turn it into a stream */
-    channel_data = php_ssh2_channel_data_create(channel, resource, false);
+    channel_data = php_ssh2_channel_data_create(channel, resource, true);
 
     stream = php_stream_alloc(&php_ssh2_channel_stream_ops, channel_data, 0, "r+");
 


### PR DESCRIPTION
`ssh2_shell()` streams can report EOF before libssh2 processes the remote exit status, so `stream_get_meta_data()` can return `exit_status` 0 after draining a shell that failed.

Shell streams now use the existing remote-close completion path already used by exec streams. Reads before remote EOF are unchanged.

The regression closes the remote terminal descriptors before a delayed non-zero exit. It reports 0 on unchanged master and 23 with this change.