### PR TITLE
Preserve hooked stream timeout failures

### DIFF
--- a/ext-src/swoole_runtime.cc
+++ b/ext-src/swoole_runtime.cc
@@ -466,8 +466,8 @@ static php_stream_size_t socket_write(php_stream *stream, const char *buf, size_
         php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), didwrite, 0);
     }
 
-    if (didwrite < 0) {
-        if (sock->errCode == ETIMEDOUT || sock->get_socket()->catch_write_error(sock->errCode) == SW_WAIT) {
+    if (didwrite < 0 && sock->errCode != ETIMEDOUT) {
+        if (sock->get_socket()->catch_write_error(sock->errCode) == SW_WAIT) {
             didwrite = 0;
         } else {
             stream->eof = 1;
@@ -505,8 +505,8 @@ static php_stream_size_t socket_read(php_stream *stream, char *buf, size_t count
         php_stream_notify_progress_increment(PHP_STREAM_CONTEXT(stream), nr_bytes, 0);
     }
 
-    if (nr_bytes < 0) {
-        if (sock->errCode == ETIMEDOUT || sock->get_socket()->catch_read_error(sock->errCode) == SW_WAIT) {
+    if (nr_bytes < 0 && sock->errCode != ETIMEDOUT) {
+        if (sock->get_socket()->catch_read_error(sock->errCode) == SW_WAIT) {
             nr_bytes = 0;
         } else {
             stream->eof = 1;

--- a/tests/swoole_runtime/stream_get_meta_data.phpt
+++ b/tests/swoole_runtime/stream_get_meta_data.phpt
@@ -19,7 +19,7 @@ function test($port) {
         $http = "GET / HTTP/1.0\r\nAccept: */*User-Agent: Lowell-Agent\r\nHost: www.baidu.com\r\nConnection: Close\r\n\r\n";
         fwrite($fp, $http);
         $content = fread($fp, 1024);
-        Assert::isEmpty($content);
+        Assert::false($content);
         $res = stream_get_meta_data($fp);
         Assert::false($res['eof']);
         Assert::true($res['blocked']);

--- a/tests/swoole_runtime/stream_write_timeout.phpt
+++ b/tests/swoole_runtime/stream_write_timeout.phpt
@@ -1,0 +1,35 @@
+--TEST--
+swoole_runtime: stream write timeout
+--SKIPIF--
+<?php require __DIR__ . '/../include/skipif.inc'; ?>
+--INI--
+default_socket_timeout=1
+--FILE--
+<?php
+require __DIR__ . '/../include/bootstrap.php';
+
+use Swoole\Runtime;
+
+use function Swoole\Coroutine\run;
+
+Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+
+run(function () {
+    [$reader, $writer] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+    stream_set_blocking($writer, false);
+
+    while (@fwrite($writer, 'x') > 0) {
+    }
+
+    stream_set_blocking($writer, true);
+    Assert::false(@fwrite($writer, 'x'));
+
+    $metadata = stream_get_meta_data($writer);
+    Assert::true($metadata['timed_out']);
+    Assert::false($metadata['eof']);
+
+    fclose($reader);
+    fclose($writer);
+});
+?>
+--EXPECT--


### PR DESCRIPTION
Native PHP returns `false` when a blocking stream read or write times out without transferring data. The coroutine stream hook converted these failures into zero-byte results, so `fread()` returned an empty string and `fwrite()` returned `0`.

Keep timeout failures as errors while preserving the existing nonblocking, EOF, and partial-I/O behavior.

The read regression tightens the existing timeout test. The write regression fills a local socket pair, then verifies the blocking timeout returns `false` without marking the stream as EOF.