### PR TITLE
Register WebSocket frame classes on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,6 +85,7 @@ jobs:
         shell: powershell
         run: |
           $tests = @(
+            'tests\swoole_http_server_coro\websocket_compression.phpt',
             'tests\swoole_windows\atomic_compat.phpt',
             'tests\swoole_windows\bootstrap.phpt',
             'tests\swoole_windows\iocp_cancel.phpt',

--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -1050,9 +1050,9 @@ PHP_MINIT_FUNCTION(swoole) {
     php_swoole_http_cookie_minit(module_number);
 #ifndef _WIN32
     php_swoole_http_server_minit(module_number);
-    php_swoole_websocket_server_minit(module_number);
     php_swoole_redis_server_minit(module_number);
 #endif
+    php_swoole_websocket_server_minit(module_number);
     php_swoole_http_server_coro_minit(module_number);
     php_swoole_name_resolver_minit(module_number);
 #ifdef SW_USE_PGSQL


### PR DESCRIPTION
The coroutine HTTP client and server are available on Windows, but the WebSocket frame classes and constants they use are not registered. Code using the `SWOOLE_WEBSOCKET_*` constants fails, and receiving a frame or pushing an object from the client passes a null class entry to PHP and crashes.

This registers the platform-independent frame classes and constants on Windows while keeping the native WebSocket server unavailable there. The existing coroutine WebSocket test now runs in the Windows suite and covers frame receive on both client and server paths.