### PR TITLE
Preserve the current Thread scheduling policy

### DIFF
--- a/ext-src/stubs/php_swoole_thread.stub.php
+++ b/ext-src/stubs/php_swoole_thread.stub.php
@@ -21,7 +21,7 @@ namespace Swoole {
         public static function setAffinity(array $cpu_settings): bool {}
         public static function getAffinity(): array {}
         #endif
-        public static function setPriority(int $priority, int $policy = 0): bool {}
+        public static function setPriority(int $priority, int $policy = -1): bool {}
         public static function getPriority(): array {}
         public static function getNativeId(): int {}
     }

--- a/ext-src/stubs/php_swoole_thread_arginfo.h
+++ b/ext-src/stubs/php_swoole_thread_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 46ec6a19af2d6a669e9c74651c12805626f832c8 */
+ * Stub hash: c365efcb773785337bad5e82365c0f40d7b433bb */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Thread___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, script_file, IS_STRING, 0)
@@ -48,7 +48,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Thread_setPriority, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, priority, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, policy, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, policy, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Swoole_Thread_getPriority arginfo_class_Swoole_Thread_getInfo

--- a/ext-src/swoole_thread.cc
+++ b/ext-src/swoole_thread.cc
@@ -306,12 +306,13 @@ static PHP_METHOD(swoole_thread, setPriority) {
     ZEND_PARSE_PARAMETERS_END();
 
     struct sched_param param;
+    int sched_policy = policy;
     if (policy == -1) {
-        pthread_setschedparam(pthread_self(), policy, &param);
+        pthread_getschedparam(pthread_self(), &sched_policy, &param);
     }
 
     param.sched_priority = priority;
-    int retval = pthread_setschedparam(pthread_self(), policy, &param);
+    int retval = pthread_setschedparam(pthread_self(), sched_policy, &param);
     if (retval == 0) {
         RETURN_TRUE;
     } else {

--- a/tests/swoole_thread/priority.phpt
+++ b/tests/swoole_thread/priority.phpt
@@ -26,6 +26,11 @@ function test_thread_priority($priority, $policy)
     $r = Thread::getPriority();
     Assert::eq($r['policy'], $policy);
     Assert::eq($r['priority'], $priority);
+
+    Assert::assert(Thread::setPriority($priority + 1));
+    $r = Thread::getPriority();
+    Assert::eq($r['policy'], $policy);
+    Assert::eq($r['priority'], $priority + 1);
 }
 
 $tm->parentFunc = function () {


### PR DESCRIPTION
`Swoole\Thread::setPriority()` documents `-1` as leaving the current scheduling policy unchanged. The POSIX implementation calls `pthread_setschedparam()` while trying to read that policy, then calls it again with the invalid `-1` value. The one-argument form warns with `EINVAL` and returns `false`.

Use `pthread_getschedparam()` to retain the current policy before changing the priority, and align the stub default with the documented value. The existing priority test now covers omitted-policy calls on FIFO and round-robin threads.