### PR TITLE
Release BASE event pool resources after shutdown

### DIFF
--- a/core-tests/src/server/server.cpp
+++ b/core-tests/src/server/server.cpp
@@ -2783,6 +2783,23 @@ TEST(server, startup_error) {
     ASSERT_NE(strstr(server->get_startup_error_message(), "require 'onPacket' callback"), nullptr);
 }
 
+TEST(server, base_event_worker_pool_cleanup) {
+    Server server(Server::MODE_BASE);
+    server.worker_num = 2;
+    ASSERT_NE(server.add_port(SW_SOCK_TCP, TEST_HOST, 0), nullptr);
+    ASSERT_EQ(server.create(), SW_OK);
+
+    server.onReceive = [](Server *server, RecvData *req) -> int { return SW_OK; };
+    server.onManagerStart = [](Server *server) {
+        swoole_timer_after(50, [server](TIMER_PARAMS) { server->shutdown(); });
+    };
+
+    ASSERT_EQ(server.start(), SW_OK);
+    ASSERT_EQ(server.get_event_worker_pool()->pipes, nullptr);
+    ASSERT_EQ(server.get_event_worker_pool()->map_, nullptr);
+    ASSERT_EQ(server.get_event_worker_pool()->message_box, nullptr);
+}
+
 TEST(server, abort_worker) {
     Server *server = new Server(Server::MODE_BASE);
     server->worker_num = 2;

--- a/src/server/manager.cc
+++ b/src/server/manager.cc
@@ -55,7 +55,8 @@ int Server::start_manager_process() {
         return SW_ERR;
     }
 
-    if (get_event_worker_pool()->create_message_box(SW_MESSAGE_BOX_SIZE) == SW_ERR) {
+    if (get_event_worker_pool()->message_box == nullptr &&
+        get_event_worker_pool()->create_message_box(SW_MESSAGE_BOX_SIZE) == SW_ERR) {
         return SW_ERR;
     }
 

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -88,7 +88,11 @@ int Server::start_reactor_processes() {
         return retval;
     }
 
-    return start_manager_process();
+    int retval = start_manager_process();
+    if (retval == SW_OK) {
+        pool->destroy();
+    }
+    return retval;
 }
 
 static int ReactorProcess_onPipeRead(Reactor *reactor, Event *event) {


### PR DESCRIPTION
Multi-worker BASE servers left their event ProcessPool pipes, map, and message box allocated after shutdown. They also replaced the message box created with the pool.

Reuse the existing message box and release the pool after the manager finishes.

Tests:
- `server.base_event_worker_pool_cleanup`
- `server.base`
- `server.task_base`
- `server.reactor_num_base`
- `server.process`