### PR TITLE
Restore Server CPU affinity

### DIFF
--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -634,6 +634,21 @@ void Server::destroy_worker(Worker *worker) {
  * [Worker]
  */
 void Server::init_event_worker(Worker *worker) const {
+#ifdef HAVE_CPU_AFFINITY
+    if (open_cpu_affinity && !is_thread_mode()) {
+        cpu_set_t cpu_set;
+        CPU_ZERO(&cpu_set);
+        if (cpu_affinity_available_num) {
+            CPU_SET(cpu_affinity_available[worker->id % cpu_affinity_available_num], &cpu_set);
+        } else {
+            CPU_SET(worker->id % SW_CPU_NUM, &cpu_set);
+        }
+        if (swoole_set_cpu_affinity(&cpu_set) < 0) {
+            swoole_sys_warning("swoole_set_cpu_affinity() failed");
+        }
+    }
+#endif
+
     worker->init();
     worker->set_max_request(max_request, max_request_grace);
 }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -848,6 +848,23 @@ void Server::reactor_thread_main_loop(Server *serv, int reactor_id) {
         return;
     }
 
+#ifdef HAVE_CPU_AFFINITY
+    if (serv->open_cpu_affinity) {
+        cpu_set_t cpu_set;
+        CPU_ZERO(&cpu_set);
+        if (serv->cpu_affinity_available_num) {
+            CPU_SET(serv->cpu_affinity_available[reactor_id % serv->cpu_affinity_available_num], &cpu_set);
+        } else {
+            CPU_SET(reactor_id % SW_CPU_NUM, &cpu_set);
+        }
+        int error = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set), &cpu_set);
+        if (error != 0) {
+            errno = error;
+            swoole_sys_warning("pthread_setaffinity_np() failed");
+        }
+    }
+#endif
+
     if (serv->is_thread_mode()) {
         serv->call_worker_start_callback(serv->get_worker(reactor_id));
     } else {

--- a/tests/swoole_server/cpu_affinity.phpt
+++ b/tests/swoole_server/cpu_affinity.phpt
@@ -1,0 +1,32 @@
+--TEST--
+swoole_server: bind event workers to available CPUs
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_no_process_affinity();
+$affinity = Swoole\Process::getAffinity();
+skip('requires CPUs 0 and 1', !in_array(0, $affinity) || !in_array(1, $affinity));
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+use Swoole\Server;
+
+$server = new Server('127.0.0.1', get_constant_port(__FILE__), SWOOLE_BASE);
+$server->set(array(
+    'worker_num' => 1,
+    'open_cpu_affinity' => true,
+    'cpu_affinity_ignore' => array(0),
+    'log_file' => '/dev/null',
+));
+$server->on('WorkerStart', function (Server $server) {
+    echo implode(',', Process::getAffinity()), PHP_EOL;
+    $server->shutdown();
+});
+$server->on('Receive', function () {});
+$server->start();
+?>
+--EXPECT--
+1

--- a/tests/swoole_thread/server/cpu_affinity.phpt
+++ b/tests/swoole_thread/server/cpu_affinity.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_thread/server: bind event workers to available CPUs
+--SKIPIF--
+<?php
+require __DIR__ . '/../../include/skipif.inc';
+skip_if_nts();
+skip('no thread affinity', !method_exists(Swoole\Thread::class, 'getAffinity'));
+$affinity = Swoole\Thread::getAffinity();
+skip('requires CPUs 0 and 1', !in_array(0, $affinity) || !in_array(1, $affinity));
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../include/bootstrap.php';
+
+use Swoole\Thread;
+use Swoole\Thread\Queue;
+
+$port = get_constant_port(__FILE__);
+$server = new Swoole\Http\Server('127.0.0.1', $port, SWOOLE_THREAD);
+$server->set(array(
+    'worker_num' => 1,
+    'open_cpu_affinity' => true,
+    'cpu_affinity_ignore' => array(0),
+    'log_level' => SWOOLE_LOG_ERROR,
+    'init_arguments' => function () {
+        return [new Queue()];
+    },
+));
+$server->on('WorkerStart', function () {
+    [$queue] = Thread::getArguments();
+    echo implode(',', Thread::getAffinity()), PHP_EOL;
+    $queue->push(true, Queue::NOTIFY_ALL);
+});
+$server->on('Request', function ($request, $response) {
+    $response->end('OK');
+});
+$server->addProcess(new Swoole\Process(function () use ($server, $port) {
+    [$queue] = Thread::getArguments();
+    $queue->pop(-1);
+    Assert::eq(file_get_contents("http://127.0.0.1:{$port}/"), 'OK');
+    $server->shutdown();
+}));
+$server->start();
+?>
+--EXPECT--
+1


### PR DESCRIPTION
`open_cpu_affinity` and `cpu_affinity_ignore` are still accepted and documented, but #5320 removed the code that applied them, so enabling them has had no effect since 6.0.

This restores the previous binding at the current startup points. Process-mode and base-mode event workers use the process affinity call, and reactor threads use `pthread_setaffinity_np()`. Thread-mode workers run in the reactor thread entry, so they are bound there instead of through the process call. Configurations that already enable `open_cpu_affinity` will bind workers and reactor threads again.

The regressions start a base-mode worker and a thread-mode worker with `cpu_affinity_ignore` set to `[0]` and check that each is bound to CPU 1.