### PR TITLE
Close duplicated standard IO handles after thread exit

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1304,8 +1304,10 @@ PHP_RSHUTDOWN_FUNCTION(swoole) {
         stream->flags |= PHP_STREAM_FLAG_NO_CLOSE;
     };
     /* do not close the stdout and stderr */
-    php_swoole_set_stdio_no_close(ZEND_STRL("STDOUT"));
-    php_swoole_set_stdio_no_close(ZEND_STRL("STDERR"));
+    if (sw_is_main_thread()) {
+        php_swoole_set_stdio_no_close(ZEND_STRL("STDOUT"));
+        php_swoole_set_stdio_no_close(ZEND_STRL("STDERR"));
+    }
 #endif
 
     return SUCCESS;

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -452,7 +452,7 @@ void php_swoole_thread_start(std::shared_ptr<Thread> thread, zend_string *file, 
             argv->to_array(&thread_argv);
             argv->del_ref();
         }
-        thread_register_stdio_file_handles(true);
+        thread_register_stdio_file_handles(false);
         php_execute_script(&file_handle);
     }
     zend_end_try();

--- a/tests/swoole_thread/stdio_close.phpt
+++ b/tests/swoole_thread/stdio_close.phpt
@@ -1,0 +1,31 @@
+--TEST--
+swoole_thread: stdio close
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_nts();
+skip_if_not_linux();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Thread;
+
+$tm = new \SwooleTest\ThreadManager();
+
+$tm->parentFunc = function () {
+    $count = count(scandir('/proc/self/fd'));
+    $thread = new Thread(__FILE__, 'child');
+    $thread->join();
+    Assert::eq(count(scandir('/proc/self/fd')), $count);
+    echo "DONE\n";
+};
+
+$tm->childFunc = function () {
+};
+
+$tm->run();
+?>
+--EXPECT--
+DONE


### PR DESCRIPTION
## Summary

Each PHP child thread opens its own `STDIN`, `STDOUT`, and `STDERR` streams. PHP duplicates the process descriptors for those streams, but Swoole marked the duplicates as non-closing during registration and request shutdown. Every completed thread therefore left three descriptors open. Thread-mode Server worker restarts followed the same path.

This change lets child request shutdown close its duplicated standard-I/O descriptors while preserving the main request's existing shutdown behavior.

## Testing

Added a Linux thread regression that compares the process descriptor count before starting a child thread and after joining it. It increases by three on the unchanged 6.1 branch and remains unchanged with this fix.

The existing thread standard-I/O test and representative user-thread and Server thread paths pass with the fix.
