### PR TITLE
Reuse ProcessPool message bus across starts

### DIFF
--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -594,7 +594,7 @@ static PHP_METHOD(swoole_process_pool, start) {
 #endif
 
     if (pp->enable_message_bus) {
-        if (pool->create_message_bus() != SW_OK) {
+        if (pool->message_bus == nullptr && pool->create_message_bus() != SW_OK) {
             RETURN_FALSE;
         }
         pool->message_bus->set_allocator(sw_zend_string_allocator());

--- a/tests/swoole_process_pool/message_bus_start_twice.phpt
+++ b/tests/swoole_process_pool/message_bus_start_twice.phpt
@@ -1,0 +1,32 @@
+--TEST--
+swoole_process_pool: start message bus twice
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Constant;
+use Swoole\Process\Pool;
+
+$pool = new Pool(1, SWOOLE_IPC_UNIXSOCK);
+$pool->set([
+    'enable_message_bus' => true,
+]);
+
+$pool->on(Constant::EVENT_WORKER_START, function (Pool $pool) {
+    Assert::true($pool->sendMessage('hello', 0));
+});
+
+$pool->on(Constant::EVENT_MESSAGE, function (Pool $pool, string $data) {
+    Assert::same($data, 'hello');
+    echo "DONE\n";
+    $pool->shutdown();
+});
+
+$pool->start();
+$pool->start();
+?>
+--EXPECT--
+DONE
+DONE


### PR DESCRIPTION
A Process Pool can be started again after shutdown, but enabling the message bus made the second start fail because `start()` tried to create the object-owned bus again.

Reuse the existing bus and cover message delivery across two starts of the same pool.

Tests:
- `tests/swoole_process_pool/message_bus_start_twice.phpt`