### PR TITLE
Restore ProcessPool signal dispositions after start

### DIFF
--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -580,17 +580,23 @@ static PHP_METHOD(swoole_process_pool, start) {
     }
 
     ProcessPoolObject *pp = process_pool_fetch_object(ZEND_THIS);
-    std::unordered_map<int, swSignalHandler> ori_handlers;
+    std::unordered_map<int, struct sigaction> ori_handlers;
 
     // The reactor must be cleaned up before registering signal
     swoole_event_free();
-    ori_handlers[SIGTERM] = swoole_signal_set(SIGTERM, process_pool_signal_handler);
-    ori_handlers[SIGUSR1] = swoole_signal_set(SIGUSR1, process_pool_signal_handler);
-    ori_handlers[SIGUSR2] = swoole_signal_set(SIGUSR2, process_pool_signal_handler);
-    ori_handlers[SIGIO] = swoole_signal_set(SIGIO, process_pool_signal_handler);
-    ori_handlers[SIGWINCH] = swoole_signal_set(SIGWINCH, process_pool_signal_handler);
+    sigaction(SIGTERM, nullptr, &ori_handlers[SIGTERM]);
+    swoole_signal_set(SIGTERM, process_pool_signal_handler);
+    sigaction(SIGUSR1, nullptr, &ori_handlers[SIGUSR1]);
+    swoole_signal_set(SIGUSR1, process_pool_signal_handler);
+    sigaction(SIGUSR2, nullptr, &ori_handlers[SIGUSR2]);
+    swoole_signal_set(SIGUSR2, process_pool_signal_handler);
+    sigaction(SIGIO, nullptr, &ori_handlers[SIGIO]);
+    swoole_signal_set(SIGIO, process_pool_signal_handler);
+    sigaction(SIGWINCH, nullptr, &ori_handlers[SIGWINCH]);
+    swoole_signal_set(SIGWINCH, process_pool_signal_handler);
 #ifdef SIGRTMIN
-    ori_handlers[SIGRTMIN] = swoole_signal_set(SIGRTMIN, process_pool_signal_handler);
+    sigaction(SIGRTMIN, nullptr, &ori_handlers[SIGRTMIN]);
+    swoole_signal_set(SIGRTMIN, process_pool_signal_handler);
 #endif
 
     if (pp->enable_message_bus) {
@@ -645,7 +651,8 @@ static PHP_METHOD(swoole_process_pool, start) {
     current_pool = nullptr;
 
     for (auto &ori_handler : ori_handlers) {
-        swoole_signal_set(ori_handler.first, ori_handler.second);
+        swoole_signal_set(ori_handler.first, reinterpret_cast<swSignalHandler>(-1), 0, 0);
+        sigaction(ori_handler.first, &ori_handler.second, nullptr);
     }
 }
 

--- a/tests/swoole_process_pool/restore_signal_disposition.phpt
+++ b/tests/swoole_process_pool/restore_signal_disposition.phpt
@@ -1,0 +1,34 @@
+--TEST--
+swoole_process_pool: restore signal disposition
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_not_linux();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Process;
+use Swoole\Process\Pool;
+
+$process = new Process(function () {
+    $pool = new Pool(1);
+    $pool->on('workerStart', function (Pool $pool) {
+        $pool->shutdown();
+    });
+    $pool->start();
+
+    Process::kill(getmypid(), SIGIO);
+    usleep(100000);
+    exit(99);
+});
+
+$process->start();
+$status = Process::wait();
+
+Assert::same($status['signal'], SIGIO);
+echo "DONE\n";
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
`Process\Pool::start()` temporarily replaces its control-signal handlers. It restored only the previous handler pointer through Swoole's callback registration path, so signals that originally used `SIG_DFL` remained routed through an empty Swoole callback after the pool stopped.

Save and restore each complete signal action, and clear the temporary Swoole registry entry before restoring it. This preserves the original handler, flags, and mask.

The regression runs the pool in an isolated child and verifies that Linux `SIGIO` returns to its default terminating behavior.
