### PR TITLE
Reject message queue keys outside key_t

### DIFF
--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -384,6 +384,11 @@ static PHP_METHOD(swoole_process, useQueue) {
 
     Worker *process = php_swoole_process_get_and_check_worker(ZEND_THIS);
 
+    if (msgkey > 0 && (zend_ulong) (std::make_unsigned<key_t>::type) msgkey != (zend_ulong) msgkey) {
+        php_swoole_fatal_error(E_WARNING, "message queue key is out of range [" ZEND_LONG_FMT "]", (zend_long) msgkey);
+        RETURN_FALSE;
+    }
+
     if (msgkey <= 0) {
         msgkey = ftok(zend_get_executed_filename(), 1);
     }

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -381,6 +381,12 @@ static PHP_METHOD(swoole_process_pool, __construct) {
         RETURN_FALSE;
     }
 
+    if (ipc_type == SW_IPC_MSGQUEUE && (zend_long) (key_t) msgq_key != msgq_key &&
+        (zend_ulong) (std::make_unsigned<key_t>::type) msgq_key != (zend_ulong) msgq_key) {
+        zend_throw_exception_ex(swoole_exception_ce, errno, "the parameter $msgqueue_key is out of range");
+        RETURN_FALSE;
+    }
+
     if (enable_coroutine && ipc_type > 0 && ipc_type != SW_IPC_UNIXSOCK) {
         ipc_type = SW_IPC_UNIXSOCK;
         zend_throw_error(nullptr, "the parameter $ipc_type must be SWOOLE_IPC_UNIXSOCK when enable coroutine");

--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2390,6 +2390,10 @@ static PHP_METHOD(swoole_server, set) {
     // message queue key
     if (php_swoole_array_get_value(vht, "message_queue_key", ztmp)) {
         zend_long v = zval_get_long(ztmp);
+        if (v > 0 && (zend_ulong) (std::make_unsigned<key_t>::type) v != (zend_ulong) v) {
+            php_swoole_fatal_error(E_ERROR, "message_queue_key is out of range");
+            RETURN_FALSE;
+        }
         serv->message_queue_key = SW_MAX(0, SW_MIN(v, INT64_MAX));
     }
 #ifdef SW_THREAD

--- a/tests/swoole_process/message_queue_key_range.phpt
+++ b/tests/swoole_process/message_queue_key_range.phpt
@@ -1,0 +1,17 @@
+--TEST--
+swoole_process: reject message queue keys outside key_t
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_linux();
+skip('64-bit only', PHP_INT_SIZE < 8);
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$process = new Swoole\Process(function () {});
+var_dump(@$process->useQueue(1 << 32));
+?>
+--EXPECT--
+bool(false)

--- a/tests/swoole_process_pool/message_queue_key_range.phpt
+++ b/tests/swoole_process_pool/message_queue_key_range.phpt
@@ -1,0 +1,20 @@
+--TEST--
+swoole_process_pool: reject message queue keys outside key_t
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_linux();
+skip('64-bit only', PHP_INT_SIZE < 8);
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+try {
+    new Swoole\Process\Pool(1, SWOOLE_IPC_MSGQUEUE, 1 << 32);
+} catch (Swoole\Exception $exception) {
+    echo $exception->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+the parameter $msgqueue_key is out of range

--- a/tests/swoole_server/message_queue_key_range.phpt
+++ b/tests/swoole_server/message_queue_key_range.phpt
@@ -1,0 +1,18 @@
+--TEST--
+swoole_server: reject message queue keys outside key_t
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_linux();
+skip('64-bit only', PHP_INT_SIZE < 8);
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+$server = new Swoole\Server('127.0.0.1', get_constant_port(__FILE__), SWOOLE_BASE);
+Assert::true($server->set(['message_queue_key' => 0xffffffff]));
+$server->set(['message_queue_key' => 1 << 32]);
+?>
+--EXPECTF--
+Fatal error: %s: message_queue_key is out of range in %s on line %d


### PR DESCRIPTION
`Server::set()`'s `message_queue_key`, `Process::useQueue()`, and `Process\Pool` with `SWOOLE_IPC_MSGQUEUE` accept PHP integers but pass them to `msgget()` as `key_t`. On Linux, where `key_t` is 32 bits, distinct integers can open the same queue: `useQueue(0x123456)` and `useQueue(0x100123456)` return the same queue ID, and `1 << 32` becomes `IPC_PRIVATE`.

Each entry point now rejects a key that does not fit in `key_t`, using its existing error style. Unsigned 32-bit keys such as `0xffffffff` remain accepted, and Pool only checks the key when it uses a message queue.

The regressions pass `1 << 32` to each API on 64-bit Linux.
