### PR TITLE
Return buffered stream data without waiting

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -494,7 +494,11 @@ static php_stream_size_t socket_read(php_stream *stream, char *buf, size_t count
         return sock->get_socket()->recv_sync(buf, count, 0);
     }
 
-    if (abstract->blocking) {
+    if (abstract->blocking
+#if PHP_VERSION_ID >= 80300
+        && !stream->has_buffered_data
+#endif
+    ) {
         nr_bytes = sock->recv(buf, count);
     } else {
         nr_bytes = sock->get_socket()->recv(buf, count, 0);

--- a/tests/swoole_runtime/buffered_read.phpt
+++ b/tests/swoole_runtime/buffered_read.phpt
@@ -1,0 +1,46 @@
+--TEST--
+swoole_runtime: return buffered stream data without waiting
+--SKIPIF--
+<?php
+require __DIR__ . '/../include/skipif.inc';
+skip_if_php_version_lower_than('8.3');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Coroutine\Channel;
+use Swoole\Runtime;
+
+use function Swoole\Coroutine\run;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_TCP);
+
+run(function () {
+    $port = get_one_free_port();
+    $release = new Channel(1);
+
+    go(function () use ($port, $release) {
+        $server = stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
+        $connection = stream_socket_accept($server);
+        fwrite($connection, "line\nrecord1\n");
+        $release->pop();
+        fwrite($connection, "record2\n");
+        fclose($connection);
+        fclose($server);
+    });
+
+    $stream = stream_socket_client("tcp://127.0.0.1:{$port}", $errno, $errstr);
+    Assert::same(fgets($stream), "line\n");
+
+    go(function () use ($release) {
+        Co::sleep(0.01);
+        $release->push(true);
+    });
+
+    Assert::same(fread($stream, 8192), "record1\n");
+    Assert::same(fread($stream, 8192), "record2\n");
+    fclose($stream);
+});
+?>
+--EXPECT--


### PR DESCRIPTION
PHP 8.3 tells stream transports when fread() has already copied buffered bytes. Native PHP makes a non-waiting socket read in that case.

The coroutine stream hook ignored that signal and waited for another socket event. This delayed available data until more bytes arrived, the peer closed, or the read timed out.

Use the existing non-waiting receive path when PHP reports buffered data. Older PHP versions keep the current path.

The regression uses a local TCP stream to prove the first buffered record is returned before a later record is sent. The existing runtime TCP and TLS stream tests also pass.